### PR TITLE
fix: global cache/proxy toggles lack proper linkage with routes and providers

### DIFF
--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -354,7 +354,7 @@ impl Gateway {
             .map(parse_bool_setting)
             .unwrap_or(false);
         if !enabled {
-            anyhow::bail!("proxy is disabled in settings");
+            return Ok(self.http_client.clone());
         }
 
         let proxy_url = self

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -1059,26 +1059,20 @@ export default function ProvidersPage() {
                   </Button>
                 </div>
               </div>
-              <div className="space-y-2">
-                <FieldLabel>{isZh ? "使用本地代理" : "Use Local Proxy"}</FieldLabel>
-                <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
-                  <span className="text-xs text-slate-600">
-                    {isZh ? "开启后走设置页中的本地代理地址" : "Route requests via local proxy from settings"}
-                  </span>
-                  <Switch
-                    checked={Boolean(form.use_proxy)}
-                    disabled={!isGlobalProxyEnabled}
-                    onCheckedChange={(checked) => setForm({ ...form, use_proxy: checked })}
-                  />
+              {isGlobalProxyEnabled && (
+                <div className="space-y-2">
+                  <FieldLabel>{isZh ? "使用本地代理" : "Use Local Proxy"}</FieldLabel>
+                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                    <span className="text-xs text-slate-600">
+                      {isZh ? "开启后走设置页中的本地代理地址" : "Route requests via local proxy from settings"}
+                    </span>
+                    <Switch
+                      checked={Boolean(form.use_proxy)}
+                      onCheckedChange={(checked) => setForm({ ...form, use_proxy: checked })}
+                    />
+                  </div>
                 </div>
-                {!isGlobalProxyEnabled && (
-                  <p className="text-xs text-amber-600">
-                    {isZh
-                      ? "系统设置中的本地代理未启用，当前无法为 Provider 开启代理。"
-                      : "Local proxy is disabled in Settings, so provider proxy cannot be enabled."}
-                  </p>
-                )}
-              </div>
+              )}
               <div className="space-y-2">
                 <FieldLabel>API Key</FieldLabel>
                 <div className="relative">
@@ -1428,26 +1422,20 @@ export default function ProvidersPage() {
                         </Button>
                       </div>
                     </div>
-                    <div className="space-y-2">
-                      <FieldLabel>{isZh ? "使用本地代理" : "Use Local Proxy"}</FieldLabel>
-                      <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
-                        <span className="text-xs text-slate-600">
-                          {isZh ? "开启后走设置页中的本地代理地址" : "Route requests via local proxy from settings"}
-                        </span>
-                        <Switch
-                          checked={Boolean(editForm.use_proxy)}
-                          disabled={!isGlobalProxyEnabled}
-                          onCheckedChange={(checked) => setEditForm({ ...editForm, use_proxy: checked })}
-                        />
+                    {isGlobalProxyEnabled && (
+                      <div className="space-y-2">
+                        <FieldLabel>{isZh ? "使用本地代理" : "Use Local Proxy"}</FieldLabel>
+                        <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                          <span className="text-xs text-slate-600">
+                            {isZh ? "开启后走设置页中的本地代理地址" : "Route requests via local proxy from settings"}
+                          </span>
+                          <Switch
+                            checked={Boolean(editForm.use_proxy)}
+                            onCheckedChange={(checked) => setEditForm({ ...editForm, use_proxy: checked })}
+                          />
+                        </div>
                       </div>
-                      {!isGlobalProxyEnabled && (
-                        <p className="text-xs text-amber-600">
-                          {isZh
-                            ? "系统设置中的本地代理未启用，当前无法为 Provider 开启代理。"
-                            : "Local proxy is disabled in Settings, so provider proxy cannot be enabled."}
-                        </p>
-                      )}
-                    </div>
+                    )}
                     <div className="space-y-2">
                       <FieldLabel>{isZh ? "API Key" : "API Key"}</FieldLabel>
                       <div className="relative">
@@ -1590,6 +1578,11 @@ export default function ProvidersPage() {
                             {protocol}
                           </Badge>
                         ))}
+                        {isGlobalProxyEnabled && p.use_proxy && (
+                          <Badge variant="success" className="connect-label-badge">
+                            {isZh ? "本地代理" : "Proxy"}
+                          </Badge>
+                        )}
                         {status === "success" ? (
                           <CheckCircle
                             className="h-3.5 w-3.5 text-green-500"

--- a/webui/src/pages/routes.tsx
+++ b/webui/src/pages/routes.tsx
@@ -682,40 +682,39 @@ export default function RoutesPage() {
             />
             {createForm.route_type !== "embedding" && (
               <>
-                <RouteToggleControl
-                  title={isZh ? "精确匹配缓存" : "Exact Cache"}
-                  isZh={isZh}
-                  checked={createForm.cache_exact_enabled}
-                  disabled={!globalExactCacheEnabled}
-                  disabledMessage={isZh ? "请在系统设置中开启全局精确匹配缓存" : "Enable global exact cache in settings first"}
-                  onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, cache_exact_enabled: checked }))}
-                />
-                <RouteToggleControl
-                  title={isZh ? "语义相似缓存" : "Semantic Cache"}
-                  isZh={isZh}
-                  checked={createForm.cache_semantic_enabled}
-                  disabled={!globalSemanticCacheEnabled}
-                  disabledMessage={isZh ? "请在系统设置中开启全局语义相似缓存" : "Enable global semantic cache in settings first"}
-                  onCheckedChange={(checked) => {
-                    if (!globalSemanticCacheEnabled) return;
-                    updateCreateSemanticEnabled(checked);
-                  }}
-                />
-                {globalSemanticCacheEnabled && createForm.cache_semantic_enabled && (
-                  <div className="space-y-2">
-                    <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
-                    <Input
-                      type="number"
-                      step="0.01"
-                      min={0}
-                      max={1}
-                      value={createForm.cache_semantic_threshold}
-                      onChange={(e) =>
-                        setCreateForm((prev) => ({ ...prev, cache_semantic_threshold: e.target.value }))
-                      }
-                      placeholder={defaultThresholdInput(globalSemanticThreshold)}
+                {globalExactCacheEnabled && (
+                  <RouteToggleControl
+                    title={isZh ? "精确匹配缓存" : "Exact Cache"}
+                    isZh={isZh}
+                    checked={createForm.cache_exact_enabled}
+                    onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, cache_exact_enabled: checked }))}
+                  />
+                )}
+                {globalSemanticCacheEnabled && (
+                  <>
+                    <RouteToggleControl
+                      title={isZh ? "语义相似缓存" : "Semantic Cache"}
+                      isZh={isZh}
+                      checked={createForm.cache_semantic_enabled}
+                      onCheckedChange={(checked) => updateCreateSemanticEnabled(checked)}
                     />
-                  </div>
+                    {createForm.cache_semantic_enabled && (
+                      <div className="space-y-2">
+                        <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
+                        <Input
+                          type="number"
+                          step="0.01"
+                          min={0}
+                          max={1}
+                          value={createForm.cache_semantic_threshold}
+                          onChange={(e) =>
+                            setCreateForm((prev) => ({ ...prev, cache_semantic_threshold: e.target.value }))
+                          }
+                          placeholder={defaultThresholdInput(globalSemanticThreshold)}
+                        />
+                      </div>
+                    )}
+                  </>
                 )}
               </>
             )}
