### PR TITLE
feat(server): refactor CLI params, embed WebUI, and add token auth for browser UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,16 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libssl-dev
 
+      - name: Build webui
+        run: |
+          pnpm -C webui install --frozen-lockfile
+          pnpm -C webui build
+
       - name: Cargo check
         run: cargo check --workspace --exclude nyro-desktop
 
       - name: Build nyro-server
         run: cargo build -p nyro-server
-
-      - name: Build webui
-        run: |
-          pnpm -C webui install --frozen-lockfile
-          pnpm -C webui build
 
       - name: Run smoke tests
         run: python3 scripts/smoke/server_smoke.py

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ dev: webui-build
 build: webui-build
 	cargo tauri build
 
-# Build server binary only (release)
-server:
+# Build server binary only (release, webui embedded)
+server: webui-build
 	cargo build -p nyro-server --release
 
-# Run server binary locally (debug)
-server-dev:
+# Run server binary locally (debug, webui embedded)
+server-dev: webui-build
 	cargo run -p nyro-server -- --proxy-port 19530 --admin-port 19531
 
 # Build webui

--- a/scripts/smoke/server_smoke.py
+++ b/scripts/smoke/server_smoke.py
@@ -350,10 +350,8 @@ def run_smoke() -> None:
                 str(admin_port),
                 "--data-dir",
                 data_dir,
-                "--admin-key",
+                "--admin-token",
                 admin_key,
-                "--webui-dir",
-                "./webui/dist",
             ]
 
             proc = subprocess.Popen(

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -9,13 +9,14 @@ description = "Nyro AI Gateway — Standalone Server Binary"
 nyro-core = { path = "../crates/nyro-core" }
 tokio = { workspace = true }
 axum = { workspace = true }
-tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 shellexpand = "3"
 anyhow = { workspace = true }
 serde_yaml = "0.9"
 chrono = { workspace = true }
+rust-embed = { version = "8", features = ["compression"] }

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -9,14 +9,14 @@ use nyro_core::Gateway;
 use serde::Deserialize;
 
 #[derive(Clone)]
-struct AdminKey(String);
+struct AdminToken(String);
 
 async fn admin_auth(
-    key: Option<Extension<AdminKey>>,
+    token_ext: Option<Extension<AdminToken>>,
     req: Request,
     next: Next,
 ) -> impl IntoResponse {
-    let Some(Extension(admin_key)) = key else {
+    let Some(Extension(admin_token)) = token_ext else {
         return next.run(req).await;
     };
 
@@ -30,18 +30,18 @@ async fn admin_auth(
         .strip_prefix("Bearer ")
         .unwrap_or(auth_header);
 
-    if token == admin_key.0 {
+    if token == admin_token.0 {
         next.run(req).await
     } else {
         (
             StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "invalid admin key"})),
+            Json(serde_json::json!({"error": "invalid admin token"})),
         )
             .into_response()
     }
 }
 
-pub fn create_router(gateway: Gateway, admin_key: Option<String>) -> Router {
+pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
     let providers_item = get(get_provider_handler)
         .put(update_provider_handler)
         .delete(delete_provider_handler);
@@ -79,11 +79,11 @@ pub fn create_router(gateway: Gateway, admin_key: Option<String>) -> Router {
         .route("/config/import", axum::routing::post(import_config_handler))
         .with_state(gateway);
 
-    if let Some(key) = admin_key {
-        if !key.is_empty() {
+    if let Some(token) = admin_token {
+        if !token.is_empty() {
             api = api
                 .layer(middleware::from_fn(admin_auth))
-                .layer(Extension(AdminKey(key)));
+                .layer(Extension(AdminToken(token)));
         }
     }
 

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -2,11 +2,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::http::{HeaderValue, Method, header};
+use axum::body::Body;
+use axum::http::{HeaderValue, Method, StatusCode, header};
+use axum::response::Response;
 use clap::Parser;
 use nyro_core::{
     Gateway,
-    cache::{CacheConfig, ExactCacheConfig, SemanticCacheConfig},
     config::{
         GatewayConfig, GatewayStorageConfig, SqlStorageConfig, SqliteStorageConfig,
         StorageBackendKind,
@@ -14,121 +15,137 @@ use nyro_core::{
     logging,
     storage::MemoryStorage,
 };
+use rust_embed::RustEmbed;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 mod admin_routes;
 mod yaml_config;
 
+#[derive(RustEmbed)]
+#[folder = "../webui/dist/"]
+struct WebUiAssets;
+
 #[derive(Parser)]
-#[command(name = "nyro-server", about = "Nyro AI Gateway — Server Mode")]
+#[command(name = "nyro-server", version, about = "Nyro AI Gateway — Server Mode")]
 struct Args {
-    #[arg(long, default_value = "127.0.0.1")]
+    // ── Server ────────────────────────────────────────────────────────────────
+    #[arg(long, default_value = "127.0.0.1", env = "NYRO_PROXY_HOST",
+          help_heading = "Server")]
     proxy_host: String,
 
-    #[arg(long, default_value = "19530")]
+    #[arg(long, default_value_t = 19530, env = "NYRO_PROXY_PORT",
+          help_heading = "Server")]
     proxy_port: u16,
 
-    #[arg(long, default_value = "127.0.0.1")]
+    #[arg(long, default_value = "127.0.0.1", env = "NYRO_ADMIN_HOST",
+          help_heading = "Server")]
     admin_host: String,
 
-    #[arg(long, default_value = "19531")]
+    #[arg(long, default_value_t = 19531, env = "NYRO_ADMIN_PORT",
+          help_heading = "Server")]
     admin_port: u16,
 
