### PR TITLE
feat(cache): add stream replay TPS throttle and per-cache header control

### DIFF
--- a/crates/nyro-core/src/cache/config.rs
+++ b/crates/nyro-core/src/cache/config.rs
@@ -8,6 +8,10 @@ pub struct ExactCacheConfig {
     pub enabled: bool,
     pub default_ttl: Duration,
     pub max_entries: usize,
+    /// Tokens per second for cached stream replay. 0 = no throttle (instant).
+    pub stream_replay_tps: u32,
+    /// Whether to expose X-NYRO-CACHE-* response headers on cache hit/miss.
+    pub expose_headers: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,6 +22,10 @@ pub struct SemanticCacheConfig {
     pub vector_dimensions: usize,
     pub default_ttl: Duration,
     pub max_entries: usize,
+    /// Tokens per second for cached stream replay. 0 = no throttle (instant).
+    pub stream_replay_tps: u32,
+    /// Whether to expose X-NYRO-CACHE-* response headers on cache hit/miss.
+    pub expose_headers: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,6 +41,8 @@ impl Default for CacheConfig {
                 enabled: false,
                 default_ttl: Duration::from_secs(3600),
                 max_entries: 1000,
+                stream_replay_tps: 100,
+                expose_headers: true,
             },
             semantic: SemanticCacheConfig {
                 enabled: false,
@@ -41,6 +51,8 @@ impl Default for CacheConfig {
                 vector_dimensions: 1536,
                 default_ttl: Duration::from_secs(600),
                 max_entries: 500,
+                stream_replay_tps: 100,
+                expose_headers: true,
             },
         }
     }
@@ -53,6 +65,8 @@ impl CacheConfig {
                 "enabled": self.exact.enabled,
                 "default_ttl": self.exact.default_ttl.as_secs(),
                 "max_entries": self.exact.max_entries,
+                "stream_replay_tps": self.exact.stream_replay_tps,
+                "expose_headers": self.exact.expose_headers,
             },
             "semantic": {
                 "enabled": self.semantic.enabled,
@@ -61,6 +75,8 @@ impl CacheConfig {
                 "vector_dimensions": self.semantic.vector_dimensions,
                 "default_ttl": self.semantic.default_ttl.as_secs(),
                 "max_entries": self.semantic.max_entries,
+                "stream_replay_tps": self.semantic.stream_replay_tps,
+                "expose_headers": self.semantic.expose_headers,
             }
         })
     }