@@ -886,44 +885,43 @@ export default function RoutesPage() {
                     />
                     {editForm.route_type !== "embedding" && (
                       <>
-                        <RouteToggleControl
-                          title={isZh ? "精确匹配缓存" : "Exact Cache"}
-                          isZh={isZh}
-                          checked={editForm.cache_exact_enabled}
-                          disabled={!globalExactCacheEnabled}
-                          disabledMessage={isZh ? "请在系统设置中开启全局精确匹配缓存" : "Enable global exact cache in settings first"}
-                          onCheckedChange={(checked) =>
-                            setEditForm((prev) => (prev ? { ...prev, cache_exact_enabled: checked } : prev))
-                          }
-                        />
-                        <RouteToggleControl
-                          title={isZh ? "语义相似缓存" : "Semantic Cache"}
-                          isZh={isZh}
-                          checked={editForm.cache_semantic_enabled}
-                          disabled={!globalSemanticCacheEnabled}
-                          disabledMessage={isZh ? "请在系统设置中开启全局语义相似缓存" : "Enable global semantic cache in settings first"}
-                          onCheckedChange={(checked) => {
-                            if (!globalSemanticCacheEnabled) return;
-                            updateEditSemanticEnabled(checked);
-                          }}
-                        />
-                        {globalSemanticCacheEnabled && editForm.cache_semantic_enabled && (
-                          <div className="space-y-2">
-                            <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
-                            <Input
-                              type="number"
-                              step="0.01"
-                              min={0}
-                              max={1}
-                              value={editForm.cache_semantic_threshold}
-                              onChange={(e) =>
-                                setEditForm((prev) =>
-                                  prev ? { ...prev, cache_semantic_threshold: e.target.value } : prev
-                                )
-                              }
-                              placeholder={defaultThresholdInput(globalSemanticThreshold)}
+                        {globalExactCacheEnabled && (
+                          <RouteToggleControl
+                            title={isZh ? "精确匹配缓存" : "Exact Cache"}
+                            isZh={isZh}
+                            checked={editForm.cache_exact_enabled}
+                            onCheckedChange={(checked) =>
+                              setEditForm((prev) => (prev ? { ...prev, cache_exact_enabled: checked } : prev))
+                            }
+                          />
+                        )}
+                        {globalSemanticCacheEnabled && (
+                          <>
+                            <RouteToggleControl
+                              title={isZh ? "语义相似缓存" : "Semantic Cache"}
+                              isZh={isZh}
+                              checked={editForm.cache_semantic_enabled}
+                              onCheckedChange={(checked) => updateEditSemanticEnabled(checked)}
                             />
-                          </div>
+                            {editForm.cache_semantic_enabled && (
+                              <div className="space-y-2">
+                                <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  min={0}
+                                  max={1}
+                                  value={editForm.cache_semantic_threshold}
+                                  onChange={(e) =>
+                                    setEditForm((prev) =>
+                                      prev ? { ...prev, cache_semantic_threshold: e.target.value } : prev
+                                    )
+                                  }
+                                  placeholder={defaultThresholdInput(globalSemanticThreshold)}
+                                />
+                              </div>
+                            )}
+                          </>
                         )}
                       </>
                     )}
@@ -996,12 +994,12 @@ export default function RoutesPage() {
                         {isZh ? "鉴权" : "Auth"}
                       </Badge>
                     )}
-                    {route.cache?.exact && (
+                    {globalExactCacheEnabled && route.cache?.exact && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? "精确匹配缓存" : "Exact Cache"}
                       </Badge>
                     )}
-                    {route.cache?.semantic && (
+                    {globalSemanticCacheEnabled && route.cache?.semantic && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? "语义相似缓存" : "Semantic Cache"}
                       </Badge>
@@ -1022,7 +1020,22 @@ export default function RoutesPage() {
                     <Pencil className="h-4 w-4" />
                   </button>
                   <button
-                    onClick={() => setRouteToDelete(route)}
+                    onClick={() => {
+                      if (
+                        route.route_type === "embedding" &&
+                        cacheSettings?.semantic?.enabled &&
+                        cacheSettings.semantic.embedding_route === route.virtual_model
+                      ) {
+                        setErrorDialog({
+                          title: isZh ? "无法删除该路由" : "Cannot delete this route",
+                          description: isZh
+                            ? `该 Embedding 路由「${route.name}」正被系统设置中的语义相似缓存引用，请先在系统设置中关闭语义相似缓存或更换 Embedding 路由后再删除。`
+                            : `The embedding route "${route.name}" is referenced by semantic cache in system settings. Please disable semantic cache or change the embedding route in settings before deleting.`,
+                        });
+                        return;
+                      }
+                      setRouteToDelete(route);
+                    }}
                     className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
                   >
                     <Trash2 className="h-4 w-4" />

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -7,7 +7,6 @@ import type {
   ExportData,
   GatewayStatus,
   ImportResult,
-  Provider,
   Route as RouteType,
 } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
@@ -160,26 +159,11 @@ export default function SettingsPage() {
         backend("set_setting", { key: "proxy_url", value: input.url }),
         backend("set_setting", { key: "proxy_bypass", value: input.bypass }),
       ]);
-
-      // If global proxy is turned off, force all providers to disable provider-level proxy usage.
-      if (!input.enabled) {
-        const providers = await backend<Provider[]>("get_providers");
-        const providersUsingProxy = providers.filter((provider) => provider.use_proxy);
-        await Promise.all(
-          providersUsingProxy.map((provider) =>
-            backend("update_provider", {
-              id: provider.id,
-              input: { use_proxy: false },
-            }),
-          ),
-        );
-      }
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["setting", "proxy_enabled"] });
       qc.invalidateQueries({ queryKey: ["setting", "proxy_url"] });
       qc.invalidateQueries({ queryKey: ["setting", "proxy_bypass"] });
-      qc.invalidateQueries({ queryKey: ["providers"] });
     },
     onError: (error: unknown) => {
       showErrorDialog("保存代理设置失败", "Failed to save proxy settings", error);
@@ -453,7 +437,11 @@ export default function SettingsPage() {
                   onCheckedChange={(checked) =>
                     setCacheForm((prev) => ({
                       ...prev,
-                      semantic: { ...prev.semantic, enabled: checked },
+                      semantic: {
+                        ...prev.semantic,
+                        enabled: checked,
+                        embedding_route: checked ? prev.semantic.embedding_route : "",
+                      },
                     }))
                   }
                 />
@@ -476,7 +464,7 @@ export default function SettingsPage() {
                   <SelectContent>
                     {embeddingRoutes.map((route) => (
                       <SelectItem key={route.id} value={route.virtual_model}>
-                        {route.name} ({route.virtual_model})
+                        {route.name} · {route.virtual_model}
                       </SelectItem>
                     ))}
                     {!selectedEmbeddingRouteExists && cacheForm.semantic.embedding_route.trim() && (


### PR DESCRIPTION
Cache <-> Routes (frontend):
- Route list badges now check globalExactCacheEnabled / globalSemanticCacheEnabled; badges are hidden when global cache is off
- Cache toggles in create/edit route forms are hidden entirely when global cache is disabled; existing saved config is preserved (not cleared)

Proxy <-> Providers (frontend):
- Provider list now shows a proxy badge controlled by global proxy_enabled
- Proxy toggle in create/edit provider forms is hidden when global proxy is off
- Remove batch use_proxy=false reset in settings.tsx when disabling global proxy, so configs are preserved and auto-restore when proxy is re-enabled

Proxy fallback (backend):
- http_client_for_provider: when global proxy is disabled, fall back to the direct HTTP client instead of bailing, preventing 502 on use_proxy=true routes

Semantic cache <-> Embedding route:
- Clear embedding_route field when semantic cache toggle is turned off
- Block deletion of an embedding route if it is referenced by semantic cache config; show an error dialog prompting the user to remove the dependency first

FIX #40 