-    #[arg(long, default_value = "~/.nyro")]
-    data_dir: String,
+    #[arg(long, env = "NYRO_ADMIN_TOKEN",
+          help = "Bearer token for admin API authentication",
+          help_heading = "Server")]
+    admin_token: Option<String>,
 
-    #[arg(long, help = "Bearer token for admin API authentication")]
-    admin_key: Option<String>,
+    #[arg(
+        long,
+        default_value = "info",
+        env = "NYRO_LOG_LEVEL",
+        value_parser = ["error", "warn", "info", "debug", "trace"],
+        help_heading = "Server"
+    )]
+    log_level: String,
 
+    // ── Advanced (CORS) ───────────────────────────────────────────────────────
     #[arg(
         long = "admin-cors-origin",
         action = clap::ArgAction::Append,
-        help = "Allowed CORS origin for admin API (repeatable, use '*' for any)"
+        help = "Allowed CORS origin for admin API (repeatable, use '*' for any)",
+        help_heading = "Advanced"
     )]
     admin_cors_origins: Vec<String>,
 
     #[arg(
         long = "proxy-cors-origin",
         action = clap::ArgAction::Append,
-        help = "Allowed CORS origin for proxy API (repeatable, use '*' for any)"
+        help = "Allowed CORS origin for proxy API (repeatable, use '*' for any)",
+        help_heading = "Advanced"
     )]
     proxy_cors_origins: Vec<String>,
 
-    #[arg(
-        long,
-        default_value = "./webui/dist",
-        help = "Path to webui static files"
-    )]
-    webui_dir: String,
+    // ── Storage ───────────────────────────────────────────────────────────────
+    #[arg(long, default_value = "~/.nyro", env = "NYRO_DATA_DIR",
+          help_heading = "Storage")]
+    data_dir: String,
 
-    #[arg(long, value_parser = ["sqlite", "postgres"], default_value = "sqlite")]
+    #[arg(long, value_parser = ["sqlite", "postgres"], default_value = "sqlite",
+          env = "NYRO_STORAGE_BACKEND", help_heading = "Storage")]
     storage_backend: String,