@@ -84,11 +100,30 @@ impl CacheConfig {
         let semantic_default_ttl = semantic.get("default_ttl")?.as_u64()?.max(1);
         let semantic_max_entries = semantic.get("max_entries")?.as_u64()?.max(1) as usize;
 
+        let exact_stream_replay_tps = exact
+            .get("stream_replay_tps")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(100) as u32;
+        let exact_expose_headers = exact
+            .get("expose_headers")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let semantic_stream_replay_tps = semantic
+            .get("stream_replay_tps")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(100) as u32;
+        let semantic_expose_headers = semantic
+            .get("expose_headers")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         Some(Self {
             exact: ExactCacheConfig {
                 enabled: exact_enabled,
                 default_ttl: Duration::from_secs(exact_default_ttl),
                 max_entries: exact_max_entries,
+                stream_replay_tps: exact_stream_replay_tps,
+                expose_headers: exact_expose_headers,
             },
             semantic: SemanticCacheConfig {
                 enabled: semantic_enabled,
@@ -97,6 +132,8 @@ impl CacheConfig {
                 vector_dimensions,
                 default_ttl: Duration::from_secs(semantic_default_ttl),
                 max_entries: semantic_max_entries,
+                stream_replay_tps: semantic_stream_replay_tps,
+                expose_headers: semantic_expose_headers,
             },
         })
     }

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -353,6 +353,8 @@ async fn proxy_pipeline(
                         Some(key),
                         "EXACT",
                         None,
+                        cache_config.exact.stream_replay_tps,
+                        cache_config.exact.expose_headers,
                     );
                     emit_log(
                         &gw,
@@ -393,6 +395,8 @@ async fn proxy_pipeline(
                                     Some(key),
                                     "EXACT",
                                     None,
+                                    cache_config.exact.stream_replay_tps,
+                                    cache_config.exact.expose_headers,
                                 );
                                 emit_log(
                                     &gw,
@@ -450,6 +454,8 @@ async fn proxy_pipeline(
                                 Some(&hit.key),
                                 "SEMANTIC",
                                 Some(hit.score),
+                                cache_config.semantic.stream_replay_tps,
+                                cache_config.semantic.expose_headers,
                             );
                             emit_log(
                                 &gw,
@@ -567,6 +573,8 @@ async fn proxy_pipeline(
         forward_headers.extend(extra_headers.clone());
         let egress_str = egress.to_string();
 
+        let miss_expose_headers =
+            cache_config.exact.expose_headers || cache_config.semantic.expose_headers;
         let response = if is_stream {
             handle_stream(
                 gw.clone(),
@@ -592,6 +600,7 @@ async fn proxy_pipeline(
                 semantic_write_ctx.clone(),
                 singleflight_leader.as_ref().map(|(k, _)| k.as_str()),
                 singleflight_leader.as_ref().map(|(_, tx)| tx.clone()),
+                miss_expose_headers,
             )
             .await
         } else {
@@ -617,6 +626,7 @@ async fn proxy_pipeline(
                 exact_enabled_for_route,
                 Some(exact_ttl),
                 semantic_write_ctx.clone(),
+                miss_expose_headers,
             )
             .await
         };
@@ -666,6 +676,7 @@ async fn handle_non_stream(
     allow_exact_store: bool,
     exact_cache_ttl: Option<Duration>,
     semantic_write_ctx: Option<SemanticWriteContext>,
+    expose_headers: bool,
 ) -> Response {
     let credential_to_use = credential.to_string();
     let call_result = match client
@@ -740,7 +751,7 @@ async fn handle_non_stream(
         Json(output.clone()),
     )
         .into_response();
-    set_cache_headers(&mut response, "MISS", cache_key, None);
+    set_cache_headers(&mut response, "MISS", cache_key, None, expose_headers);
 
     if status < 400 && !is_tool {
         let entry = CacheEntry {
@@ -807,6 +818,7 @@ async fn handle_stream(
     semantic_write_ctx: Option<SemanticWriteContext>,
     singleflight_key: Option<&str>,
     singleflight_tx: Option<broadcast::Sender<Vec<u8>>>,
+    expose_headers: bool,
 ) -> Response {
     let credential_to_use = credential.to_string();
     let call_result = match client
@@ -1015,7 +1027,7 @@ async fn handle_stream(
         .header(header::CONNECTION, "keep-alive")
         .body(body)
         .unwrap();
-    set_cache_headers(&mut response, "MISS", cache_key, None);
+    set_cache_headers(&mut response, "MISS", cache_key, None, expose_headers);
     response
 }
 
@@ -1466,19 +1478,28 @@ fn extract_semantic_embedding_input(request: &InternalRequest) -> Option<(String
     Some((system_prompt, embedding_text))
 }
 
-fn set_cache_headers(response: &mut Response, cache_status: &str, key: Option<&str>, score: Option<f64>) {
+fn set_cache_headers(
+    response: &mut Response,
+    cache_status: &str,
+    key: Option<&str>,
+    score: Option<f64>,
+    expose_headers: bool,
+) {
+    if !expose_headers {
+        return;
+    }
     let headers = response.headers_mut();
     if let Ok(value) = HeaderValue::from_str(cache_status) {
-        headers.insert("x-nyro-cache", value);
+        headers.insert("X-NYRO-CACHE", value);
     }
     if let Some(key) = key {
         if let Ok(value) = HeaderValue::from_str(key) {
-            headers.insert("x-nyro-cache-key", value);
+            headers.insert("X-NYRO-CACHE-KEY", value);
         }
     }
     if let Some(score) = score {
         if let Ok(value) = HeaderValue::from_str(&format!("{score:.4}")) {
-            headers.insert("x-nyro-cache-score", value);
+            headers.insert("X-NYRO-CACHE-SCORE", value);
         }
     }
 }
@@ -1490,10 +1511,20 @@ fn cached_entry_to_response(
     cache_key: Option<&str>,
     cache_status: &str,
     score: Option<f64>,
+    stream_replay_tps: u32,
+    expose_headers: bool,
 ) -> Response {
     if is_stream {
         if let Some(internal) = entry.internal_response.as_ref() {
-            return replay_cached_stream(ingress, internal, cache_key, cache_status, score);
+            return replay_cached_stream(
+                ingress,
+                internal,
+                cache_key,
+                cache_status,
+                score,
+                stream_replay_tps,
+                expose_headers,
+            );
         }
     }
     let mut response = (
@@ -1501,7 +1532,7 @@ fn cached_entry_to_response(
         Json(entry.payload.clone()),
     )
         .into_response();
-    set_cache_headers(&mut response, cache_status, cache_key, score);
+    set_cache_headers(&mut response, cache_status, cache_key, score, expose_headers);
     response
 }
 
@@ -1511,9 +1542,17 @@ fn replay_cached_stream(
     cache_key: Option<&str>,
     cache_status: &str,
     score: Option<f64>,
+    stream_replay_tps: u32,
+    expose_headers: bool,
 ) -> Response {
     let mut formatter = crate::protocol::get_stream_formatter(ingress);
     let deltas = internal_response_to_deltas(internal);
+    // When TPS throttle is enabled, split large text chunks to ~1 token each (4 chars).
+    let deltas = if stream_replay_tps > 0 {
+        split_text_deltas(deltas, 4)
+    } else {
+        deltas
+    };
     let mut payloads: Vec<String> = formatter
         .format_deltas(&deltas)
         .into_iter()
@@ -1526,9 +1565,23 @@ fn replay_cached_stream(
             .map(|event| event.to_sse_string()),
     );
 
+    let interval = if stream_replay_tps > 0 {
+        Some(std::time::Duration::from_micros(
+            1_000_000 / stream_replay_tps as u64,
+        ))
+    } else {
+        None
+    };
+
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<String, Infallible>>(payloads.len().max(1));
     tokio::spawn(async move {
-        for payload in payloads {
+        for (i, payload) in payloads.into_iter().enumerate() {
+            // First chunk is sent immediately to keep TTFT at zero.
+            if i > 0 {
+                if let Some(d) = interval {
+                    tokio::time::sleep(d).await;
+                }
+            }
             if tx.send(Ok(payload)).await.is_err() {
                 break;
             }
@@ -1543,7 +1596,7 @@ fn replay_cached_stream(
         .header(header::CONNECTION, "keep-alive")
         .body(body)
         .unwrap();
-    set_cache_headers(&mut response, cache_status, cache_key, score);
+    set_cache_headers(&mut response, cache_status, cache_key, score, expose_headers);
     response
 }
 
@@ -1585,6 +1638,35 @@ fn internal_response_to_deltas(internal: &InternalResponse) -> Vec<StreamDelta> 
             .unwrap_or_else(|| "stop".to_string()),
     });
     deltas
+}
+
+fn split_text_deltas(deltas: Vec<StreamDelta>, chunk_chars: usize) -> Vec<StreamDelta> {
+    deltas
+        .into_iter()
+        .flat_map(|d| match d {
+            StreamDelta::TextDelta(text) => {
+                let chars: Vec<char> = text.chars().collect();
+                if chars.len() <= chunk_chars {
+                    return vec![StreamDelta::TextDelta(text)];
+                }
+                chars
+                    .chunks(chunk_chars)
+                    .map(|c| StreamDelta::TextDelta(c.iter().collect()))
+                    .collect()
+            }
+            StreamDelta::ReasoningDelta(text) => {
+                let chars: Vec<char> = text.chars().collect();
+                if chars.len() <= chunk_chars {
+                    return vec![StreamDelta::ReasoningDelta(text)];
+                }
+                chars
+                    .chunks(chunk_chars)
+                    .map(|c| StreamDelta::ReasoningDelta(c.iter().collect()))
+                    .collect()
+            }
+            other => vec![other],
+        })
+        .collect()
 }
 
 async fn finalize_singleflight(

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -241,6 +241,8 @@ export interface CacheSettings {
     enabled: boolean;
     default_ttl: number;
     max_entries: number;
+    stream_replay_tps: number;
+    expose_headers: boolean;
   };
   semantic: {
     enabled: boolean;
@@ -249,6 +251,8 @@ export interface CacheSettings {
     vector_dimensions: number;
     default_ttl: number;
     max_entries: number;
+    stream_replay_tps: number;
+    expose_headers: boolean;
   };
 }
 

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -82,6 +82,8 @@ export default function SettingsPage() {
       enabled: false,
       default_ttl: 3600,
       max_entries: 1000,
+      stream_replay_tps: 100,
+      expose_headers: true,
     },
     semantic: {
       enabled: false,
@@ -90,6 +92,8 @@ export default function SettingsPage() {
       vector_dimensions: 1536,
       default_ttl: 600,
       max_entries: 500,
+      stream_replay_tps: 100,
+      expose_headers: true,
     },
   });
   const embeddingRoutes = routes.filter((route) => route.route_type === "embedding");
@@ -100,6 +104,8 @@ export default function SettingsPage() {
     ? cacheForm.exact.enabled !== cacheSettings.exact.enabled
       || cacheForm.exact.default_ttl !== cacheSettings.exact.default_ttl
       || cacheForm.exact.max_entries !== cacheSettings.exact.max_entries
+      || cacheForm.exact.stream_replay_tps !== cacheSettings.exact.stream_replay_tps
+      || cacheForm.exact.expose_headers !== cacheSettings.exact.expose_headers
     : false;
   const semanticCacheDirty = cacheSettings
     ? cacheForm.semantic.enabled !== cacheSettings.semantic.enabled
@@ -108,6 +114,8 @@ export default function SettingsPage() {
       || cacheForm.semantic.vector_dimensions !== cacheSettings.semantic.vector_dimensions
       || cacheForm.semantic.default_ttl !== cacheSettings.semantic.default_ttl
       || cacheForm.semantic.max_entries !== cacheSettings.semantic.max_entries
+      || cacheForm.semantic.stream_replay_tps !== cacheSettings.semantic.stream_replay_tps
+      || cacheForm.semantic.expose_headers !== cacheSettings.semantic.expose_headers
     : false;
   const normalizedProxyEnabledSetting = ["1", "true", "yes", "on"].includes(
     (proxyEnabledSetting ?? "").trim().toLowerCase(),
@@ -399,6 +407,39 @@ export default function SettingsPage() {
                   }
                 />
               </div>
+              <div className="space-y-1.5">
+                <label className="ml-1 text-xs text-slate-700">{isZh ? "流式重放速率 (TPS)" : "Stream Replay TPS"}</label>
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder={isZh ? "0 = 不限速" : "0 = No Limit"}
+                  value={cacheForm.exact.stream_replay_tps}
+                  onChange={(e) =>
+                    setCacheForm((prev) => ({
+                      ...prev,
+                      exact: { ...prev.exact, stream_replay_tps: Math.max(0, Number(e.target.value || 0)) },
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="ml-1 text-xs text-slate-700">{isZh ? "输出缓存响应头" : "Expose Cache Headers"}</label>
+                <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <ToggleStatusLabel enabled={cacheForm.exact.expose_headers} isZh={isZh} />
+                  </div>
+                  <Switch
+                    checked={cacheForm.exact.expose_headers}
+                    disabled={saveCacheMut.isPending}
+                    onCheckedChange={(checked) =>
+                      setCacheForm((prev) => ({
+                        ...prev,
+                        exact: { ...prev.exact, expose_headers: checked },
+                      }))
+                    }
+                  />
+                </div>
+              </div>
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -545,6 +586,39 @@ export default function SettingsPage() {
                     }))
                   }
                 />
+              </div>
+              <div className="space-y-1.5">
+                <label className="ml-1 text-xs text-slate-700">{isZh ? "流式重放速率 (TPS)" : "Stream Replay TPS"}</label>
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder={isZh ? "0 = 不限速" : "0 = No Limit"}
+                  value={cacheForm.semantic.stream_replay_tps}
+                  onChange={(e) =>
+                    setCacheForm((prev) => ({
+                      ...prev,
+                      semantic: { ...prev.semantic, stream_replay_tps: Math.max(0, Number(e.target.value || 0)) },
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="ml-1 text-xs text-slate-700">{isZh ? "输出缓存响应头" : "Expose Cache Headers"}</label>
+                <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <ToggleStatusLabel enabled={cacheForm.semantic.expose_headers} isZh={isZh} />
+                  </div>
+                  <Switch
+                    checked={cacheForm.semantic.expose_headers}
+                    disabled={saveCacheMut.isPending}
+                    onCheckedChange={(checked) =>
+                      setCacheForm((prev) => ({
+                        ...prev,
+                        semantic: { ...prev.semantic, expose_headers: checked },
+                      }))
+                    }
+                  />
+                </div>
               </div>
               </div>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
- Add stream_replay_tps (default 100) to ExactCacheConfig and SemanticCacheConfig; set to 0 to disable throttle and restore instant-flush behaviour
- Add expose_headers (default true) to both configs, independently controlling whether X-NYRO-CACHE-* headers are emitted for exact vs semantic hits
- Rename response headers to uppercase: X-NYRO-CACHE / X-NYRO-CACHE-KEY / X-NYRO-CACHE-SCORE (industry convention)
- Implement split_text_deltas helper to chunk large TextDelta/ReasoningDelta into ~1-token pieces for smooth per-token pacing
- First SSE chunk is always sent immediately to keep TTFT at zero
- MISS path he type has expose_headers=true
- Extend WebUI CacheSettings type and settings page with TPS input and Expose Headers switch for both exact and semantic cache sections
- Fully backwards-compatible: from_admin_json falls back to defaults (100 / true) when new fields are absent in stored config

FIX #44 