### PR TITLE
chore: rename GitHub org from NYRO-WAY to nyroway

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -189,7 +189,7 @@ jobs:
           LINUX_ARM_SHA="$(sha256sum "$LINUX_ARM_ASSET" | awk '{print $1}')"
           LINUX_INTEL_SHA="$(sha256sum "$LINUX_INTEL_ASSET" | awk '{print $1}')"
 
-          git clone https://x-access-token:${GH_TOKEN}@github.com/NYRO-WAY/homebrew-nyro.git /tmp/homebrew-nyro
+          git clone https://x-access-token:${GH_TOKEN}@github.com/nyroway/homebrew-nyro.git /tmp/homebrew-nyro
           cd /tmp/homebrew-nyro
           VERSION="$VERSION" \
           MAC_ARM_SHA="$MAC_ARM_SHA" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/nyro-core", "src-tauri", "src-server"]
 version = "1.5.0"
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/NYRO-WAY/NYRO"
+repository = "https://github.com/nyroway/nyro"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/NYRO-WAY/NYRO/releases/latest"><img src="https://img.shields.io/github/v/release/NYRO-WAY/NYRO" alt="Release"></a>
+  <a href="https://github.com/nyroway/nyro/releases/latest"><img src="https://img.shields.io/github/v/release/nyroway/nyro" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="README_CN.md"><img src="https://img.shields.io/badge/文档-中文-8A2BE2" alt="中文"></a>
 </p>
@@ -153,7 +153,7 @@ Nyro detects installed tools, generates the correct configuration for the select
 **Homebrew (macOS / Linux)**
 
 ```bash
-brew tap nyro-way/nyro
+brew tap nyroway/nyro
 brew install --cask nyro
 ```
 
@@ -161,15 +161,15 @@ brew install --cask nyro
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.ps1 | iex
+irm https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.ps1 | iex
 ```
 
 **Manual Download**
 
-Download the latest installer for your platform from [GitHub Releases](https://github.com/NYRO-WAY/NYRO/releases/latest).
+Download the latest installer for your platform from [GitHub Releases](https://github.com/nyroway/nyro/releases/latest).
 
 > **macOS**: After manual install run `sudo xattr -rd com.apple.quarantine /Applications/Nyro.app`, or use the install script which handles this automatically.
 >
@@ -179,7 +179,7 @@ Download the latest installer for your platform from [GitHub Releases](https://g
 
 ```bash
 # Download
-curl -LO https://github.com/NYRO-WAY/NYRO/releases/latest/download/nyro-server-linux-x86_64
+curl -LO https://github.com/nyroway/nyro/releases/latest/download/nyro-server-linux-x86_64
 chmod +x nyro-server-linux-x86_64
 
 # Start (localhost only, no auth required)

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/NYRO-WAY/NYRO/releases/latest"><img src="https://img.shields.io/github/v/release/NYRO-WAY/NYRO" alt="Release"></a>
+  <a href="https://github.com/nyroway/nyro/releases/latest"><img src="https://img.shields.io/github/v/release/nyroway/nyro" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/Language-English-2d7ff9" alt="English"></a>
 </p>
@@ -151,7 +151,7 @@ Nyro 会自动检测已安装工具，为所选路由生成正确配置并一键
 **Homebrew（macOS / Linux）**
 
 ```bash
-brew tap nyro-way/nyro
+brew tap nyroway/nyro
 brew install --cask nyro
 ```
 
@@ -159,15 +159,15 @@ brew install --cask nyro
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.ps1 | iex
+irm https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.ps1 | iex
 ```
 
 **手动下载**
 
-从 [GitHub Releases](https://github.com/NYRO-WAY/NYRO/releases/latest) 下载你平台对应的最新安装包。
+从 [GitHub Releases](https://github.com/nyroway/nyro/releases/latest) 下载你平台对应的最新安装包。
 
 > **macOS**：手动安装后请运行 `sudo xattr -rd com.apple.quarantine /Applications/Nyro.app`，或使用安装脚本自动处理。
 >
@@ -177,7 +177,7 @@ irm https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/insta
 
 ```bash
 # 下载