-
-    #[arg(
-        long,
-        default_value = "NYRO_STORAGE_DSN",
-        help = "Environment variable name used to load storage DSN/URI"
-    )]
-    storage_dsn_env: String,
 
     #[arg(
         long,
         default_value = "true",
         action = clap::ArgAction::Set,
-        help = "Run SQLite migrations on startup (true/false)"
+        help = "Run migrations on startup (true/false)",
+        help_heading = "Storage"
     )]
-    sqlite_migrate_on_start: bool,
+    migrate_on_start: bool,
 
-    #[arg(long, default_value_t = 10)]
-    storage_max_connections: u32,
+    #[arg(
+        long,
+        env = "NYRO_POSTGRES_DSN",
+        help = "PostgreSQL connection string (required when --storage-backend=postgres)",
+        help_heading = "Storage"
+    )]
+    postgres_dsn: Option<String>,
 
-    #[arg(long, default_value_t = 1)]
-    storage_min_connections: u32,
+    #[arg(long, default_value_t = 10,
+          help = "Postgres: max connection pool size",
+          help_heading = "Storage")]
+    postgres_max_connections: u32,
 
-    #[arg(long, default_value_t = 10)]
-    storage_acquire_timeout_secs: u64,
+    #[arg(long, default_value_t = 1,
+          help = "Postgres: min connection pool size",
+          help_heading = "Storage")]
+    postgres_min_connections: u32,
 
-    #[arg(long, help = "Idle timeout in seconds for SQL backends")]
-    storage_idle_timeout_secs: Option<u64>,
+    #[arg(long, default_value_t = 10,
+          help = "Postgres: connection acquire timeout (seconds)",
+          help_heading = "Storage")]
+    postgres_acquire_timeout: u64,
 
-    #[arg(long, help = "Max lifetime in seconds for SQL backends")]
-    storage_max_lifetime_secs: Option<u64>,
+    #[arg(long, help = "Postgres: idle connection timeout (seconds)",
+          help_heading = "Storage")]
+    postgres_idle_timeout: Option<u64>,
 
+    #[arg(long, help = "Postgres: max connection lifetime (seconds)",
+          help_heading = "Storage")]
+    postgres_max_lifetime: Option<u64>,
+
+    // ── Standalone ────────────────────────────────────────────────────────────
     #[arg(
         long = "config",
         short = 'c',
-        help = "Path to YAML config file for standalone mode (no DB, no admin API, no WebUI)"
+        help = "Path to YAML config file for standalone mode (no DB, no admin API)",
+        help_heading = "Standalone"
     )]
     config_file: Option<String>,
-
-    #[arg(long, default_value_t = false)]
-    cache_exact_enabled: bool,
-    #[arg(long, default_value_t = 3600)]
-    cache_exact_ttl: u64,
-    #[arg(long, default_value_t = 1000)]
-    cache_exact_max_entries: usize,
-
-    #[arg(long, default_value_t = false)]
-    cache_semantic_enabled: bool,
-    #[arg(long, default_value = "")]
-    cache_semantic_route: String,
-    #[arg(long, default_value_t = 0.92)]
-    cache_semantic_threshold: f64,
-    #[arg(long, default_value_t = 1536)]
-    cache_semantic_dimensions: usize,
-    #[arg(long, default_value_t = 600)]
-    cache_semantic_ttl: u64,
-    #[arg(long, default_value_t = 500)]
-    cache_semantic_max_entries: usize,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter("nyro=debug,tower_http=debug")
-        .init();
-
     let args = Args::parse();
