### PR TITLE
fix(server): add missing stream_replay_tps and expose_headers fields in cache config initializers

### DIFF
--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -272,6 +272,8 @@ fn build_cache_config_from_args(args: &Args) -> anyhow::Result<CacheConfig> {
             enabled: args.cache_exact_enabled,
             default_ttl: Duration::from_secs(args.cache_exact_ttl.max(1)),
             max_entries: args.cache_exact_max_entries.max(1),
+            stream_replay_tps: 100,
+            expose_headers: true,
         },
         semantic: SemanticCacheConfig {
             enabled: args.cache_semantic_enabled,
@@ -280,6 +282,8 @@ fn build_cache_config_from_args(args: &Args) -> anyhow::Result<CacheConfig> {
             vector_dimensions: args.cache_semantic_dimensions.max(1),
             default_ttl: Duration::from_secs(args.cache_semantic_ttl.max(1)),
             max_entries: args.cache_semantic_max_entries.max(1),
+            stream_replay_tps: 100,
+            expose_headers: true,
         },
     })
 }

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -201,6 +201,8 @@ impl YamlCacheConfig {
                 enabled: self.exact.enabled,
                 default_ttl: Duration::from_secs(self.exact.default_ttl.unwrap_or(3600)),
                 max_entries: self.exact.max_entries.unwrap_or(1000),
+                stream_replay_tps: 100,
+                expose_headers: true,
             },
             semantic: SemanticCacheConfig {
                 enabled: self.semantic.enabled,
@@ -209,6 +211,8 @@ impl YamlCacheConfig {
                 vector_dimensions: self.semantic.vector_dimensions.unwrap_or(1536),
                 default_ttl: Duration::from_secs(self.semantic.default_ttl.unwrap_or(600)),
                 max_entries: self.semantic.max_entries.unwrap_or(500),
+                stream_replay_tps: 100,
+                expose_headers: true,
             },
         }
     }


### PR DESCRIPTION
…in cache config initializers

ExactCacheConfig and SemanticCacheConfig gained two new fields in feat #45 but the nyro-server initializers in main.rs and yaml_config.rs were not updated, causing a compile error in CI.

Set both fields to their defaults: stream_replay_tps=100, expose_headers=true.