-curl -LO https://github.com/NYRO-WAY/NYRO/releases/latest/download/nyro-server-linux-x86_64
+curl -LO https://github.com/nyroway/nyro/releases/latest/download/nyro-server-linux-x86_64
 chmod +x nyro-server-linux-x86_64
 
 # 启动（仅 localhost，无需鉴权）

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,5 +1,5 @@
 # Nyro AI Gateway Install Script for Windows
-# Usage: irm https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.ps1 | iex
+# Usage: irm https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.ps1 | iex
 #
 # Parameters (set before running):
 #   $Version = "1.0.0"   # Install specific version
@@ -10,7 +10,7 @@ if (-not $DryRun) { $DryRun = $false }
 
 $ErrorActionPreference = "Continue"
 
-$Repo = "NYRO-WAY/NYRO"
+$Repo = "nyroway/nyro"
 $AppName = "Nyro"
 $GithubApi = "https://api.github.com/repos/$Repo/releases"
 $script:ReleaseVersion = ""
@@ -81,7 +81,7 @@ function Get-ReleaseVersion {
     }
 
     Script-Error "Failed to determine latest version. Try specifying version manually:"
-    Write-Host '  $Version = "1.0.0"; irm https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.ps1 | iex' -ForegroundColor Yellow
+    Write-Host '  $Version = "1.0.0"; irm https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.ps1 | iex' -ForegroundColor Yellow
     return $false
 }
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nyro AI Gateway Install Script (Linux + macOS)
-# Usage: curl -fsSL https://raw.githubusercontent.com/NYRO-WAY/NYRO/master/scripts/install/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/install.sh | bash
 #
 # Environment variables:
 #   VERSION   - Install specific version (e.g. "1.0.0"), default: latest
@@ -14,7 +14,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-REPO="NYRO-WAY/NYRO"
+REPO="nyroway/nyro"
 APP_NAME="Nyro"
 GITHUB_API="https://api.github.com/repos/${REPO}/releases"
 

--- a/scripts/release/gen_latest_json.py
+++ b/scripts/release/gen_latest_json.py
@@ -2,12 +2,12 @@
 """Generate latest.json for Tauri updater from release assets and .sig files.
 
 Usage:
-    VERSION=v0.1.0 REPO=NYRO-WAY/NYRO python3 scripts/gen_latest_json.py \
+    VERSION=v0.1.0 REPO=nyroway/nyro python3 scripts/gen_latest_json.py \
         --assets-dir release-assets --output latest.json
 
 Environment variables:
     VERSION   Git tag name, e.g. v0.1.0
-    REPO      GitHub owner/repo, e.g. NYRO-WAY/NYRO
+    REPO      GitHub owner/repo, e.g. nyroway/nyro
 """
 import argparse
 import json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/NYRO-WAY/NYRO/releases/latest/download/latest.json"
+        "https://github.com/nyroway/nyro/releases/latest/download/latest.json"
       ],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk3Qzc1MTU5MkU5NDg2NjUKUldSbGhwUXVXVkhIbCtEbHhhVG1NWjRrcGFpTjhOWHBUaVpHV0s0SlVnOG55UmRLQXAvTEFqcTMK"

--- a/webui/src/components/layout/app-layout.tsx
+++ b/webui/src/components/layout/app-layout.tsx
@@ -59,7 +59,7 @@ export function AppLayout() {
   }
 
   async function openProjectGithub() {
-    await openExternalUrl("https://github.com/NYRO-WAY/NYRO");
+    await openExternalUrl("https://github.com/nyroway/nyro");
   }
 
   async function handleSurfaceMouseDown(e: React.MouseEvent<HTMLElement>) {

--- a/webui/src/components/layout/sidebar.tsx
+++ b/webui/src/components/layout/sidebar.tsx
@@ -30,7 +30,7 @@ const NAV_ITEMS = [
   { label: "Settings", path: "/settings", icon: Settings },
   {
     label: "Feedback",
-    href: "https://github.com/NYRO-WAY/NYRO/issues/new",
+    href: "https://github.com/nyroway/nyro/issues/new",
     icon: MessageSquarePlus,
     external: true as const,
   },


### PR DESCRIPTION
Update all references to the old organization name across configs, scripts, docs, and frontend code.