+
+    let filter = format!(
+        "nyro={level},tower_http={level}",
+        level = args.log_level
+    );
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .init();
 
     if let Some(ref config_path) = args.config_file {
         return run_standalone(config_path, &args).await;
@@ -141,16 +158,9 @@ async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
     tracing::info!("standalone mode: loading {config_path}");
     let yaml = yaml_config::YamlConfig::load(config_path)?;
 
-    let proxy_host = if args.proxy_host != "127.0.0.1" {
-        args.proxy_host.clone()
-    } else {
-        yaml.server.proxy_host.clone()
-    };
-    let proxy_port = if args.proxy_port != 19530 {
-        args.proxy_port
-    } else {
-        yaml.server.proxy_port
-    };
+    // Standalone mode: proxy address comes exclusively from YAML
+    let proxy_host = yaml.server.proxy_host.clone();
+    let proxy_port = yaml.server.proxy_port;
 
     let providers = yaml_config::build_providers(&yaml);
     let routes = yaml_config::build_routes(&yaml, &providers);
@@ -189,8 +199,7 @@ async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
         logging::run_collector(log_rx, storage_for_logs).await;
     });
 
-    let proxy_addr = format!("{proxy_host}:{proxy_port}");
-    tracing::info!("proxy  → http://{proxy_addr}");
+    tracing::info!("proxy  → http://{}:{}", proxy_host, proxy_port);
     tracing::info!("standalone mode: admin API and WebUI are disabled");
 
     gateway.start_proxy().await?;
@@ -199,13 +208,14 @@ async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
 
 async fn run_full(args: &Args) -> anyhow::Result<()> {
     let data_dir = shellexpand::tilde(&args.data_dir).to_string();
-    let admin_key = args.admin_key.clone().filter(|k| !k.trim().is_empty());
+    let admin_token = args.admin_token.clone().filter(|t| !t.trim().is_empty());
 
-    if !is_loopback_host(&args.admin_host) && admin_key.is_none() {
+    if !is_loopback_host(&args.admin_host) && admin_token.is_none() {
         anyhow::bail!(
-            "--admin-key is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
+            "--admin-token is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
         );
     }
+
     let admin_cors_origins = if args.admin_cors_origins.is_empty() {
         default_local_origins(&[args.admin_port])
     } else {
@@ -223,7 +233,6 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
         proxy_cors_origins,
         data_dir: PathBuf::from(data_dir),
         storage: build_storage_config(args)?,
-        cache: build_cache_config_from_args(args)?,
         ..Default::default()
     };
 
@@ -242,14 +251,10 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
         logging::run_collector(log_rx, storage_for_logs).await;
     });
 
-    let admin_router = admin_routes::create_router(gateway, admin_key.clone());
-
-    let index_path = std::path::Path::new(&args.webui_dir).join("index.html");
-    let webui_service = tower_http::services::ServeDir::new(&args.webui_dir)
-        .fallback(tower_http::services::ServeFile::new(index_path));
+    let admin_router = admin_routes::create_router(gateway, admin_token.clone());
 
     let app = admin_router
-        .fallback_service(webui_service)
+        .fallback(serve_webui)
         .layer(build_cors_layer(&admin_cors_origins));
 
     let admin_addr = format!("{}:{}", args.admin_host, args.admin_port);
@@ -259,34 +264,118 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
     tracing::info!("proxy  → http://{proxy_bind_addr}");
     tracing::info!("webui  → http://{admin_addr}");
 
-    if admin_key.is_none() {
-        tracing::warn!("admin API auth disabled: set --admin-key for production");
+    if admin_token.is_none() {
+        tracing::warn!("admin API auth disabled: set --admin-token for production");
     }
     axum::serve(listener, app).await?;
     Ok(())
 }
 
