### PR TITLE
feat(cache): unify vector dimension lifecycle across storage backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ axum = { version = "0.7", features = ["macros"] }
 reqwest = { version = "0.12", features = ["stream", "json", "rustls-tls"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres"] }
+sqlite-vec = "0.1.9"
+libsqlite3-sys = { version = "0.30", features = ["bundled"] }
+zerocopy = { version = "0.7", features = ["derive"] }
+pgvector = { version = "0.4", features = ["sqlx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"

--- a/crates/nyro-core/Cargo.toml
+++ b/crates/nyro-core/Cargo.toml
@@ -19,6 +19,10 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+sqlite-vec = { workspace = true }
+libsqlite3-sys = { workspace = true }
+zerocopy = { workspace = true }
+pgvector = { workspace = true }
 
 eventsource-stream = "0.2"
 async-stream = "0.3"

--- a/crates/nyro-core/src/cache/config.rs
+++ b/crates/nyro-core/src/cache/config.rs
@@ -3,25 +3,9 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CacheStorageKind {
-    Memory,
-    Database,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum VectorStorageKind {
-    Memory,
-    // SqliteVec, // future
-    // PgVector,  // future
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExactCacheConfig {
     pub enabled: bool,
-    pub storage: CacheStorageKind,
     pub default_ttl: Duration,
     pub max_entries: usize,
 }
@@ -29,7 +13,6 @@ pub struct ExactCacheConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemanticCacheConfig {
     pub enabled: bool,
-    pub storage: VectorStorageKind,
     pub embedding_route: String,
     pub similarity_threshold: f64,
     pub vector_dimensions: usize,
@@ -48,13 +31,11 @@ impl Default for CacheConfig {
         Self {
             exact: ExactCacheConfig {
                 enabled: false,
-                storage: CacheStorageKind::Memory,
                 default_ttl: Duration::from_secs(3600),
                 max_entries: 1000,
             },
             semantic: SemanticCacheConfig {
                 enabled: false,
-                storage: VectorStorageKind::Memory,
                 embedding_route: String::new(),
                 similarity_threshold: 0.92,
                 vector_dimensions: 1536,
@@ -70,18 +51,11 @@ impl CacheConfig {
         json!({
             "exact": {
                 "enabled": self.exact.enabled,
-                "storage": match self.exact.storage {
-                    CacheStorageKind::Memory => "memory",
-                    CacheStorageKind::Database => "database",
-                },
                 "default_ttl": self.exact.default_ttl.as_secs(),
                 "max_entries": self.exact.max_entries,
             },
             "semantic": {
                 "enabled": self.semantic.enabled,
-                "storage": match self.semantic.storage {
-                    VectorStorageKind::Memory => "memory",
-                },
                 "embedding_route": self.semantic.embedding_route,
                 "similarity_threshold": self.semantic.similarity_threshold,
                 "vector_dimensions": self.semantic.vector_dimensions,
@@ -96,24 +70,15 @@ impl CacheConfig {
         let semantic = value.get("semantic")?;
 
         let exact_enabled = exact.get("enabled")?.as_bool()?;
-        let exact_storage = match exact.get("storage")?.as_str()?.trim().to_ascii_lowercase().as_str() {
-            "database" => CacheStorageKind::Database,
-            _ => CacheStorageKind::Memory,
-        };
         let exact_default_ttl = exact.get("default_ttl")?.as_u64()?.max(1);
         let exact_max_entries = exact.get("max_entries")?.as_u64()?.max(1) as usize;
 
         let semantic_enabled = semantic.get("enabled")?.as_bool()?;
-        let semantic_storage = match semantic
-            .get("storage")?
+        let embedding_route = semantic
+            .get("embedding_route")?
             .as_str()?
             .trim()
-            .to_ascii_lowercase()
-            .as_str()
-        {
-            _ => VectorStorageKind::Memory,
-        };
-        let embedding_route = semantic.get("embedding_route")?.as_str()?.trim().to_string();
+            .to_string();
         let similarity_threshold = semantic.get("similarity_threshold")?.as_f64()?;
         let vector_dimensions = semantic.get("vector_dimensions")?.as_u64()?.max(1) as usize;
         let semantic_default_ttl = semantic.get("default_ttl")?.as_u64()?.max(1);
@@ -122,13 +87,11 @@ impl CacheConfig {
         Some(Self {
             exact: ExactCacheConfig {
                 enabled: exact_enabled,
-                storage: exact_storage,
                 default_ttl: Duration::from_secs(exact_default_ttl),
                 max_entries: exact_max_entries,
             },
             semantic: SemanticCacheConfig {
                 enabled: semantic_enabled,
-                storage: semantic_storage,
                 embedding_route,
                 similarity_threshold,
                 vector_dimensions,

--- a/crates/nyro-core/src/cache/mod.rs
+++ b/crates/nyro-core/src/cache/mod.rs
@@ -3,10 +3,12 @@ pub mod config;
 pub mod entry;
 pub mod key;
 pub mod vector;
+pub mod vector_pg;
+pub mod vector_sqlite;
 
 pub use backend::{CacheBackend, DatabaseCacheBackend, InMemoryCacheBackend};
-pub use config::{
-    CacheConfig, CacheStorageKind, ExactCacheConfig, SemanticCacheConfig, VectorStorageKind,
-};
+pub use config::{CacheConfig, ExactCacheConfig, SemanticCacheConfig};
 pub use entry::CacheEntry;
 pub use vector::{MemoryVectorStore, VectorHit, VectorStore, VectorStoreEntry};
+pub use vector_pg::PgVectorStore;
+pub use vector_sqlite::SqliteVecVectorStore;

--- a/crates/nyro-core/src/cache/vector_pg.rs
+++ b/crates/nyro-core/src/cache/vector_pg.rs
@@ -1,0 +1,132 @@
+use async_trait::async_trait;
+use pgvector::Vector;
+use sqlx::{Pool, Postgres};
+
+use super::vector::{VectorHit, VectorStore};
+
+#[derive(Clone)]
+pub struct PgVectorStore {
+    pool: Pool<Postgres>,
+    max_entries: usize,
+}
+
+impl PgVectorStore {
+    pub fn new(pool: Pool<Postgres>, max_entries: usize) -> Self {
+        Self {
+            pool,
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    async fn evict_partition_if_needed(&self, partition: &str) -> anyhow::Result<()> {
+        let total: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM semantic_cache_vectors WHERE partition = $1")
+                .bind(partition)
+                .fetch_one(&self.pool)
+                .await?;
+        let overflow = total.saturating_sub(self.max_entries as i64);
+        if overflow <= 0 {
+            return Ok(());
+        }
+
+        sqlx::query(
+            "DELETE FROM semantic_cache_vectors
+             WHERE id IN (
+                SELECT id
+                FROM semantic_cache_vectors
+                WHERE partition = $1
+                ORDER BY created_at ASC, id ASC
+                LIMIT $2
+             )",
+        )
+        .bind(partition)
+        .bind(overflow)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl VectorStore for PgVectorStore {
+    async fn upsert(
+        &self,
+        partition: &str,
+        key: String,
+        vector: Vec<f32>,
+        data: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        let dimensions = vector.len() as i32;
+        let vector = Vector::from(vector);
+        sqlx::query(
+            "INSERT INTO semantic_cache_vectors (partition, cache_key, dimensions, embedding, data, created_at)
+             VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
+             ON CONFLICT (partition, cache_key)
+             DO UPDATE SET dimensions = EXCLUDED.dimensions,
+                           embedding = EXCLUDED.embedding,
+                           data = EXCLUDED.data,
+                           created_at = CURRENT_TIMESTAMP",
+        )
+        .bind(partition)
+        .bind(&key)
+        .bind(dimensions)
+        .bind(vector)
+        .bind(data)
+        .execute(&self.pool)
+        .await?;
+
+        self.evict_partition_if_needed(partition).await
+    }
+
+    async fn search(
+        &self,
+        partition: &str,
+        query: &[f32],
+        threshold: f64,
+    ) -> anyhow::Result<Option<VectorHit>> {
+        let dimensions = query.len() as i32;
+        let query_vector = Vector::from(query.to_vec());
+        let row = sqlx::query_as::<_, (String, Vec<u8>, f64)>(
+            "SELECT cache_key, data, (1 - (embedding <=> $1))::float8 AS similarity
+             FROM semantic_cache_vectors
+             WHERE partition = $2
+               AND dimensions = $3
+             ORDER BY embedding <=> $1
+             LIMIT 1",
+        )
+        .bind(query_vector)
+        .bind(partition)
+        .bind(dimensions)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some((key, data, similarity)) = row else {
+            return Ok(None);
+        };
+        if similarity < threshold {
+            return Ok(None);
+        }
+
+        Ok(Some(VectorHit {
+            key,
+            data,
+            score: similarity,
+        }))
+    }
+
+    async fn clear(&self) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM semantic_cache_vectors")
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn clear_partition(&self, partition: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM semantic_cache_vectors WHERE partition = $1")
+            .bind(partition)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/nyro-core/src/cache/vector_sqlite.rs
+++ b/crates/nyro-core/src/cache/vector_sqlite.rs
@@ -1,0 +1,131 @@
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use zerocopy::AsBytes;
+
+use super::vector::{VectorHit, VectorStore};
+
+#[derive(Clone)]
+pub struct SqliteVecVectorStore {
+    pool: SqlitePool,
+    max_entries: usize,
+}
+
+impl SqliteVecVectorStore {
+    pub fn new(pool: SqlitePool, max_entries: usize) -> Self {
+        Self {
+            pool,
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    async fn evict_partition_if_needed(&self, partition: &str) -> anyhow::Result<()> {
+        let total: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM semantic_cache_vectors WHERE partition = ?")
+                .bind(partition)
+                .fetch_one(&self.pool)
+                .await?;
+
+        let overflow = total.saturating_sub(self.max_entries as i64);
+        if overflow <= 0 {
+            return Ok(());
+        }
+
+        sqlx::query(
+            "DELETE FROM semantic_cache_vectors WHERE rowid IN (
+                SELECT rowid
+                FROM semantic_cache_vectors
+                WHERE partition = ?
+                ORDER BY created_at ASC, rowid ASC
+                LIMIT ?
+            )",
+        )
+        .bind(partition)
+        .bind(overflow)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl VectorStore for SqliteVecVectorStore {
+    async fn upsert(
+        &self,
+        partition: &str,
+        key: String,
+        vector: Vec<f32>,
+        data: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM semantic_cache_vectors WHERE partition = ? AND cache_key = ?")
+            .bind(partition)
+            .bind(&key)
+            .execute(&self.pool)
+            .await?;
+
+        sqlx::query(
+            "INSERT INTO semantic_cache_vectors(partition, cache_key, dimensions, embedding, data, created_at)
+             VALUES(?, ?, ?, ?, ?, unixepoch())",
+        )
+        .bind(partition)
+        .bind(&key)
+        .bind(vector.len() as i64)
+        .bind(vector.as_bytes())
+        .bind(data)
+        .execute(&self.pool)
+        .await?;
+
+        self.evict_partition_if_needed(partition).await
+    }
+
+    async fn search(
+        &self,
+        partition: &str,
+        query: &[f32],
+        threshold: f64,
+    ) -> anyhow::Result<Option<VectorHit>> {
+        let row = sqlx::query_as::<_, (String, Vec<u8>, f64)>(
+            "SELECT cache_key, data, distance
+             FROM semantic_cache_vectors
+             WHERE embedding MATCH ?
+               AND k = 1
+               AND partition = ?
+               AND dimensions = ?",
+        )
+        .bind(query.as_bytes())
+        .bind(partition)
+        .bind(query.len() as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some((key, data, distance)) = row else {
+            return Ok(None);
+        };
+
+        let similarity = 1.0 - distance;
+        if similarity < threshold {
+            return Ok(None);
+        }
+
+        Ok(Some(VectorHit {
+            key,
+            data,
+            score: similarity,
+        }))
+    }
+
+    async fn clear(&self) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM semantic_cache_vectors")
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn clear_partition(&self, partition: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM semantic_cache_vectors WHERE partition = ?")
+            .bind(partition)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -1,12 +1,24 @@
 pub mod models;
 
 use std::path::Path;
+use std::sync::Once;
 
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlite_vec::sqlite3_vec_init;
 use sqlx::Row;
 use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+static SQLITE_VEC_INIT: Once = Once::new();
+const VECTOR_DIMENSIONS_SETTING_KEY: &str = "vector_embedding_dimensions";
 
 pub async fn init_pool(data_dir: &Path) -> anyhow::Result<SqlitePool> {
+    SQLITE_VEC_INIT.call_once(|| unsafe {
+        // Register sqlite-vec once per process. All later SQLite connections can use vec0 tables.
+        libsqlite3_sys::sqlite3_auto_extension(Some(std::mem::transmute(
+            sqlite3_vec_init as *const (),
+        )));
+    });
+
     std::fs::create_dir_all(data_dir)?;
     let db_path = data_dir.join("gateway.db");
 
@@ -24,7 +36,7 @@ pub async fn init_pool(data_dir: &Path) -> anyhow::Result<SqlitePool> {
     Ok(pool)
 }
 
-pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
+pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Result<()> {
     sqlx::raw_sql(INIT_SQL).execute(pool).await?;
     ensure_provider_column(pool, "vendor", "TEXT").await?;
     ensure_provider_column(pool, "preset_key", "TEXT").await?;
@@ -50,6 +62,7 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     ensure_api_key_column(pool, "rpd", "INTEGER").await?;
     ensure_route_targets_table(pool).await?;
     ensure_cache_entries_table(pool).await?;
+    ensure_semantic_cache_vectors_table(pool, vector_dimensions).await?;
     backfill_provider_vendor(pool).await?;
     backfill_route_fields(pool).await?;
     backfill_route_targets(pool).await?;
@@ -57,7 +70,9 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
 }
 
 async fn backfill_provider_vendor(pool: &SqlitePool) -> anyhow::Result<()> {
-    if column_exists(pool, "providers", "vendor").await? && column_exists(pool, "providers", "preset_key").await? {
+    if column_exists(pool, "providers", "vendor").await?
+        && column_exists(pool, "providers", "preset_key").await?
+    {
         sqlx::query(
             "UPDATE providers \
              SET vendor = lower(trim(preset_key)) \
@@ -183,9 +198,11 @@ async fn ensure_api_key_tables(pool: &SqlitePool) -> anyhow::Result<()> {
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key)")
         .execute(pool)
         .await?;
-    sqlx::query("CREATE INDEX IF NOT EXISTS idx_api_key_routes_route_id ON api_key_routes(route_id)")
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_api_key_routes_route_id ON api_key_routes(route_id)",
+    )
+    .execute(pool)
+    .await?;
 
     Ok(())
 }
@@ -224,11 +241,67 @@ async fn ensure_cache_entries_table(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
-    sqlx::query("CREATE INDEX IF NOT EXISTS idx_cache_entries_expires_at ON cache_entries(expires_at)")
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_cache_entries_expires_at ON cache_entries(expires_at)",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn recreate_vec0_table(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Result<()> {
+    let dimensions = vector_dimensions.max(1);
+    sqlx::query("DROP TABLE IF EXISTS semantic_cache_vectors")
         .execute(pool)
         .await?;
 
+    let ddl = format!(
+        r#"CREATE VIRTUAL TABLE semantic_cache_vectors USING vec0(
+            partition TEXT partition key,
+            cache_key TEXT,
+            dimensions INTEGER,
+            embedding float[{dimensions}],
+            +data BLOB,
+            created_at INTEGER
+        )"#
+    );
+    sqlx::query(&ddl).execute(pool).await?;
+    sqlx::query(
+        "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(VECTOR_DIMENSIONS_SETTING_KEY)
+    .bind(dimensions.to_string())
+    .execute(pool)
+    .await?;
     Ok(())
+}
+
+async fn ensure_semantic_cache_vectors_table(
+    pool: &SqlitePool,
+    vector_dimensions: usize,
+) -> anyhow::Result<()> {
+    let dimensions = vector_dimensions.max(1);
+    let stored_dimension = sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(VECTOR_DIMENSIONS_SETTING_KEY)
+        .fetch_optional(pool)
+        .await?
+        .and_then(|raw| raw.trim().parse::<usize>().ok());
+    let table_exists = semantic_cache_vectors_table_exists(pool).await?;
+    if !table_exists || stored_dimension != Some(dimensions) {
+        recreate_vec0_table(pool, dimensions).await?;
+    }
+    Ok(())
+}
+
+async fn semantic_cache_vectors_table_exists(pool: &SqlitePool) -> anyhow::Result<bool> {
+    let count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'semantic_cache_vectors'",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(count > 0)
 }
 
 async fn backfill_route_fields(pool: &SqlitePool) -> anyhow::Result<()> {
@@ -286,12 +359,18 @@ async fn backfill_route_targets(pool: &SqlitePool) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn column_exists(pool: &SqlitePool, table_name: &str, column_name: &str) -> anyhow::Result<bool> {
+async fn column_exists(
+    pool: &SqlitePool,
+    table_name: &str,
+    column_name: &str,
+) -> anyhow::Result<bool> {
     let pragma = format!("PRAGMA table_info({table_name})");
     let rows = sqlx::query(&pragma).fetch_all(pool).await?;
-    Ok(rows
-        .iter()
-        .any(|row| row.try_get::<String, _>("name").map(|name| name == column_name).unwrap_or(false)))
+    Ok(rows.iter().any(|row| {
+        row.try_get::<String, _>("name")
+            .map(|name| name == column_name)
+            .unwrap_or(false)
+    }))
 }
 
 const INIT_SQL: &str = r#"

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -15,20 +15,20 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use dashmap::DashMap;
-use tokio::sync::mpsc;
+use sqlx::{Pool, Postgres, SqlitePool};
 use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 
-use config::{
-    GatewayConfig, SqlStorageConfig, StorageBackendKind,
+use crate::cache::{
+    CacheBackend, CacheConfig, DatabaseCacheBackend, InMemoryCacheBackend, MemoryVectorStore,
+    PgVectorStore, SqliteVecVectorStore, VectorStore,
 };
+use crate::router::health::HealthRegistry;
+use config::{GatewayConfig, SqlStorageConfig, StorageBackendKind};
 use logging::LogEntry;
 use storage::sql::config::SqlBackendConfig;
+use storage::postgres::recreate_pg_vector_table;
 use storage::{DynStorage, PostgresStorage, SqliteStorage};
-use crate::router::health::HealthRegistry;
-use crate::cache::{
-    CacheBackend, CacheConfig, CacheStorageKind, DatabaseCacheBackend, InMemoryCacheBackend,
-    MemoryVectorStore, VectorStore, VectorStorageKind,
-};
 
 #[derive(Clone, Debug)]
 pub struct CapabilityCacheEntry {
@@ -36,10 +36,18 @@ pub struct CapabilityCacheEntry {
     pub cached_at: Instant,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuntimeStorageKind {
+    Memory,
+    Sqlite,
+    Postgres,
+}
+
 #[derive(Clone)]
 pub struct Gateway {
     pub config: GatewayConfig,
     pub storage: DynStorage,
+    pub storage_kind: RuntimeStorageKind,
     pub http_client: reqwest::Client,
     proxy_client_cache: Arc<tokio::sync::RwLock<Option<ProxyClientCache>>>,
     pub route_cache: Arc<tokio::sync::RwLock<router::RouteCache>>,
@@ -50,6 +58,8 @@ pub struct Gateway {
     pub cache_backend: Arc<tokio::sync::RwLock<Option<Arc<dyn CacheBackend>>>>,
     pub vector_store: Arc<tokio::sync::RwLock<Option<Arc<dyn VectorStore>>>>,
     pub cache_in_flight: Arc<DashMap<String, broadcast::Sender<Vec<u8>>>>,
+    sqlite_pool: Option<SqlitePool>,
+    postgres_pool: Option<Pool<Postgres>>,
 }
 
 #[derive(Clone)]
@@ -60,20 +70,44 @@ struct ProxyClientCache {
 
 impl Gateway {
     pub async fn new(config: GatewayConfig) -> anyhow::Result<(Self, mpsc::Receiver<LogEntry>)> {
-        let sqlite_storage = if config.storage.sqlite.migrate_on_start {
-            SqliteStorage::from_config(&config).await?
-        } else {
-            let pool = db::init_pool(&config.data_dir).await?;
-            SqliteStorage::from_pool(pool)
-        };
-
-        let sqlite_fallback: DynStorage = Arc::new(sqlite_storage.clone());
-
-        let storage: DynStorage = match config.storage.backend {
-            StorageBackendKind::Sqlite => sqlite_fallback.clone(),
+        let (storage_kind, storage, sqlite_pool, postgres_pool): (
+            RuntimeStorageKind,
+            DynStorage,
+            Option<SqlitePool>,
+            Option<Pool<Postgres>>,
+        ) = match config.storage.backend {
+            StorageBackendKind::Sqlite => {
+                let sqlite_storage = if config.storage.sqlite.migrate_on_start {
+                    SqliteStorage::from_config(&config).await?
+                } else {
+                    let pool = db::init_pool(&config.data_dir).await?;
+                    SqliteStorage::from_pool_with_dimensions(
+                        pool,
+                        config.cache.semantic.vector_dimensions,
+                    )
+                };
+                let pool = sqlite_storage.pool().clone();
+                (
+                    RuntimeStorageKind::Sqlite,
+                    Arc::new(sqlite_storage),
+                    Some(pool),
+                    None,
+                )
+            }
             StorageBackendKind::Postgres => {
                 let backend_config = to_sql_backend_config(&config.storage.postgres, "postgres")?;
-                Arc::new(PostgresStorage::connect(backend_config, sqlite_fallback.clone()).await?)
+                let postgres_storage = PostgresStorage::connect_with_vector_dimensions(
+                    backend_config,
+                    config.cache.semantic.vector_dimensions,
+                )
+                .await?;
+                let pool = postgres_storage.pool().clone();
+                (
+                    RuntimeStorageKind::Postgres,
+                    Arc::new(postgres_storage),
+                    None,
+                    Some(pool),
+                )
             }
         };
 
@@ -86,12 +120,23 @@ impl Gateway {
             anyhow::bail!("selected storage backend is not reachable");
         }
 
-        Self::from_storage(config, storage).await
+        Self::from_storage_with_kind(config, storage, storage_kind, sqlite_pool, postgres_pool)
+            .await
     }
 
     pub async fn from_storage(
         config: GatewayConfig,
         storage: DynStorage,
+    ) -> anyhow::Result<(Self, mpsc::Receiver<LogEntry>)> {
+        Self::from_storage_with_kind(config, storage, RuntimeStorageKind::Memory, None, None).await
+    }
+
+    async fn from_storage_with_kind(
+        config: GatewayConfig,
+        storage: DynStorage,
+        storage_kind: RuntimeStorageKind,
+        sqlite_pool: Option<SqlitePool>,
+        postgres_pool: Option<Pool<Postgres>>,
     ) -> anyhow::Result<(Self, mpsc::Receiver<LogEntry>)> {
         let http_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(300))
@@ -109,6 +154,7 @@ impl Gateway {
         let gw = Self {
             config,
             storage,
+            storage_kind,
             http_client,
             proxy_client_cache: Arc::new(tokio::sync::RwLock::new(None)),
             route_cache,
@@ -119,6 +165,8 @@ impl Gateway {
             cache_backend: Arc::new(tokio::sync::RwLock::new(None)),
             vector_store: Arc::new(tokio::sync::RwLock::new(None)),
             cache_in_flight: Arc::new(DashMap::new()),
+            sqlite_pool,
+            postgres_pool,
         };
 
         let runtime_cache = gw
@@ -152,15 +200,14 @@ impl Gateway {
         let current = self.runtime_cache_config.read().await.clone();
 
         let exact_needs_rebuild = current.exact.enabled != next.exact.enabled
-            || current.exact.storage != next.exact.storage
             || current.exact.max_entries != next.exact.max_entries;
         let next_cache_backend: Option<Arc<dyn CacheBackend>> = if exact_needs_rebuild {
             if next.exact.enabled {
-                match next.exact.storage {
-                    CacheStorageKind::Memory => {
+                match self.storage_kind {
+                    RuntimeStorageKind::Memory => {
                         Some(Arc::new(InMemoryCacheBackend::new(next.exact.max_entries)))
                     }
-                    CacheStorageKind::Database => {
+                    RuntimeStorageKind::Sqlite | RuntimeStorageKind::Postgres => {
                         Some(Arc::new(DatabaseCacheBackend::new(self.storage.clone())))
                     }
                 }
@@ -172,10 +219,38 @@ impl Gateway {
         };
 
         let semantic_needs_rebuild = current.semantic.enabled != next.semantic.enabled
-            || current.semantic.storage != next.semantic.storage
             || current.semantic.max_entries != next.semantic.max_entries
             || current.semantic.embedding_route != next.semantic.embedding_route
             || current.semantic.vector_dimensions != next.semantic.vector_dimensions;
+
+        if current.semantic.vector_dimensions != next.semantic.vector_dimensions {
+            let previous_vector_store = self.vector_store.read().await.clone();
+            *self.vector_store.write().await = None;
+
+            let recreate_result = match self.storage_kind {
+                RuntimeStorageKind::Memory => Ok(()),
+                RuntimeStorageKind::Sqlite => {
+                    let pool = self
+                        .sqlite_pool
+                        .as_ref()
+                        .context("sqlite pool unavailable during vector table recreate")?;
+                    db::recreate_vec0_table(pool, next.semantic.vector_dimensions).await
+                }
+                RuntimeStorageKind::Postgres => {
+                    let pool = self
+                        .postgres_pool
+                        .as_ref()
+                        .context("postgres pool unavailable during vector table recreate")?;
+                    recreate_pg_vector_table(pool, next.semantic.vector_dimensions).await
+                }
+            };
+
+            if let Err(error) = recreate_result {
+                *self.vector_store.write().await = previous_vector_store;
+                return Err(error);
+            }
+        }
+
         let next_vector_store: Option<Arc<dyn VectorStore>> = if semantic_needs_rebuild {
             if next.semantic.enabled {
                 let embedding_route = next.semantic.embedding_route.trim();
@@ -201,9 +276,37 @@ impl Gateway {
                         next.semantic.enabled = false;
                         None
                     } else {
-                        match next.semantic.storage {
-                            VectorStorageKind::Memory => {
+                        match self.storage_kind {
+                            RuntimeStorageKind::Memory => {
                                 Some(Arc::new(MemoryVectorStore::new(next.semantic.max_entries)))
+                            }
+                            RuntimeStorageKind::Sqlite => {
+                                if let Some(pool) = self.sqlite_pool.clone() {
+                                    Some(Arc::new(SqliteVecVectorStore::new(
+                                        pool,
+                                        next.semantic.max_entries,
+                                    )))
+                                } else {
+                                    tracing::warn!(
+                                        "semantic cache selected sqlite storage but sqlite pool is unavailable; semantic cache disabled"
+                                    );
+                                    next.semantic.enabled = false;
+                                    None
+                                }
+                            }
+                            RuntimeStorageKind::Postgres => {
+                                if let Some(pool) = self.postgres_pool.clone() {
+                                    Some(Arc::new(PgVectorStore::new(
+                                        pool,
+                                        next.semantic.max_entries,
+                                    )))
+                                } else {
+                                    tracing::warn!(
+                                        "semantic cache selected postgres storage but postgres pool is unavailable; semantic cache disabled"
+                                    );
+                                    next.semantic.enabled = false;
+                                    None
+                                }
                             }
                         }
                     }
@@ -234,7 +337,10 @@ impl Gateway {
         admin::AdminService::new(self.clone())
     }
 
-    pub async fn http_client_for_provider(&self, use_proxy: bool) -> anyhow::Result<reqwest::Client> {
+    pub async fn http_client_for_provider(
+        &self,
+        use_proxy: bool,
+    ) -> anyhow::Result<reqwest::Client> {
         if !use_proxy {
             return Ok(self.http_client.clone());
         }
@@ -334,10 +440,16 @@ impl Gateway {
 }
 
 fn parse_bool_setting(value: &str) -> bool {
-    matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
-fn to_sql_backend_config(config: &SqlStorageConfig, backend: &str) -> anyhow::Result<SqlBackendConfig> {
+fn to_sql_backend_config(
+    config: &SqlStorageConfig,
+    backend: &str,
+) -> anyhow::Result<SqlBackendConfig> {
     let url = config
         .configured_url()
         .with_context(|| format!("{backend} backend selected but storage url is empty"))?;

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -14,10 +14,12 @@ use crate::logging::LogEntry;
 use crate::storage::sql::config::SqlBackendConfig;
 use crate::storage::sql::pool::RelationalPool;
 use crate::storage::traits::{
-    ApiKeyAccessRecord, ApiKeyStore, AuthAccessStore, CacheStore, DynStorage, LogStore,
-    ProviderStore, ProviderTestResult, RouteSnapshotStore, RouteStore, RouteTargetStore,
-    SettingsStore, Storage, StorageBackend, StorageBootstrap, StorageHealth, UsageWindow,
+    ApiKeyAccessRecord, ApiKeyStore, AuthAccessStore, CacheStore, LogStore, ProviderStore,
+    ProviderTestResult, RouteSnapshotStore, RouteStore, RouteTargetStore, SettingsStore, Storage,
+    StorageBackend, StorageBootstrap, StorageHealth, UsageWindow,
 };
+
+const VECTOR_DIMENSIONS_SETTING_KEY: &str = "vector_embedding_dimensions";
 
 #[derive(Clone)]
 pub struct PostgresAdapter {
@@ -33,9 +35,12 @@ pub struct PostgresHealth {
 
 impl PostgresAdapter {
     pub async fn connect(config: SqlBackendConfig) -> anyhow::Result<Self> {
-        let pool = RelationalPool::connect(crate::storage::sql::config::SqlBackendKind::Postgres, &config)
-            .await
-            .context("connect postgres adapter")?;
+        let pool = RelationalPool::connect(
+            crate::storage::sql::config::SqlBackendKind::Postgres,
+            &config,
+        )
+        .await
+        .context("connect postgres adapter")?;
         let pool = pool
             .as_postgres()
             .cloned()
@@ -67,6 +72,7 @@ impl PostgresAdapter {
 
 #[derive(Clone)]
 pub struct PostgresStorage {
+    pool: Pool<Postgres>,
     provider_store: Arc<PostgresProviderStore>,
     route_store: Arc<PostgresRouteStore>,
     route_target_store: Arc<PostgresRouteTargetStore>,
@@ -78,31 +84,29 @@ pub struct PostgresStorage {
 }
 
 impl PostgresStorage {
-    pub async fn connect(config: SqlBackendConfig, _fallback: DynStorage) -> anyhow::Result<Self> {
+    pub async fn connect(config: SqlBackendConfig) -> anyhow::Result<Self> {
+        Self::connect_with_vector_dimensions(config, 1536).await
+    }
+
+    pub async fn connect_with_vector_dimensions(
+        config: SqlBackendConfig,
+        vector_dimensions: usize,
+    ) -> anyhow::Result<Self> {
         let adapter = PostgresAdapter::connect(config).await?;
-        let provider_store = Arc::new(PostgresProviderStore {
-            pool: adapter.pool().clone(),
+        let pool = adapter.pool().clone();
+        let provider_store = Arc::new(PostgresProviderStore { pool: pool.clone() });
+        let route_store = Arc::new(PostgresRouteStore { pool: pool.clone() });
+        let route_target_store = Arc::new(PostgresRouteTargetStore { pool: pool.clone() });
+        let settings_store = Arc::new(PostgresSettingsStore { pool: pool.clone() });
+        let api_key_store = Arc::new(PostgresApiKeyStore { pool: pool.clone() });
+        let auth_store = Arc::new(PostgresAuthAccessStore { pool: pool.clone() });
+        let log_store = Arc::new(PostgresLogStore { pool: pool.clone() });
+        let bootstrap = Arc::new(PostgresBootstrap {
+            adapter,
+            vector_dimensions: vector_dimensions.max(1),
         });
-        let route_store = Arc::new(PostgresRouteStore {
-            pool: adapter.pool().clone(),
-        });
-        let route_target_store = Arc::new(PostgresRouteTargetStore {
-            pool: adapter.pool().clone(),
-        });
-        let settings_store = Arc::new(PostgresSettingsStore {
-            pool: adapter.pool().clone(),
-        });
-        let api_key_store = Arc::new(PostgresApiKeyStore {
-            pool: adapter.pool().clone(),
-        });
-        let auth_store = Arc::new(PostgresAuthAccessStore {
-            pool: adapter.pool().clone(),
-        });
-        let log_store = Arc::new(PostgresLogStore {
-            pool: adapter.pool().clone(),
-        });
-        let bootstrap = Arc::new(PostgresBootstrap { adapter });
         Ok(Self {
+            pool,
             provider_store,
             route_store,
             route_target_store,
@@ -112,6 +116,73 @@ impl PostgresStorage {
             log_store,
             bootstrap,
         })
+    }
+
+    pub fn pool(&self) -> &Pool<Postgres> {
+        &self.pool
+    }
+}
+
+pub async fn recreate_pg_vector_table(
+    pool: &Pool<Postgres>,
+    vector_dimensions: usize,
+) -> anyhow::Result<()> {
+    let dimensions = vector_dimensions.max(1);
+    let mut tx = pool.begin().await?;
+    let result: anyhow::Result<()> = async {
+        sqlx::query("DROP TABLE IF EXISTS semantic_cache_vectors")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(&semantic_cache_vectors_table_ddl(dimensions))
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "CREATE UNIQUE INDEX idx_semantic_cache_vectors_partition_key
+             ON semantic_cache_vectors(partition, cache_key)",
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX idx_semantic_cache_vectors_partition_created_at
+             ON semantic_cache_vectors(partition, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX idx_semantic_cache_vectors_hnsw
+             ON semantic_cache_vectors USING hnsw (embedding vector_cosine_ops)",
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO settings(key, value, updated_at)
+             VALUES($1, $2, CURRENT_TIMESTAMP)
+             ON CONFLICT(key) DO UPDATE
+             SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(VECTOR_DIMENSIONS_SETTING_KEY)
+        .bind(dimensions.to_string())
+        .execute(&mut *tx)
+        .await?;
+        Ok(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            tx.commit().await?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = tx.rollback().await;
+            if is_pg_permission_error(&error) {
+                anyhow::bail!(
+                    "insufficient database privileges to rebuild semantic_cache_vectors automatically. ask your DBA to run:\n\n{}",
+                    rebuild_guidance_sql(dimensions)
+                );
+            }
+            Err(error)
+        }
     }
 }
 
@@ -171,10 +242,12 @@ impl ProviderStore for PostgresProviderStore {
     }
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Provider>> {
-        Ok(sqlx::query_as::<_, Provider>(&provider_select(Some("WHERE id = $1")))
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, Provider>(&provider_select(Some("WHERE id = $1")))
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
     }
 
     async fn create(&self, input: CreateProvider) -> anyhow::Result<Provider> {
@@ -205,11 +278,16 @@ impl ProviderStore for PostgresProviderStore {
         .bind(input.use_proxy)
         .execute(&self.pool)
         .await?;
-        self.get(&id).await?.context("provider missing after create")
+        self.get(&id)
+            .await?
+            .context("provider missing after create")
     }
 
     async fn update(&self, id: &str, input: UpdateProvider) -> anyhow::Result<Provider> {
-        let current = self.get(id).await?.context("provider not found for update")?;
+        let current = self
+            .get(id)
+            .await?
+            .context("provider not found for update")?;
         let models_source_input = input.effective_models_source().map(ToString::to_string);
         let name = input.name.unwrap_or(current.name);
         let vendor = if input.vendor.is_some() {
@@ -217,13 +295,10 @@ impl ProviderStore for PostgresProviderStore {
         } else {
             normalize_provider_vendor(current.vendor.as_deref())
         };
-        let models_source = models_source_input
-            .or_else(|| current.models_source.clone());
+        let models_source = models_source_input.or_else(|| current.models_source.clone());
         let protocol = input.protocol.unwrap_or(current.protocol.clone());
         let base_url = input.base_url.unwrap_or(current.base_url);
-        let default_protocol = input
-            .default_protocol
-            .unwrap_or(current.default_protocol);
+        let default_protocol = input.default_protocol.unwrap_or(current.default_protocol);
         let protocol_endpoints = input
             .protocol_endpoints
             .unwrap_or(current.protocol_endpoints);
@@ -286,7 +361,11 @@ impl ProviderStore for PostgresProviderStore {
         Ok(row.is_some())
     }
 
-    async fn record_test_result(&self, provider_id: &str, result: ProviderTestResult) -> anyhow::Result<()> {
+    async fn record_test_result(
+        &self,
+        provider_id: &str,
+        result: ProviderTestResult,
+    ) -> anyhow::Result<()> {
         let _ = result.tested_at;
         sqlx::query(
             "UPDATE providers SET last_test_success = $1, last_test_at = CURRENT_TIMESTAMP WHERE id = $2",
@@ -307,9 +386,11 @@ struct PostgresRouteStore {
 #[async_trait]
 impl RouteStore for PostgresRouteStore {
     async fn list(&self) -> anyhow::Result<Vec<Route>> {
-        Ok(sqlx::query_as::<_, Route>(&route_select(Some("ORDER BY created_at DESC")))
-            .fetch_all(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, Route>(&route_select(Some("ORDER BY created_at DESC")))
+                .fetch_all(&self.pool)
+                .await?,
+        )
     }
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Route>> {
@@ -441,7 +522,6 @@ impl RouteStore for PostgresRouteStore {
         };
         Ok(row.is_some())
     }
-
 }
 
 #[async_trait]
@@ -536,9 +616,11 @@ impl SettingsStore for PostgresSettingsStore {
     }
 
     async fn list_all(&self) -> anyhow::Result<Vec<(String, String)>> {
-        Ok(sqlx::query_as::<_, (String, String)>("SELECT key, value FROM settings")
-            .fetch_all(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, (String, String)>("SELECT key, value FROM settings")
+                .fetch_all(&self.pool)
+                .await?,
+        )
     }
 }
 
@@ -682,15 +764,17 @@ impl AuthAccessStore for PostgresAuthAccessStore {
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.map(|(id, status, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
-            id,
-            status,
-            expires_at,
-            rpm,
-            rpd,
-            tpm,
-            tpd,
-        }))
+        Ok(row.map(
+            |(id, status, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
+                id,
+                status,
+                expires_at,
+                rpm,
+                rpd,
+                tpm,
+                tpd,
+            },
+        ))
     }
 
     async fn route_binding_exists(&self, api_key_id: &str, route_id: &str) -> anyhow::Result<bool> {
@@ -708,7 +792,11 @@ impl AuthAccessStore for PostgresAuthAccessStore {
         list_api_key_route_ids(&self.pool, api_key_id).await
     }
 
-    async fn request_count_since(&self, api_key_id: &str, window: UsageWindow) -> anyhow::Result<i64> {
+    async fn request_count_since(
+        &self,
+        api_key_id: &str,
+        window: UsageWindow,
+    ) -> anyhow::Result<i64> {
         let interval = interval_expr(window);
         let sql = format!(
             "SELECT COUNT(*) FROM request_logs WHERE api_key_id = $1 AND created_at >= CURRENT_TIMESTAMP - INTERVAL '{interval}'"
@@ -719,7 +807,11 @@ impl AuthAccessStore for PostgresAuthAccessStore {
             .await?)
     }
 
-    async fn token_count_since(&self, api_key_id: &str, window: UsageWindow) -> anyhow::Result<i64> {
+    async fn token_count_since(
+        &self,
+        api_key_id: &str,
+        window: UsageWindow,
+    ) -> anyhow::Result<i64> {
         let interval = interval_expr(window);
         let sql = format!(
             "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM request_logs WHERE api_key_id = $1 AND created_at >= CURRENT_TIMESTAMP - INTERVAL '{interval}'"
@@ -802,7 +894,10 @@ impl LogStore for PostgresLogStore {
             idx += 1;
         }
 
-        data_sql.push_str(&format!(" ORDER BY created_at DESC LIMIT ${idx} OFFSET ${}", idx + 1));
+        data_sql.push_str(&format!(
+            " ORDER BY created_at DESC LIMIT ${idx} OFFSET ${}",
+            idx + 1
+        ));
 
         let mut count_query = sqlx::query_scalar::<_, i64>(&count_sql);
         let mut data_query = sqlx::query_as::<_, RequestLog>(&data_sql);
@@ -822,14 +917,18 @@ impl LogStore for PostgresLogStore {
 
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64> {
         let interval = cutoff_expression.trim().trim_start_matches('-').trim();
-        let sql = format!("DELETE FROM request_logs WHERE created_at < CURRENT_TIMESTAMP - INTERVAL '{interval}'");
+        let sql = format!(
+            "DELETE FROM request_logs WHERE created_at < CURRENT_TIMESTAMP - INTERVAL '{interval}'"
+        );
         let result = sqlx::query(&sql).execute(&self.pool).await?;
         Ok(result.rows_affected())
     }
 
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         let sql = if let Some(hours) = hours {
-            format!("SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours'")
+            format!(
+                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours'"
+            )
         } else {
             "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs".to_string()
         };
@@ -839,7 +938,9 @@ impl LogStore for PostgresLogStore {
     }
 
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>> {
-        let sql = format!("SELECT to_char(date_trunc('hour', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:00:00') AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY 1 ORDER BY 1 ASC");
+        let sql = format!(
+            "SELECT to_char(date_trunc('hour', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:00:00') AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY 1 ORDER BY 1 ASC"
+        );
         Ok(sqlx::query_as::<_, StatsHourly>(&sql)
             .fetch_all(&self.pool)
             .await?)
@@ -847,7 +948,9 @@ impl LogStore for PostgresLogStore {
 
     async fn stats_by_model(&self, hours: Option<i64>) -> anyhow::Result<Vec<ModelStats>> {
         let sql = if let Some(hours) = hours {
-            format!("SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY actual_model ORDER BY request_count DESC")
+            format!(
+                "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY actual_model ORDER BY request_count DESC"
+            )
         } else {
             "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY actual_model ORDER BY request_count DESC".to_string()
         };
@@ -858,7 +961,9 @@ impl LogStore for PostgresLogStore {
 
     async fn stats_by_provider(&self, hours: Option<i64>) -> anyhow::Result<Vec<ProviderStats>> {
         let sql = if let Some(hours) = hours {
-            format!("SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY provider_name ORDER BY request_count DESC")
+            format!(
+                "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY provider_name ORDER BY request_count DESC"
+            )
         } else {
             "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY provider_name ORDER BY request_count DESC".to_string()
         };
@@ -920,6 +1025,7 @@ impl CacheStore for PostgresLogStore {
 #[derive(Clone)]
 struct PostgresBootstrap {
     adapter: PostgresAdapter,
+    vector_dimensions: usize,
 }
 
 #[async_trait]
@@ -944,9 +1050,11 @@ impl StorageBootstrap for PostgresBootstrap {
         sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS cache_semantic_ttl BIGINT")
             .execute(self.adapter.pool())
             .await?;
-        sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS cache_semantic_threshold DOUBLE PRECISION")
-            .execute(self.adapter.pool())
-            .await?;
+        sqlx::query(
+            "ALTER TABLE routes ADD COLUMN IF NOT EXISTS cache_semantic_threshold DOUBLE PRECISION",
+        )
+        .execute(self.adapter.pool())
+        .await?;
         sqlx::query("UPDATE routes SET strategy = 'weighted' WHERE strategy IS NULL OR btrim(strategy) = ''")
             .execute(self.adapter.pool())
             .await?;
@@ -1000,6 +1108,10 @@ impl StorageBootstrap for PostgresBootstrap {
         )
         .execute(self.adapter.pool())
         .await?;
+        sqlx::query("CREATE EXTENSION IF NOT EXISTS vector")
+            .execute(self.adapter.pool())
+            .await?;
+        ensure_semantic_cache_vectors_table(self.adapter.pool(), self.vector_dimensions).await?;
         Ok(())
     }
 
@@ -1012,7 +1124,84 @@ impl StorageBootstrap for PostgresBootstrap {
             writable: health.can_connect,
         })
     }
+}
 
+async fn ensure_semantic_cache_vectors_table(
+    pool: &Pool<Postgres>,
+    vector_dimensions: usize,
+) -> anyhow::Result<()> {
+    let dimensions = vector_dimensions.max(1);
+    let stored_dimension = sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = $1")
+        .bind(VECTOR_DIMENSIONS_SETTING_KEY)
+        .fetch_optional(pool)
+        .await?
+        .and_then(|raw| raw.trim().parse::<usize>().ok());
+    let table_exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = current_schema()
+              AND table_name = 'semantic_cache_vectors'
+        )",
+    )
+    .fetch_one(pool)
+    .await?;
+    if !table_exists || stored_dimension != Some(dimensions) {
+        recreate_pg_vector_table(pool, dimensions).await?;
+    }
+    Ok(())
+}
+
+fn semantic_cache_vectors_table_ddl(vector_dimensions: usize) -> String {
+    let dimensions = vector_dimensions.max(1);
+    format!(
+        "CREATE TABLE semantic_cache_vectors (
+            id BIGSERIAL PRIMARY KEY,
+            partition TEXT NOT NULL,
+            cache_key TEXT NOT NULL,
+            dimensions INTEGER NOT NULL,
+            embedding vector({dimensions}) NOT NULL,
+            data BYTEA NOT NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )"
+    )
+}
+
+fn rebuild_guidance_sql(vector_dimensions: usize) -> String {
+    let dimensions = vector_dimensions.max(1);
+    format!(
+        "BEGIN;
+DROP TABLE IF EXISTS semantic_cache_vectors;
+CREATE TABLE semantic_cache_vectors (
+    id BIGSERIAL PRIMARY KEY,
+    partition TEXT NOT NULL,
+    cache_key TEXT NOT NULL,
+    dimensions INTEGER NOT NULL,
+    embedding vector({dimensions}) NOT NULL,
+    data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX idx_semantic_cache_vectors_partition_key ON semantic_cache_vectors(partition, cache_key);
+CREATE INDEX idx_semantic_cache_vectors_partition_created_at ON semantic_cache_vectors(partition, created_at);
+CREATE INDEX idx_semantic_cache_vectors_hnsw ON semantic_cache_vectors USING hnsw (embedding vector_cosine_ops);
+INSERT INTO settings(key, value, updated_at)
+VALUES('{VECTOR_DIMENSIONS_SETTING_KEY}', '{dimensions}', CURRENT_TIMESTAMP)
+ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP;
+COMMIT;"
+    )
+}
+
+fn is_pg_permission_error(error: &anyhow::Error) -> bool {
+    for cause in error.chain() {
+        if let Some(sqlx_error) = cause.downcast_ref::<sqlx::Error>() {
+            if let sqlx::Error::Database(db_error) = sqlx_error {
+                if db_error.code().as_deref() == Some("42501") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn provider_select(suffix: Option<&str>) -> String {
@@ -1083,7 +1272,10 @@ fn interval_expr(window: UsageWindow) -> &'static str {
     }
 }
 
-async fn list_api_key_route_ids(pool: &Pool<Postgres>, api_key_id: &str) -> anyhow::Result<Vec<String>> {
+async fn list_api_key_route_ids(
+    pool: &Pool<Postgres>,
+    api_key_id: &str,
+) -> anyhow::Result<Vec<String>> {
     Ok(sqlx::query_scalar::<_, String>(
         "SELECT route_id FROM api_key_routes WHERE api_key_id = $1 ORDER BY route_id ASC",
     )

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -36,12 +36,16 @@ pub struct SqliteStorage {
 impl SqliteStorage {
     pub async fn from_config(config: &GatewayConfig) -> anyhow::Result<Self> {
         let pool = db::init_pool(&config.data_dir).await?;
-        let storage = Self::from_pool(pool);
+        let storage = Self::from_pool_with_dimensions(pool, config.cache.semantic.vector_dimensions);
         storage.bootstrap().migrate().await?;
         Ok(storage)
     }
 
     pub fn from_pool(pool: SqlitePool) -> Self {
+        Self::from_pool_with_dimensions(pool, 1536)
+    }
+
+    pub fn from_pool_with_dimensions(pool: SqlitePool, vector_dimensions: usize) -> Self {
         let provider_store = Arc::new(SqliteProviderStore { pool: pool.clone() });
         let route_store = Arc::new(SqliteRouteStore { pool: pool.clone() });
         let route_target_store = Arc::new(SqliteRouteTargetStore { pool: pool.clone() });
@@ -49,7 +53,10 @@ impl SqliteStorage {
         let api_key_store = Arc::new(SqliteApiKeyStore { pool: pool.clone() });
         let auth_store = Arc::new(SqliteAuthAccessStore { pool: pool.clone() });
         let log_store = Arc::new(SqliteLogStore { pool: pool.clone() });
-        let bootstrap = Arc::new(SqliteBootstrap { pool: pool.clone() });
+        let bootstrap = Arc::new(SqliteBootstrap {
+            pool: pool.clone(),
+            vector_dimensions: vector_dimensions.max(1),
+        });
         Self {
             pool,
             provider_store,
@@ -1059,6 +1066,7 @@ impl CacheStore for SqliteLogStore {
 #[derive(Clone)]
 struct SqliteBootstrap {
     pool: SqlitePool,
+    vector_dimensions: usize,
 }
 
 #[async_trait]
@@ -1068,7 +1076,7 @@ impl StorageBootstrap for SqliteBootstrap {
     }
 
     async fn migrate(&self) -> anyhow::Result<()> {
-        db::migrate(&self.pool).await
+        db::migrate(&self.pool, self.vector_dimensions).await
     }
 
     async fn health(&self) -> anyhow::Result<StorageHealth> {

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -2,13 +2,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::Parser;
 use axum::http::{HeaderValue, Method, header};
+use clap::Parser;
 use nyro_core::{
     Gateway,
-    cache::{
-        CacheConfig, CacheStorageKind, ExactCacheConfig, SemanticCacheConfig, VectorStorageKind,
-    },
+    cache::{CacheConfig, ExactCacheConfig, SemanticCacheConfig},
     config::{
         GatewayConfig, GatewayStorageConfig, SqlStorageConfig, SqliteStorageConfig,
         StorageBackendKind,
@@ -56,7 +54,11 @@ struct Args {
     )]
     proxy_cors_origins: Vec<String>,
 
-    #[arg(long, default_value = "./webui/dist", help = "Path to webui static files")]
+    #[arg(
+        long,
+        default_value = "./webui/dist",
+        help = "Path to webui static files"
+    )]
     webui_dir: String,
 
     #[arg(long, value_parser = ["sqlite", "postgres"], default_value = "sqlite")]
@@ -101,8 +103,6 @@ struct Args {
 
     #[arg(long, default_value_t = false)]
     cache_exact_enabled: bool,
-    #[arg(long, default_value = "memory")]
-    cache_exact_storage: String,
     #[arg(long, default_value_t = 3600)]
     cache_exact_ttl: u64,
     #[arg(long, default_value_t = 1000)]
@@ -110,8 +110,6 @@ struct Args {
 
     #[arg(long, default_value_t = false)]
     cache_semantic_enabled: bool,
-    #[arg(long, default_value = "memory")]
-    cache_semantic_storage: String,
     #[arg(long, default_value = "")]
     cache_semantic_route: String,
     #[arg(long, default_value_t = 0.92)]
@@ -269,30 +267,14 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
 }
 
 fn build_cache_config_from_args(args: &Args) -> anyhow::Result<CacheConfig> {
-    let exact_storage = match args.cache_exact_storage.trim().to_ascii_lowercase().as_str() {
-        "memory" | "in_memory" | "inmemory" => CacheStorageKind::Memory,
-        "database" => CacheStorageKind::Database,
-        other => anyhow::bail!("unsupported exact cache storage: {other}"),
-    };
-    let semantic_storage = match args
-        .cache_semantic_storage
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "memory" => VectorStorageKind::Memory,
-        other => anyhow::bail!("unsupported semantic cache storage: {other}"),
-    };
     Ok(CacheConfig {
         exact: ExactCacheConfig {
             enabled: args.cache_exact_enabled,
-            storage: exact_storage,
             default_ttl: Duration::from_secs(args.cache_exact_ttl.max(1)),
             max_entries: args.cache_exact_max_entries.max(1),
         },
         semantic: SemanticCacheConfig {
             enabled: args.cache_semantic_enabled,
-            storage: semantic_storage,
             embedding_route: args.cache_semantic_route.trim().to_string(),
             similarity_threshold: args.cache_semantic_threshold,
             vector_dimensions: args.cache_semantic_dimensions.max(1),
@@ -307,7 +289,10 @@ fn is_loopback_host(host: &str) -> bool {
 }
 
 fn default_local_origins(ports: &[u16]) -> Vec<String> {
-    let mut origins = vec!["tauri://localhost".to_string(), "http://tauri.localhost".to_string()];
+    let mut origins = vec![
+        "tauri://localhost".to_string(),
+        "http://tauri.localhost".to_string(),
+    ];
     for port in ports {
         origins.push(format!("http://127.0.0.1:{port}"));
         origins.push(format!("http://localhost:{port}"));
@@ -335,7 +320,13 @@ fn parse_allow_origin(origins: &[String]) -> AllowOrigin {
 fn build_cors_layer(origins: &[String]) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(parse_allow_origin(origins))
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
         .allow_headers([
             header::AUTHORIZATION,
             header::CONTENT_TYPE,
@@ -374,10 +365,7 @@ fn parse_storage_backend(value: &str) -> anyhow::Result<StorageBackendKind> {
     }
 }
 
-fn resolve_storage_dsn(
-    args: &Args,
-    backend: StorageBackendKind,
-) -> anyhow::Result<Option<String>> {
+fn resolve_storage_dsn(args: &Args, backend: StorageBackendKind) -> anyhow::Result<Option<String>> {
     if matches!(backend, StorageBackendKind::Sqlite) {
         return Ok(None);
     }

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -1,9 +1,7 @@
+use nyro_core::cache::{CacheConfig, ExactCacheConfig, SemanticCacheConfig};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::time::Duration;
-use nyro_core::cache::{
-    CacheConfig, CacheStorageKind, ExactCacheConfig, SemanticCacheConfig, VectorStorageKind,
-};
-use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct YamlConfig {
@@ -32,8 +30,6 @@ pub struct YamlExactCacheConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
-    pub storage: Option<String>,
-    #[serde(default)]
     pub default_ttl: Option<u64>,
     #[serde(default)]
     pub max_entries: Option<usize>,
@@ -43,8 +39,6 @@ pub struct YamlExactCacheConfig {
 pub struct YamlSemanticCacheConfig {
     #[serde(default)]
     pub enabled: bool,
-    #[serde(default)]
-    pub storage: Option<String>,
     #[serde(default)]
     pub embedding_route: Option<String>,
     #[serde(default)]
@@ -156,7 +150,10 @@ impl YamlConfig {
                 anyhow::bail!("providers[{i}]: name is required");
             }
             if p.endpoints.is_empty() {
-                anyhow::bail!("providers[{i}] ({}): at least one endpoint is required", p.name);
+                anyhow::bail!(
+                    "providers[{i}] ({}): at least one endpoint is required",
+                    p.name
+                );
             }
             if !p.endpoints.contains_key(&p.default_protocol) {
                 anyhow::bail!(
@@ -199,40 +196,14 @@ impl YamlConfig {
 
 impl YamlCacheConfig {
     pub fn to_cache_config(&self) -> CacheConfig {
-        let exact_storage = match self
-            .exact
-            .storage
-            .as_deref()
-            .unwrap_or("memory")
-            .trim()
-            .to_ascii_lowercase()
-            .as_str()
-        {
-            "database" => CacheStorageKind::Database,
-            "in_memory" | "inmemory" => CacheStorageKind::Memory,
-            _ => CacheStorageKind::Memory,
-        };
-        let semantic_storage = match self
-            .semantic
-            .storage
-            .as_deref()
-            .unwrap_or("memory")
-            .trim()
-            .to_ascii_lowercase()
-            .as_str()
-        {
-            _ => VectorStorageKind::Memory,
-        };
         CacheConfig {
             exact: ExactCacheConfig {
                 enabled: self.exact.enabled,
-                storage: exact_storage,
                 default_ttl: Duration::from_secs(self.exact.default_ttl.unwrap_or(3600)),
                 max_entries: self.exact.max_entries.unwrap_or(1000),
             },
             semantic: SemanticCacheConfig {
                 enabled: self.semantic.enabled,
-                storage: semantic_storage,
                 embedding_route: self.semantic.embedding_route.clone().unwrap_or_default(),
                 similarity_threshold: self.semantic.similarity_threshold.unwrap_or(0.92),
                 vector_dimensions: self.semantic.vector_dimensions.unwrap_or(1536),
@@ -332,7 +303,9 @@ pub fn build_routes(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Route> {
                 target_provider: primary.map(|t| t.provider_id.clone()).unwrap_or_default(),
                 target_model: primary.map(|t| t.model.clone()).unwrap_or_default(),
                 access_control: yr.access_control,
-                route_type: parse_route_type(&yr.route_type).unwrap_or("chat").to_string(),
+                route_type: parse_route_type(&yr.route_type)
+                    .unwrap_or("chat")
+                    .to_string(),
                 cache_exact_ttl: None,
                 cache_semantic_ttl: None,
                 cache_semantic_threshold: None,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -239,13 +239,11 @@ export interface RouteSemanticCacheConfig {
 export interface CacheSettings {
   exact: {
     enabled: boolean;
-    storage: "memory" | "database";
     default_ttl: number;
     max_entries: number;
   };
   semantic: {
     enabled: boolean;
-    storage: "memory";
     embedding_route: string;
     similarity_threshold: number;
     vector_dimensions: number;

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -80,13 +80,11 @@ export default function SettingsPage() {
   const [cacheForm, setCacheForm] = useState<CacheSettings>({
     exact: {
       enabled: false,
-      storage: "memory",
       default_ttl: 3600,
       max_entries: 1000,
     },
     semantic: {
       enabled: false,
-      storage: "memory",
       embedding_route: "",
       similarity_threshold: 0.92,
       vector_dimensions: 1536,
@@ -400,21 +398,6 @@ export default function SettingsPage() {
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
-                <label className="ml-1 text-xs text-slate-700">{isZh ? "存储" : "Storage"}</label>
-                <Select
-                  value={cacheForm.exact.storage}
-                  onValueChange={(value: "memory" | "database") =>
-                    setCacheForm((prev) => ({ ...prev, exact: { ...prev.exact, storage: value } }))
-                  }
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="memory">{isZh ? "内存" : "memory"}</SelectItem>
-                    <SelectItem value="database">{isZh ? "数据库" : "database"}</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-1.5">
                 <label className="ml-1 text-xs text-slate-700">TTL (s)</label>
                 <Input
                   type="number"
@@ -454,21 +437,7 @@ export default function SettingsPage() {
                 onCheckedChange={handleSemanticEnabledToggle}
               />
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <label className="ml-1 text-xs text-slate-700">{isZh ? "存储" : "Storage"}</label>
-                <Select
-                  value={cacheForm.semantic.storage}
-                  onValueChange={(value: "memory") =>
-                    setCacheForm((prev) => ({ ...prev, semantic: { ...prev.semantic, storage: value } }))
-                  }
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="memory">{isZh ? "内存" : "memory"}</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+            <div className="space-y-3">
               <div className="space-y-1.5">
                 <label className="ml-1 text-xs text-slate-700">
                   {isZh ? "Embedding 路由（必选）" : "Embedding Route (Required)"}
@@ -508,6 +477,7 @@ export default function SettingsPage() {
                   </p>
                 )}
               </div>
+              <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <label className="ml-1 text-xs text-slate-700">{isZh ? "阈值" : "Threshold"}</label>
                 <Input
@@ -565,6 +535,7 @@ export default function SettingsPage() {
                     }))
                   }
                 />
+              </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Auto-rebuild semantic vector tables when embedding dimensions change, persist active dimensions in settings, and add transactional pgvector rebuild with clear permission fallback guidance. This also removes manual cache storage selection and updates semantic cache settings layout in WebUI for clearer configuration.

FIX #34 