-fn build_cache_config_from_args(args: &Args) -> anyhow::Result<CacheConfig> {
-    Ok(CacheConfig {
-        exact: ExactCacheConfig {
-            enabled: args.cache_exact_enabled,
-            default_ttl: Duration::from_secs(args.cache_exact_ttl.max(1)),
-            max_entries: args.cache_exact_max_entries.max(1),
-            stream_replay_tps: 100,
-            expose_headers: true,
+// ── WebUI (embedded) ──────────────────────────────────────────────────────────
+
+async fn serve_webui(uri: axum::http::Uri) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    let file_path = if path.is_empty() { "index.html" } else { path };
+
+    match WebUiAssets::get(file_path) {
+        Some(content) => {
+            let mime = infer_mime(file_path);
+            Response::builder()
+                .header(header::CONTENT_TYPE, mime)
+                .body(Body::from(content.data.into_owned()))
+                .unwrap()
+        }
+        None => {
+            // SPA fallback: serve index.html for any unmatched path
+            match WebUiAssets::get("index.html") {
+                Some(content) => Response::builder()
+                    .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                    .body(Body::from(content.data.into_owned()))
+                    .unwrap(),
+                None => Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .unwrap(),
+            }
+        }
+    }
+}
+
+fn infer_mime(path: &str) -> &'static str {
+    if path.ends_with(".html") {
+        "text/html; charset=utf-8"
+    } else if path.ends_with(".js") || path.ends_with(".mjs") {
+        "application/javascript"
+    } else if path.ends_with(".css") {
+        "text/css"
+    } else if path.ends_with(".svg") {
+        "image/svg+xml"
+    } else if path.ends_with(".png") {
+        "image/png"
+    } else if path.ends_with(".ico") {
+        "image/x-icon"
+    } else if path.ends_with(".woff2") {
+        "font/woff2"
+    } else if path.ends_with(".woff") {
+        "font/woff"
+    } else if path.ends_with(".json") {
+        "application/json"
+    } else if path.ends_with(".map") {
+        "application/json"
+    } else {
+        "application/octet-stream"
+    }
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+fn build_storage_config(args: &Args) -> anyhow::Result<GatewayStorageConfig> {
+    let backend = parse_storage_backend(&args.storage_backend)?;
+
+    let postgres_url = if matches!(backend, StorageBackendKind::Postgres) {
+        let dsn = args
+            .postgres_dsn
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--postgres-dsn (or env NYRO_POSTGRES_DSN) is required \
+                     when --storage-backend=postgres"
+                )
+            })?;
+        Some(dsn.to_string())
+    } else {
+        None
+    };
+
+    let sql = SqlStorageConfig {
+        url: postgres_url,
+        max_connections: args.postgres_max_connections,
+        min_connections: args.postgres_min_connections,
+        acquire_timeout: Duration::from_secs(args.postgres_acquire_timeout),
+        idle_timeout: args.postgres_idle_timeout.map(Duration::from_secs),
+        max_lifetime: args.postgres_max_lifetime.map(Duration::from_secs),
+    };
+
+    Ok(GatewayStorageConfig {
+        backend,
+        sqlite: SqliteStorageConfig {
+            migrate_on_start: args.migrate_on_start,
         },
-        semantic: SemanticCacheConfig {
-            enabled: args.cache_semantic_enabled,
-            embedding_route: args.cache_semantic_route.trim().to_string(),
-            similarity_threshold: args.cache_semantic_threshold,
-            vector_dimensions: args.cache_semantic_dimensions.max(1),
-            default_ttl: Duration::from_secs(args.cache_semantic_ttl.max(1)),
-            max_entries: args.cache_semantic_max_entries.max(1),
-            stream_replay_tps: 100,
-            expose_headers: true,
-        },
+        postgres: sql,
     })
 }
+
+fn parse_storage_backend(value: &str) -> anyhow::Result<StorageBackendKind> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "sqlite" => Ok(StorageBackendKind::Sqlite),
+        "postgres" => Ok(StorageBackendKind::Postgres),
+        other => anyhow::bail!("unsupported storage backend: {other}"),
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn is_loopback_host(host: &str) -> bool {
     matches!(host, "127.0.0.1" | "localhost" | "::1")
@@ -338,57 +427,4 @@ fn build_cors_layer(origins: &[String]) -> CorsLayer {
             header::HeaderName::from_static("x-api-key"),
             header::HeaderName::from_static("anthropic-version"),
         ])
-}
-
-fn build_storage_config(args: &Args) -> anyhow::Result<GatewayStorageConfig> {
-    let backend = parse_storage_backend(&args.storage_backend)?;
-    let storage_dsn = resolve_storage_dsn(args, backend)?;
-    let sql = SqlStorageConfig {
-        url: storage_dsn.clone(),
-        max_connections: args.storage_max_connections,
-        min_connections: args.storage_min_connections,
-        acquire_timeout: Duration::from_secs(args.storage_acquire_timeout_secs),
-        idle_timeout: args.storage_idle_timeout_secs.map(Duration::from_secs),
-        max_lifetime: args.storage_max_lifetime_secs.map(Duration::from_secs),
-    };
-
-    Ok(GatewayStorageConfig {
-        backend,
-        sqlite: SqliteStorageConfig {
-            migrate_on_start: args.sqlite_migrate_on_start,
-        },
-        postgres: sql,
-    })
-}
-
-fn parse_storage_backend(value: &str) -> anyhow::Result<StorageBackendKind> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "sqlite" => Ok(StorageBackendKind::Sqlite),
-        "postgres" => Ok(StorageBackendKind::Postgres),
-        other => anyhow::bail!("unsupported storage backend: {other}"),
-    }
-}
-
-fn resolve_storage_dsn(args: &Args, backend: StorageBackendKind) -> anyhow::Result<Option<String>> {
-    if matches!(backend, StorageBackendKind::Sqlite) {
-        return Ok(None);
-    }
-
-    let env_name = args.storage_dsn_env.trim();
-    if env_name.is_empty() {
-        anyhow::bail!("--storage-dsn-env cannot be empty");
-    }
-
-    std::env::var(env_name)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .map(Some)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "storage backend {} requires env {}",
-                args.storage_backend,
-                env_name
-            )
-        })
 }

--- a/webui/src/components/layout/app-layout.tsx
+++ b/webui/src/components/layout/app-layout.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { Outlet } from "react-router-dom";
-import { Github, Languages, Moon, Sun } from "lucide-react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { Github, Languages, LogOut, Moon, Sun } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { cn } from "@/lib/utils";
 import { IS_TAURI } from "@/lib/backend";
+import { clearAdminToken, getAdminToken } from "@/lib/auth";
 import { useLocale } from "@/lib/i18n";
 import { openExternalUrl } from "@/lib/open-external";
 
@@ -32,7 +33,9 @@ const NON_DRAGGABLE_SELECTOR = [
 export function AppLayout() {
   const [collapsed, setCollapsed] = useState(false);
   const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [hasToken, setHasToken] = useState(false);
   const { locale, setLocale } = useLocale();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const saved = localStorage.getItem("nyro-theme");
@@ -44,6 +47,9 @@ export function AppLayout() {
           : "light";
     setTheme(initial);
     document.documentElement.setAttribute("data-theme", initial);
+    if (!IS_TAURI) {
+      setHasToken(getAdminToken() !== null);
+    }
   }, []);
 
   async function toggleTheme() {
@@ -56,6 +62,11 @@ export function AppLayout() {
   function toggleLocale() {
     const next = locale === "zh-CN" ? "en-US" : "zh-CN";
     setLocale(next);
+  }
+
+  function handleLogout() {
+    clearAdminToken();
+    navigate("/login", { replace: true });
   }
 
   async function openProjectGithub() {
@@ -134,6 +145,15 @@ export function AppLayout() {
               >
                 <Languages className="h-4 w-4" />
               </button>
+              {hasToken && (
+                <button
+                  onClick={handleLogout}
+                  className="native-action-btn"
+                  title={locale === "zh-CN" ? "退出登录" : "Sign out"}
+                >
+                  <LogOut className="h-4 w-4" />
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/webui/src/lib/auth.ts
+++ b/webui/src/lib/auth.ts
@@ -1,0 +1,13 @@
+const TOKEN_KEY = "nyro-admin-token";
+
+export function getAdminToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setAdminToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearAdminToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -1,3 +1,5 @@
+import { getAdminToken, clearAdminToken } from "./auth";
+
 const IS_TAURI = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
 async function invokeIPC<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
@@ -8,11 +10,28 @@ async function invokeIPC<T>(cmd: string, args?: Record<string, unknown>): Promis
 async function invokeHTTP<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   const mapping = resolveHTTP(cmd, args);
   const init: RequestInit = { method: mapping.method };
+
+  const headers: Record<string, string> = {};
+  const token = getAdminToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
   if (mapping.body) {
-    init.headers = { "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
     init.body = JSON.stringify(mapping.body);
   }
+  if (Object.keys(headers).length > 0) {
+    init.headers = headers;
+  }
+
   const resp = await fetch(mapping.url, init);
+
+  if (resp.status === 401 && window.location.pathname !== "/login") {
+    clearAdminToken();
+    window.location.replace("/login");
+    throw new Error("Authentication required");
+  }
+
   if (!resp.ok) {
     const body = await resp.json().catch(() => ({}));
     throw new Error(body.error || `HTTP ${resp.status}`);
@@ -27,7 +46,9 @@ async function invokeHTTP<T>(cmd: string, args?: Record<string, unknown>): Promi
         : `Request failed: ${cmd}`;
     throw new Error(errorMessage);
   }
-  return json.data ?? json;
+  // Use explicit key check instead of ??, so that { "data": null } correctly
+  // returns null rather than falling back to the full response object.
+  return json && typeof json === "object" && "data" in json ? json.data : json;
 }
 
 interface HTTPMapping {

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppLayout } from "@/components/layout/app-layout";
 import { AppErrorBoundary } from "@/components/error-boundary";
 import { LocaleProvider } from "@/lib/i18n";
+import { IS_TAURI } from "@/lib/backend";
 
 import "./index.css";
 
@@ -17,6 +18,7 @@ const LogsPage = lazy(() => import("@/pages/logs"));
 const StatsPage = lazy(() => import("@/pages/stats"));
 const SettingsPage = lazy(() => import("@/pages/settings"));
 const ConnectPage = lazy(() => import("@/pages/connect"));
+const LoginPage = lazy(() => import("@/pages/login"));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -36,6 +38,9 @@ createRoot(document.getElementById("root")!).render(
           <BrowserRouter>
             <Suspense fallback={<div className="p-6 text-sm text-slate-500">Loading...</div>}>
               <Routes>
+                {!IS_TAURI && (
+                  <Route path="login" element={<LoginPage />} />
+                )}
                 <Route element={<AppLayout />}>
                   <Route index element={<DashboardPage />} />
                   <Route path="providers" element={<ProvidersPage />} />

--- a/webui/src/pages/login.tsx
+++ b/webui/src/pages/login.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Eye, EyeOff, KeyRound, Loader2 } from "lucide-react";
+import { setAdminToken, getAdminToken } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { NyroIcon } from "@/components/ui/nyro-icon";
+import { useLocale } from "@/lib/i18n";
+
+const T = {
+  "zh-CN": {
+    title: "Nyro AI Gateway",
+    subtitle: "输入 Admin Token 以访问管理控制台",
+    placeholder: "请输入 Admin Token",
+    submit: "登录",
+    submitting: "验证中...",
+    errorInvalid: "Token 无效，请重试",
+    errorNetwork: "无法连接到服务，请检查服务是否正常运行",
+    show: "显示",
+    hide: "隐藏",
+  },
+  "en-US": {
+    title: "Nyro AI Gateway",
+    subtitle: "Enter your Admin Token to access the dashboard",
+    placeholder: "Enter Admin Token",
+    submit: "Sign In",
+    submitting: "Verifying...",
+    errorInvalid: "Invalid token, please try again",
+    errorNetwork: "Cannot connect to server, please check if it is running",
+    show: "Show",
+    hide: "Hide",
+  },
+} as const;
+
+export default function LoginPage() {
+  const { locale } = useLocale();
+  const t = T[locale] ?? T["en-US"];
+  const navigate = useNavigate();
+
+  const [token, setToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Apply saved theme
+  useEffect(() => {
+    const saved = localStorage.getItem("nyro-theme");
+    const theme =
+      saved === "dark" || saved === "light"
+        ? saved
+        : window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+    document.documentElement.setAttribute("data-theme", theme);
+  }, []);
+
+  // If no token is required (server returns 200 on /status without auth), skip login
+  useEffect(() => {
+    async function checkAuthRequired() {
+      try {
+        const existing = getAdminToken();
+        const headers: HeadersInit = existing
+          ? { Authorization: `Bearer ${existing}` }
+          : {};
+        const resp = await fetch("/api/v1/status", { headers });
+        if (resp.ok) {
+          navigate("/", { replace: true });
+        }
+        // 401 without token → auth is required, stay on login page
+      } catch {
+        // network error → server not reachable, stay on login
+      }
+    }
+    checkAuthRequired();
+  }, [navigate]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = token.trim();
+    if (!trimmed) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const resp = await fetch("/api/v1/status", {
+        headers: { Authorization: `Bearer ${trimmed}` },
+      });
+
+      if (resp.ok) {
+        setAdminToken(trimmed);
+        navigate("/", { replace: true });
+      } else if (resp.status === 401) {
+        setError(t.errorInvalid);
+        inputRef.current?.focus();
+      } else {
+        setError(t.errorNetwork);
+      }
+    } catch {
+      setError(t.errorNetwork);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-8">
+        {/* Logo + Title */}
+        <div className="flex flex-col items-center gap-3 text-center">
+          <NyroIcon size={52} />
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              {t.title}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">{t.subtitle}</p>
+          </div>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+              <KeyRound className="h-4 w-4 text-muted-foreground" />
+            </div>
+            <input
+              ref={inputRef}
+              type={showToken ? "text" : "password"}
+              value={token}
+              onChange={(e) => {
+                setToken(e.target.value);
+                setError(null);
+              }}
+              placeholder={t.placeholder}
+              autoComplete="current-password"
+              autoFocus
+              className="flex h-10 w-full rounded-md border border-input bg-background py-2 pl-9 pr-10 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <button
+              type="button"
+              tabIndex={-1}
+              title={showToken ? t.hide : t.show}
+              onClick={() => setShowToken((v) => !v)}
+              className="absolute inset-y-0 right-3 flex items-center text-muted-foreground hover:text-foreground"
+            >
+              {showToken ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={loading || !token.trim()}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t.submitting}
+              </>
+            ) : (
+              t.submit
+            )}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Reduce CLI params from 27 to 18: rename admin-key→admin-token, storage-dsn-env→postgres-dsn, prefix Postgres pool params with postgres-*, rename sqlite-migrate-on-start→migrate-on-start
- Remove 9 cache CLI params (managed via Admin API/WebUI + DB)
- Remove --webui-dir; embed webui/dist into binary via rust-embed
- Add --log-level param (env NYRO_LOG_LEVEL); replace hardcoded tracing filter
- Add env-var support for key params (NYRO_PROXY_HOST, NYRO_ADMIN_TOKEN, etc.)
- Add --veo --help output
- Fix standalone mode proxy_host/port priority bug (was comparing against default value)
- Fix backend.ts null-data bug: json.data ?? json returned full object when data=null, causing .trim() crashes on Providers and Settings pages
- Add /login page and token auth flow for browser mode (Tauri IPC unaffected)
- Add logout icon in web topbar when admin token is active
- Update smoke test: --admin-key→--admin-token, remove --webui-dir arg

FIX #48 