### PR TITLE
refactor: unify status fields to is_enabled across providers/routes/api_keys

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -109,7 +109,7 @@ impl AdminService {
         let static_models = input.static_models.or(current.static_models);
         let api_key = input.api_key.unwrap_or(current.api_key);
         let use_proxy = input.use_proxy.unwrap_or(current.use_proxy);
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let base_url_changed = base_url != current_base_url;
 
         let provider = self
@@ -132,7 +132,7 @@ impl AdminService {
                     static_models,
                     api_key: Some(api_key),
                     use_proxy: Some(use_proxy),
-                    is_active: Some(is_active),
+                    is_enabled: Some(is_enabled),
                 },
             )
             .await?;
@@ -383,7 +383,7 @@ impl AdminService {
 
         for target in ordered_targets {
             let provider = match self.gw.storage.providers().get(&target.provider_id).await? {
-                Some(provider) if provider.is_active => provider,
+                Some(provider) if provider.is_enabled => provider,
                 _ => continue,
             };
             let Some(openai_base_url) = resolve_openai_base_url(&provider) else {
@@ -618,7 +618,7 @@ impl AdminService {
             .first()
             .ok_or_else(|| anyhow::anyhow!("at least one route target is required"))?;
         let access_control = input.access_control.unwrap_or(current.access_control);
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let (cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) = if effective_route_type == "embedding" {
             if has_route_cache_overrides(input.cache.as_ref()) {
                 anyhow::bail!("embedding routes do not support route cache configuration");
@@ -655,7 +655,7 @@ impl AdminService {
                     cache_exact_ttl,
                     cache_semantic_ttl,
                     cache_semantic_threshold,
-                    is_active: Some(is_active),
+                    is_enabled: Some(is_enabled),
                 },
             )
             .await?;
@@ -717,12 +717,8 @@ impl AdminService {
         let rpd = input.rpd.or(current.rpd);
         let tpm = input.tpm.or(current.tpm);
         let tpd = input.tpd.or(current.tpd);
-        let status = input.status.unwrap_or(current.status);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let expires_at = input.expires_at.or(current.expires_at);
-
-        if status != "active" && status != "revoked" {
-            anyhow::bail!("invalid key status: {status}");
-        }
 
         self.api_keys_store()?
             .update(
@@ -733,7 +729,7 @@ impl AdminService {
                     rpd,
                     tpm,
                     tpd,
-                    status: Some(status),
+                    is_enabled: Some(is_enabled),
                     expires_at,
                     route_ids: input.route_ids,
                 },
@@ -883,7 +879,7 @@ impl AdminService {
                     static_models: p.static_models,
                     api_key: p.api_key,
                     use_proxy: p.use_proxy,
-                    is_active: p.is_active,
+                    is_enabled: p.is_enabled,
                 })
                 .collect(),
             routes: routes
@@ -893,7 +889,7 @@ impl AdminService {
                     virtual_model: r.virtual_model,
                     target_model: r.target_model,
                     access_control: r.access_control,
-                    is_active: r.is_active,
+                    is_enabled: r.is_enabled,
                 })
                 .collect(),
             settings: settings.into_iter().collect(),

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -60,6 +60,14 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     ensure_request_log_column(pool, "api_key_id", "TEXT").await?;
     ensure_api_key_tables(pool).await?;
     ensure_api_key_column(pool, "rpd", "INTEGER").await?;
+    // Migrate: providers/routes is_active -> is_enabled
+    ensure_provider_column(pool, "is_enabled", "INTEGER DEFAULT 1").await?;
+    migrate_provider_is_active_to_is_enabled(pool).await?;
+    ensure_route_column(pool, "is_enabled", "INTEGER DEFAULT 1").await?;
+    migrate_route_is_active_to_is_enabled(pool).await?;
+    // Migrate: api_keys status -> is_enabled
+    ensure_api_key_column(pool, "is_enabled", "INTEGER DEFAULT 1").await?;
+    migrate_api_key_status_to_is_enabled(pool).await?;
     ensure_route_targets_table(pool).await?;
     ensure_cache_entries_table(pool).await?;
     ensure_semantic_cache_vectors_table(pool, vector_dimensions).await?;
@@ -176,7 +184,7 @@ async fn ensure_api_key_tables(pool: &SqlitePool) -> anyhow::Result<()> {
             rpd         INTEGER,
             tpm         INTEGER,
             tpd         INTEGER,
-            status      TEXT NOT NULL DEFAULT 'active',
+            is_enabled  INTEGER DEFAULT 1,
             expires_at  TEXT,
             created_at  TEXT DEFAULT (datetime('now')),
             updated_at  TEXT DEFAULT (datetime('now'))
@@ -304,6 +312,36 @@ async fn semantic_cache_vectors_table_exists(pool: &SqlitePool) -> anyhow::Resul
     Ok(count > 0)
 }
 
+async fn migrate_provider_is_active_to_is_enabled(pool: &SqlitePool) -> anyhow::Result<()> {
+    if column_exists(pool, "providers", "is_active").await? {
+        sqlx::query("UPDATE providers SET is_enabled = is_active WHERE is_enabled IS NULL OR is_enabled != is_active AND is_active IS NOT NULL")
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn migrate_route_is_active_to_is_enabled(pool: &SqlitePool) -> anyhow::Result<()> {
+    if column_exists(pool, "routes", "is_active").await? {
+        sqlx::query("UPDATE routes SET is_enabled = is_active WHERE is_enabled IS NULL OR is_enabled != is_active AND is_active IS NOT NULL")
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn migrate_api_key_status_to_is_enabled(pool: &SqlitePool) -> anyhow::Result<()> {
+    if column_exists(pool, "api_keys", "status").await? {
+        sqlx::query(
+            "UPDATE api_keys SET is_enabled = CASE WHEN status = 'active' THEN 1 ELSE 0 END \
+             WHERE is_enabled IS NULL OR (status = 'active' AND is_enabled = 0) OR (status != 'active' AND is_enabled = 1)",
+        )
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
 async fn backfill_route_fields(pool: &SqlitePool) -> anyhow::Result<()> {
     if column_exists(pool, "routes", "strategy").await? {
         sqlx::query(
@@ -389,7 +427,7 @@ CREATE TABLE IF NOT EXISTS providers (
     use_proxy   INTEGER DEFAULT 0,
     last_test_success INTEGER,
     last_test_at TEXT,
-    is_active   INTEGER DEFAULT 1,
+    is_enabled  INTEGER DEFAULT 1,
     priority    INTEGER DEFAULT 0,
     created_at  TEXT DEFAULT (datetime('now')),
     updated_at  TEXT DEFAULT (datetime('now'))
@@ -407,7 +445,7 @@ CREATE TABLE IF NOT EXISTS routes (
     cache_semantic_ttl INTEGER,
     cache_semantic_threshold REAL,
     access_control    INTEGER DEFAULT 0,
-    is_active         INTEGER DEFAULT 1,
+    is_enabled        INTEGER DEFAULT 1,
     priority          INTEGER DEFAULT 0,
     created_at        TEXT DEFAULT (datetime('now'))
 );

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -28,7 +28,7 @@ pub struct Provider {
     pub use_proxy: bool,
     pub last_test_success: Option<bool>,
     pub last_test_at: Option<String>,
-    pub is_active: bool,
+    pub is_enabled: bool,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -59,7 +59,7 @@ pub struct Route {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[sqlx(skip)]
     pub cache: Option<RouteCacheConfig>,
-    pub is_active: bool,
+    pub is_enabled: bool,
     pub created_at: String,
     #[serde(default)]
     #[sqlx(skip)]
@@ -120,7 +120,7 @@ pub struct ApiKey {
     pub rpd: Option<i32>,
     pub tpm: Option<i32>,
     pub tpd: Option<i32>,
-    pub status: String,
+    pub is_enabled: bool,
     pub expires_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
@@ -135,7 +135,7 @@ pub struct ApiKeyWithBindings {
     pub rpd: Option<i32>,
     pub tpm: Option<i32>,
     pub tpd: Option<i32>,
-    pub status: String,
+    pub is_enabled: bool,
     pub expires_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
@@ -200,7 +200,7 @@ pub struct UpdateProvider {
     pub static_models: Option<String>,
     pub api_key: Option<String>,
     pub use_proxy: Option<bool>,
-    pub is_active: Option<bool>,
+    pub is_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -224,7 +224,7 @@ pub struct UpdateRoute {
     pub cache_semantic_ttl: Option<i64>,
     #[serde(skip)]
     pub cache_semantic_threshold: Option<f64>,
-    pub is_active: Option<bool>,
+    pub is_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -305,7 +305,7 @@ pub struct UpdateApiKey {
     pub rpd: Option<i32>,
     pub tpm: Option<i32>,
     pub tpd: Option<i32>,
-    pub status: Option<String>,
+    pub is_enabled: Option<bool>,
     pub expires_at: Option<String>,
     pub route_ids: Option<Vec<String>>,
 }
@@ -413,7 +413,7 @@ pub struct ExportProvider {
     pub api_key: String,
     #[serde(default)]
     pub use_proxy: bool,
-    pub is_active: bool,
+    pub is_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,7 +423,7 @@ pub struct ExportRoute {
     pub target_model: String,
     #[serde(default)]
     pub access_control: bool,
-    pub is_active: bool,
+    pub is_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -217,7 +217,7 @@ pub async fn models_list(State(gw): State<Gateway>, headers: HeaderMap) -> Respo
     if let Some(raw_key) = extract_api_key(&headers) {
         if let Some(store) = gw.storage.auth() {
             if let Ok(Some(key_row)) = store.find_api_key(&raw_key).await {
-                let key_active = key_row.status == "active"
+                let key_active = key_row.is_enabled
                     && key_row
                         .expires_at
                         .as_ref()
@@ -1060,7 +1060,7 @@ impl<'a> GatewayProxyAccessStore<'a> {
 impl ProxyAccessStore for GatewayProxyAccessStore<'_> {
     async fn get_active_provider(&self, id: &str) -> anyhow::Result<Option<Provider>> {
         let provider = self.gw.storage.providers().get(id).await?;
-        Ok(provider.filter(|p| p.is_active))
+        Ok(provider.filter(|p| p.is_enabled))
     }
 
     async fn find_api_key(&self, raw_key: &str) -> anyhow::Result<Option<ApiKeyAccessRecord>> {
@@ -1114,8 +1114,8 @@ async fn authorize_route_access<S: ProxyAccessStore + ?Sized>(
         return Err(error_response(401, "invalid api key"));
     };
 
-    if key_row.status != "active" {
-        return Err(error_response(403, "api key revoked"));
+    if !key_row.is_enabled {
+        return Err(error_response(403, "api key disabled"));
     }
 
     if let Some(expires) = key_row.expires_at.as_ref() {

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -150,7 +150,7 @@ impl RouteStore for MemoryStorage {
 impl RouteSnapshotStore for MemoryStorage {
     async fn load_active_snapshot(&self) -> anyhow::Result<Vec<Route>> {
         let routes = self.routes.read().await;
-        Ok(routes.iter().filter(|r| r.is_active).cloned().collect())
+        Ok(routes.iter().filter(|r| r.is_enabled).cloned().collect())
     }
 }
 

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -308,10 +308,10 @@ impl ProviderStore for PostgresProviderStore {
         let static_models = input.static_models.or(current.static_models);
         let api_key = input.api_key.unwrap_or(current.api_key);
         let use_proxy = input.use_proxy.unwrap_or(current.use_proxy);
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE providers SET name=$1, vendor=$2, protocol=$3, base_url=$4, default_protocol=$5, protocol_endpoints=$6, preset_key=$7, channel=$8, models_source=$9, capabilities_source=$10, static_models=$11, api_key=$12, use_proxy=$13, is_active=$14, updated_at=CURRENT_TIMESTAMP WHERE id=$15",
+            "UPDATE providers SET name=$1, vendor=$2, protocol=$3, base_url=$4, default_protocol=$5, protocol_endpoints=$6, preset_key=$7, channel=$8, models_source=$9, capabilities_source=$10, static_models=$11, api_key=$12, use_proxy=$13, is_enabled=$14, updated_at=CURRENT_TIMESTAMP WHERE id=$15",
         )
         .bind(name.trim())
         .bind(vendor)
@@ -326,7 +326,7 @@ impl ProviderStore for PostgresProviderStore {
         .bind(static_models)
         .bind(api_key)
         .bind(use_proxy)
-        .bind(is_active)
+        .bind(is_enabled)
         .bind(id)
         .execute(&self.pool)
         .await?;
@@ -448,10 +448,10 @@ impl RouteStore for PostgresRouteStore {
         let cache_exact_ttl = input.cache_exact_ttl;
         let cache_semantic_ttl = input.cache_semantic_ttl;
         let cache_semantic_threshold = input.cache_semantic_threshold;
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE routes SET name=$1, virtual_model=$2, strategy=$3, target_provider=$4, target_model=$5, access_control=$6, route_type=$7, cache_exact_ttl=$8, cache_semantic_ttl=$9, cache_semantic_threshold=$10, is_active=$11 WHERE id=$12",
+            "UPDATE routes SET name=$1, virtual_model=$2, strategy=$3, target_provider=$4, target_model=$5, access_control=$6, route_type=$7, cache_exact_ttl=$8, cache_semantic_ttl=$9, cache_semantic_threshold=$10, is_enabled=$11 WHERE id=$12",
         )
         .bind(name.trim())
         .bind(&virtual_model)
@@ -463,7 +463,7 @@ impl RouteStore for PostgresRouteStore {
         .bind(cache_exact_ttl)
         .bind(cache_semantic_ttl)
         .bind(cache_semantic_threshold)
-        .bind(is_active)
+        .bind(is_enabled)
         .bind(id)
         .execute(&self.pool)
         .await?;
@@ -527,7 +527,7 @@ impl RouteStore for PostgresRouteStore {
 #[async_trait]
 impl RouteSnapshotStore for PostgresRouteStore {
     async fn load_active_snapshot(&self) -> anyhow::Result<Vec<Route>> {
-        let sql = format!("{} WHERE is_active = true", route_select(None));
+        let sql = format!("{} WHERE COALESCE(is_enabled, TRUE) = true", route_select(None));
         Ok(sqlx::query_as::<_, Route>(&sql)
             .fetch_all(&self.pool)
             .await?)
@@ -686,18 +686,18 @@ impl ApiKeyStore for PostgresApiKeyStore {
         let rpd = input.rpd.or(current.rpd);
         let tpm = input.tpm.or(current.tpm);
         let tpd = input.tpd.or(current.tpd);
-        let status = input.status.unwrap_or(current.status);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let expires_at = input.expires_at.or(current.expires_at);
 
         sqlx::query(
-            "UPDATE api_keys SET name=$1, rpm=$2, rpd=$3, tpm=$4, tpd=$5, status=$6, expires_at=NULLIF($7, '')::timestamptz, updated_at=CURRENT_TIMESTAMP WHERE id=$8",
+            "UPDATE api_keys SET name=$1, rpm=$2, rpd=$3, tpm=$4, tpd=$5, is_enabled=$6, expires_at=NULLIF($7, '')::timestamptz, updated_at=CURRENT_TIMESTAMP WHERE id=$8",
         )
         .bind(name.trim())
         .bind(rpm)
         .bind(rpd)
         .bind(tpm)
         .bind(tpd)
-        .bind(status)
+        .bind(is_enabled)
         .bind(expires_at.as_deref().map(str::trim).unwrap_or(""))
         .bind(id)
         .execute(&self.pool)
@@ -750,7 +750,7 @@ impl AuthAccessStore for PostgresAuthAccessStore {
             _,
             (
                 String,
-                String,
+                bool,
                 Option<String>,
                 Option<i32>,
                 Option<i32>,
@@ -758,16 +758,16 @@ impl AuthAccessStore for PostgresAuthAccessStore {
                 Option<i32>,
             ),
         >(
-            "SELECT id, status, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = $1",
+            "SELECT id, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = $1",
         )
         .bind(raw_key)
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row.map(
-            |(id, status, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
+            |(id, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
                 id,
-                status,
+                is_enabled,
                 expires_at,
                 rpm,
                 rpd,
@@ -1111,6 +1111,32 @@ impl StorageBootstrap for PostgresBootstrap {
         sqlx::query("CREATE EXTENSION IF NOT EXISTS vector")
             .execute(self.adapter.pool())
             .await?;
+        // Migrate: providers/routes is_active -> is_enabled
+        sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS is_enabled BOOLEAN DEFAULT TRUE")
+            .execute(self.adapter.pool())
+            .await?;
+        sqlx::query("UPDATE providers SET is_enabled = is_active WHERE is_active IS NOT NULL AND is_enabled IS DISTINCT FROM is_active")
+            .execute(self.adapter.pool())
+            .await
+            .ok();
+        sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS is_enabled BOOLEAN DEFAULT TRUE")
+            .execute(self.adapter.pool())
+            .await?;
+        sqlx::query("UPDATE routes SET is_enabled = is_active WHERE is_active IS NOT NULL AND is_enabled IS DISTINCT FROM is_active")
+            .execute(self.adapter.pool())
+            .await
+            .ok();
+        // Migrate: api_keys status -> is_enabled
+        sqlx::query("ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS is_enabled BOOLEAN DEFAULT TRUE")
+            .execute(self.adapter.pool())
+            .await?;
+        sqlx::query(
+            "UPDATE api_keys SET is_enabled = CASE WHEN status = 'active' THEN TRUE ELSE FALSE END \
+             WHERE status IS NOT NULL AND is_enabled IS DISTINCT FROM (status = 'active')",
+        )
+        .execute(self.adapter.pool())
+        .await
+        .ok();
         ensure_semantic_cache_vectors_table(self.adapter.pool(), self.vector_dimensions).await?;
         Ok(())
     }
@@ -1206,7 +1232,7 @@ fn is_pg_permission_error(error: &anyhow::Error) -> bool {
 
 fn provider_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, FALSE) AS use_proxy, last_test_success, to_char(last_test_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS last_test_at, is_active, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM providers",
+        "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, FALSE) AS use_proxy, last_test_success, to_char(last_test_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS last_test_at, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM providers",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1219,7 +1245,7 @@ fn provider_select(suffix: Option<&str>) -> String {
 
 fn route_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, is_active, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM routes",
+        "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM routes",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1230,7 +1256,7 @@ fn route_select(suffix: Option<&str>) -> String {
 
 fn api_key_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, key, name, rpm, rpd, tpm, tpd, status, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM api_keys",
+        "SELECT id, key, name, rpm, rpd, tpm, tpd, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM api_keys",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1250,7 +1276,7 @@ fn api_key_with_bindings(row: ApiKey, route_ids: Vec<String>) -> ApiKeyWithBindi
         rpd: row.rpd,
         tpm: row.tpm,
         tpd: row.tpd,
-        status: row.status,
+        is_enabled: row.is_enabled,
         expires_at: row.expires_at,
         created_at: row.created_at,
         updated_at: row.updated_at,
@@ -1325,7 +1351,7 @@ CREATE TABLE IF NOT EXISTS providers (
     use_proxy BOOLEAN NOT NULL DEFAULT FALSE,
     last_test_success BOOLEAN,
     last_test_at TIMESTAMPTZ,
-    is_active BOOLEAN DEFAULT TRUE,
+    is_enabled BOOLEAN DEFAULT TRUE,
     priority INTEGER DEFAULT 0,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
@@ -1343,7 +1369,7 @@ CREATE TABLE IF NOT EXISTS routes (
     cache_semantic_ttl BIGINT,
     cache_semantic_threshold DOUBLE PRECISION,
     access_control BOOLEAN DEFAULT FALSE,
-    is_active BOOLEAN DEFAULT TRUE,
+    is_enabled BOOLEAN DEFAULT TRUE,
     priority INTEGER DEFAULT 0,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
@@ -1407,7 +1433,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
     rpd INTEGER,
     tpm INTEGER,
     tpd INTEGER,
-    status TEXT NOT NULL DEFAULT 'active',
+    is_enabled BOOLEAN DEFAULT TRUE,
     expires_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -126,7 +126,7 @@ struct SqliteProviderStore {
 impl ProviderStore for SqliteProviderStore {
     async fn list(&self) -> anyhow::Result<Vec<Provider>> {
         Ok(sqlx::query_as::<_, Provider>(
-            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, is_active, created_at, updated_at FROM providers ORDER BY created_at DESC",
+            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -134,7 +134,7 @@ impl ProviderStore for SqliteProviderStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Provider>> {
         Ok(sqlx::query_as::<_, Provider>(
-            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, is_active, created_at, updated_at FROM providers WHERE id = ?",
+            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -199,10 +199,10 @@ impl ProviderStore for SqliteProviderStore {
         let static_models = input.static_models.or(current.static_models);
         let api_key = input.api_key.unwrap_or(current.api_key);
         let use_proxy = input.use_proxy.unwrap_or(current.use_proxy);
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE providers SET name=?, vendor=?, protocol=?, base_url=?, default_protocol=?, protocol_endpoints=?, preset_key=?, channel=?, models_source=?, capabilities_source=?, static_models=?, api_key=?, use_proxy=?, is_active=?, updated_at=datetime('now') WHERE id=?",
+            "UPDATE providers SET name=?, vendor=?, protocol=?, base_url=?, default_protocol=?, protocol_endpoints=?, preset_key=?, channel=?, models_source=?, capabilities_source=?, static_models=?, api_key=?, use_proxy=?, is_enabled=?, updated_at=datetime('now') WHERE id=?",
         )
         .bind(name)
         .bind(vendor)
@@ -217,7 +217,7 @@ impl ProviderStore for SqliteProviderStore {
         .bind(static_models)
         .bind(api_key)
         .bind(use_proxy)
-        .bind(is_active)
+        .bind(is_enabled)
         .bind(id)
         .execute(&self.pool)
         .await?;
@@ -294,7 +294,7 @@ impl SqliteRouteStore {
 impl RouteStore for SqliteRouteStore {
     async fn list(&self) -> anyhow::Result<Vec<Route>> {
         Ok(sqlx::query_as::<_, Route>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, is_active, created_at FROM routes ORDER BY created_at DESC",
+            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -302,7 +302,7 @@ impl RouteStore for SqliteRouteStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Route>> {
         Ok(sqlx::query_as::<_, Route>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, is_active, created_at FROM routes WHERE id = ?",
+            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -377,11 +377,11 @@ impl RouteStore for SqliteRouteStore {
         let cache_exact_ttl = input.cache_exact_ttl;
         let cache_semantic_ttl = input.cache_semantic_ttl;
         let cache_semantic_threshold = input.cache_semantic_threshold;
-        let is_active = input.is_active.unwrap_or(current.is_active);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         if self.has_match_pattern_column().await? {
             sqlx::query(
-                "UPDATE routes SET name=?, virtual_model=?, match_pattern=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_active=? WHERE id=?",
+                "UPDATE routes SET name=?, virtual_model=?, match_pattern=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
@@ -394,13 +394,13 @@ impl RouteStore for SqliteRouteStore {
             .bind(cache_exact_ttl)
             .bind(cache_semantic_ttl)
             .bind(cache_semantic_threshold)
-            .bind(is_active)
+            .bind(is_enabled)
             .bind(id)
             .execute(&self.pool)
             .await?;
         } else {
             sqlx::query(
-                "UPDATE routes SET name=?, virtual_model=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_active=? WHERE id=?",
+                "UPDATE routes SET name=?, virtual_model=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
@@ -412,7 +412,7 @@ impl RouteStore for SqliteRouteStore {
             .bind(cache_exact_ttl)
             .bind(cache_semantic_ttl)
             .bind(cache_semantic_threshold)
-            .bind(is_active)
+            .bind(is_enabled)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -496,10 +496,10 @@ impl RouteSnapshotStore for SqliteRouteStore {
                 cache_exact_ttl,
                 cache_semantic_ttl,
                 cache_semantic_threshold,
-                is_active,
+                COALESCE(is_enabled, 1) AS is_enabled,
                 created_at
             FROM routes
-            WHERE is_active = 1"#,
+            WHERE COALESCE(is_enabled, 1) = 1"#,
         )
         .fetch_all(&self.pool)
         .await?)
@@ -603,7 +603,7 @@ struct SqliteApiKeyStore {
 impl ApiKeyStore for SqliteApiKeyStore {
     async fn list(&self) -> anyhow::Result<Vec<ApiKeyWithBindings>> {
         let rows = sqlx::query_as::<_, ApiKey>(
-            "SELECT id, key, name, rpm, rpd, tpm, tpd, status, expires_at, created_at, updated_at FROM api_keys ORDER BY created_at DESC",
+            "SELECT id, key, name, rpm, rpd, tpm, tpd, COALESCE(is_enabled, 1) AS is_enabled, expires_at, created_at, updated_at FROM api_keys ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -619,7 +619,7 @@ impl ApiKeyStore for SqliteApiKeyStore {
                 rpd: row.rpd,
                 tpm: row.tpm,
                 tpd: row.tpd,
-                status: row.status,
+                is_enabled: row.is_enabled,
                 expires_at: row.expires_at,
                 created_at: row.created_at,
                 updated_at: row.updated_at,
@@ -631,7 +631,7 @@ impl ApiKeyStore for SqliteApiKeyStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<ApiKeyWithBindings>> {
         let row = sqlx::query_as::<_, ApiKey>(
-            "SELECT id, key, name, rpm, rpd, tpm, tpd, status, expires_at, created_at, updated_at FROM api_keys WHERE id = ?",
+            "SELECT id, key, name, rpm, rpd, tpm, tpd, COALESCE(is_enabled, 1) AS is_enabled, expires_at, created_at, updated_at FROM api_keys WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -649,7 +649,7 @@ impl ApiKeyStore for SqliteApiKeyStore {
             rpd: row.rpd,
             tpm: row.tpm,
             tpd: row.tpd,
-            status: row.status,
+            is_enabled: row.is_enabled,
             expires_at: row.expires_at,
             created_at: row.created_at,
             updated_at: row.updated_at,
@@ -661,7 +661,7 @@ impl ApiKeyStore for SqliteApiKeyStore {
         let id = uuid::Uuid::new_v4().to_string();
         let key = format!("sk-{}", uuid::Uuid::new_v4().simple());
         sqlx::query(
-            "INSERT INTO api_keys (id, key, name, rpm, rpd, tpm, tpd, status, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?)",
+            "INSERT INTO api_keys (id, key, name, rpm, rpd, tpm, tpd, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&id)
         .bind(&key)
@@ -682,7 +682,7 @@ impl ApiKeyStore for SqliteApiKeyStore {
 
     async fn update(&self, id: &str, input: UpdateApiKey) -> anyhow::Result<ApiKeyWithBindings> {
         let current = sqlx::query_as::<_, ApiKey>(
-            "SELECT id, key, name, rpm, rpd, tpm, tpd, status, expires_at, created_at, updated_at FROM api_keys WHERE id = ?",
+            "SELECT id, key, name, rpm, rpd, tpm, tpd, COALESCE(is_enabled, 1) AS is_enabled, expires_at, created_at, updated_at FROM api_keys WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -694,18 +694,18 @@ impl ApiKeyStore for SqliteApiKeyStore {
         let rpd = input.rpd.or(current.rpd);
         let tpm = input.tpm.or(current.tpm);
         let tpd = input.tpd.or(current.tpd);
-        let status = input.status.unwrap_or(current.status);
+        let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let expires_at = input.expires_at.or(current.expires_at);
 
         sqlx::query(
-            "UPDATE api_keys SET name=?, rpm=?, rpd=?, tpm=?, tpd=?, status=?, expires_at=?, updated_at=datetime('now') WHERE id=?",
+            "UPDATE api_keys SET name=?, rpm=?, rpd=?, tpm=?, tpd=?, is_enabled=?, expires_at=?, updated_at=datetime('now') WHERE id=?",
         )
         .bind(name.trim())
         .bind(rpm)
         .bind(rpd)
         .bind(tpm)
         .bind(tpd)
-        .bind(status)
+        .bind(is_enabled)
         .bind(expires_at.as_ref().map(|v| v.trim()).filter(|v| !v.is_empty()))
         .bind(id)
         .execute(&self.pool)
@@ -763,22 +763,22 @@ impl AuthAccessStore for SqliteAuthAccessStore {
             _,
             (
                 String,
-                String,
+                bool,
                 Option<String>,
                 Option<i32>,
                 Option<i32>,
                 Option<i32>,
                 Option<i32>,
             ),
-        >("SELECT id, status, expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = ?")
+        >("SELECT id, COALESCE(is_enabled, 1) AS is_enabled, expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = ?")
         .bind(raw_key)
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row.map(
-            |(id, status, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
+            |(id, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
                 id,
-                status,
+                is_enabled,
                 expires_at,
                 rpm,
                 rpd,

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -25,7 +25,7 @@ pub enum UsageWindow {
 #[derive(Debug, Clone)]
 pub struct ApiKeyAccessRecord {
     pub id: String,
-    pub status: String,
+    pub is_enabled: bool,
     pub expires_at: Option<String>,
     pub rpm: Option<i32>,
     pub rpd: Option<i32>,

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -256,7 +256,7 @@ pub fn build_providers(yaml: &YamlConfig) -> Vec<Provider> {
                 use_proxy: yp.use_proxy,
                 last_test_success: None,
                 last_test_at: None,
-                is_active: true,
+                is_enabled: true,
                 created_at: now.clone(),
                 updated_at: now,
             }
@@ -314,7 +314,7 @@ pub fn build_routes(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Route> {
                 cache_semantic_ttl: None,
                 cache_semantic_threshold: None,
                 cache: None,
-                is_active: true,
+                is_enabled: true,
                 created_at: now,
                 targets,
             }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -13,7 +13,7 @@ export interface Provider {
   models_source?: string | null;
   capabilities_source?: string | null;
   static_models?: string | null;
-  is_active: boolean;
+  is_enabled: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -28,7 +28,7 @@ export interface Route {
   access_control: boolean;
   route_type?: "chat" | "embedding";
   cache?: RouteCacheConfig;
-  is_active: boolean;
+  is_enabled: boolean;
   created_at: string;
   targets: RouteTarget[];
 }
@@ -53,7 +53,7 @@ export interface ApiKey {
   rpd?: number | null;
   tpm?: number | null;
   tpd?: number | null;
-  status: "active" | "revoked";
+  is_enabled: boolean;
   expires_at?: string | null;
   created_at: string;
   updated_at: string;
@@ -194,7 +194,7 @@ export interface UpdateProvider {
   capabilities_source?: string;
   static_models?: string;
   api_key?: string;
-  is_active?: boolean;
+  is_enabled?: boolean;
 }
 
 export interface CreateRoute {
@@ -219,7 +219,7 @@ export interface UpdateRoute {
   access_control?: boolean;
   route_type?: "chat" | "embedding";
   cache?: RouteCacheConfig | null;
-  is_active?: boolean;
+  is_enabled?: boolean;
 }
 
 export interface RouteCacheConfig {
@@ -287,7 +287,7 @@ export interface UpdateApiKey {
   rpd?: number;
   tpm?: number;
   tpd?: number;
-  status?: "active" | "revoked";
+  is_enabled?: boolean;
   expires_at?: string;
   route_ids?: string[];
 }
@@ -321,7 +321,7 @@ export interface ExportProvider {
   capabilities_source?: string | null;
   static_models?: string | null;
   api_key: string;
-  is_active: boolean;
+  is_enabled: boolean;
 }
 
 export interface ExportRoute {
@@ -329,7 +329,7 @@ export interface ExportRoute {
   virtual_model: string;
   target_model: string;
   access_control: boolean;
-  is_active: boolean;
+  is_enabled: boolean;
 }
 
 export interface ImportResult {

--- a/webui/src/pages/api-keys.tsx
+++ b/webui/src/pages/api-keys.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronLeft, ChevronRight, Copy, KeyRound, Pencil, Plus, Trash2, X } from "lucide-react";
+import { Check, ChevronLeft, ChevronRight, Copy, KeyRound, Pencil, Plus, Trash2, ToggleRight, ToggleLeft, X } from "lucide-react";
 
 import { backend } from "@/lib/backend";
 import { localizeBackendErrorMessage } from "@/lib/backend-error";
@@ -69,13 +69,6 @@ function isApiKeyExpired(expiresAt: string | null | undefined) {
   }
   const fallbackMillis = Date.parse(expiresAt);
   return !Number.isNaN(fallbackMillis) && fallbackMillis <= Date.now();
-}
-
-function formatAdminStatusLabel(status: string, isZh: boolean) {
-  const normalized = status.trim().toLowerCase();
-  if (normalized === "active") return isZh ? "正常" : "Active";
-  if (normalized === "revoked") return isZh ? "吊销" : "Revoked";
-  return status;
 }
 
 function formatValidityLabel(expired: boolean, isZh: boolean) {
@@ -201,6 +194,15 @@ export default function ApiKeysPage() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["api-keys"] }),
     onError: (error: unknown) => {
       showErrorDialog("删除 API Key 失败", "Failed to delete API key", error);
+    },
+  });
+
+  const toggleEnabledMut = useMutation({
+    mutationFn: ({ id, is_enabled }: { id: string; is_enabled: boolean }) =>
+      backend("update_api_key", { id, input: { is_enabled } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["api-keys"] }),
+    onError: (error: unknown) => {
+      showErrorDialog("操作失败", "Operation failed", error);
     },
   });
 
@@ -607,9 +609,11 @@ export default function ApiKeysPage() {
                       <code className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600">
                         {shortApiKeyTag(item.key)}
                       </code>
-                      <Badge variant={item.status === "active" ? "success" : "danger"} className="connect-label-badge">
-                        {formatAdminStatusLabel(item.status, isZh)}
-                      </Badge>
+                      {!item.is_enabled && (
+                        <Badge variant="danger" className="connect-label-badge">
+                          {isZh ? "已禁用" : "Disabled"}
+                        </Badge>
+                      )}
                       <Badge variant={keyExpired ? "danger" : "success"} className="connect-label-badge">
                         {formatValidityLabel(keyExpired, isZh)}
                       </Badge>
@@ -634,6 +638,17 @@ export default function ApiKeysPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-0.5">
+                  <button
+                    onClick={() => toggleEnabledMut.mutate({ id: item.id, is_enabled: !item.is_enabled })}
+                    title={item.is_enabled ? (isZh ? "禁用" : "Disable") : (isZh ? "启用" : "Enable")}
+                    className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+                  >
+                    {item.is_enabled ? (
+                      <ToggleRight className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <ToggleLeft className="h-4 w-4 text-slate-400" />
+                    )}
+                  </button>
                   <button
                     onClick={() => copyKey(item)}
                     title={copiedId === item.id ? (isZh ? "复制成功" : "Copied") : (isZh ? "复制 Key" : "Copy Key")}

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -26,6 +26,8 @@ import {
   Eye,
   EyeOff,
   Info,
+  ToggleRight,
+  ToggleLeft,
 } from "lucide-react";
 import { useLocale } from "@/lib/i18n";
 import { ProviderIcon } from "@/components/ui/provider-icon";
@@ -513,6 +515,17 @@ export default function ProvidersPage() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["providers"] }),
     onError: (error: unknown) => {
       showErrorDialog("删除提供商失败", "Failed to delete provider", error);
+    },
+  });
+
+  const [providerToDisable, setProviderToDisable] = useState<Provider | null>(null);
+
+  const toggleEnabledMut = useMutation({
+    mutationFn: ({ id, is_enabled }: { id: string; is_enabled: boolean }) =>
+      backend("update_provider", { id, input: { is_enabled } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["providers"] }),
+    onError: (error: unknown) => {
+      showErrorDialog("操作失败", "Operation failed", error);
     },
   });
 
@@ -1583,6 +1596,11 @@ export default function ProvidersPage() {
                             {isZh ? "本地代理" : "Proxy"}
                           </Badge>
                         )}
+                        {!p.is_enabled && (
+                          <Badge variant="danger" className="connect-label-badge">
+                            {isZh ? "已禁用" : "Disabled"}
+                          </Badge>
+                        )}
                         {status === "success" ? (
                           <CheckCircle
                             className="h-3.5 w-3.5 text-green-500"
@@ -1598,6 +1616,23 @@ export default function ProvidersPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-0.5">
+                    <button
+                      onClick={() => {
+                        if (p.is_enabled) {
+                          setProviderToDisable(p);
+                        } else {
+                          toggleEnabledMut.mutate({ id: p.id, is_enabled: true });
+                        }
+                      }}
+                      title={p.is_enabled ? (isZh ? "禁用" : "Disable") : (isZh ? "启用" : "Enable")}
+                      className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 cursor-pointer"
+                    >
+                      {p.is_enabled ? (
+                        <ToggleRight className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <ToggleLeft className="h-4 w-4 text-slate-400" />
+                      )}
+                    </button>
                     <button
                       onClick={() => handleTest(p)}
                       disabled={Boolean(testingId)}
@@ -1708,6 +1743,21 @@ export default function ProvidersPage() {
         </DialogContent>
       </Dialog>
 
+      <ConfirmDialog
+        open={Boolean(providerToDisable)}
+        onOpenChange={(open) => {
+          if (!open) setProviderToDisable(null);
+        }}
+        title={isZh ? "确认禁用供应商" : "Confirm provider disable"}
+        description={isZh ? "禁用后，引用该供应商的路由请求将受影响，确认禁用？" : "After disabling, route requests referencing this provider will be affected. Confirm disable?"}
+        cancelText={isZh ? "取消" : "Cancel"}
+        confirmText={isZh ? "禁用" : "Disable"}
+        onConfirm={() => {
+          if (!providerToDisable) return;
+          toggleEnabledMut.mutate({ id: providerToDisable.id, is_enabled: false });
+          setProviderToDisable(null);
+        }}
+      />
       <ConfirmDialog
         open={Boolean(providerToDelete)}
         onOpenChange={(open) => {

--- a/webui/src/pages/routes.tsx
+++ b/webui/src/pages/routes.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, GitBranch, Pencil, Plus, Route as RouteIcon, Trash2, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, GitBranch, Pencil, Plus, Route as RouteIcon, Trash2, ToggleRight, ToggleLeft, X } from "lucide-react";
 
 import { backend } from "@/lib/backend";
 import { localizeBackendErrorMessage } from "@/lib/backend-error";
@@ -432,6 +432,17 @@ export default function RoutesPage() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["routes"] }),
     onError: (error: unknown) => {
       showErrorDialog("删除路由失败", "Failed to delete route", error);
+    },
+  });
+
+  const [routeToDisable, setRouteToDisable] = useState<RouteType | null>(null);
+
+  const toggleEnabledMut = useMutation({
+    mutationFn: ({ id, is_enabled }: { id: string; is_enabled: boolean }) =>
+      backend("update_route", { id, input: { is_enabled } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["routes"] }),
+    onError: (error: unknown) => {
+      showErrorDialog("操作失败", "Operation failed", error);
     },
   });
 
@@ -1004,15 +1015,32 @@ export default function RoutesPage() {
                         {isZh ? "语义相似缓存" : "Semantic Cache"}
                       </Badge>
                     )}
-                    {!route.is_active && (
+                    {!route.is_enabled && (
                       <Badge variant="danger" className="connect-label-badge">
-                        {isZh ? "停用" : "Inactive"}
+                        {isZh ? "已禁用" : "Disabled"}
                       </Badge>
                     )}
                   </div>
                   </div>
                 </div>
                 <div className="flex items-center gap-0.5">
+                  <button
+                    onClick={() => {
+                      if (route.is_enabled) {
+                        setRouteToDisable(route);
+                      } else {
+                        toggleEnabledMut.mutate({ id: route.id, is_enabled: true });
+                      }
+                    }}
+                    title={route.is_enabled ? (isZh ? "禁用" : "Disable") : (isZh ? "启用" : "Enable")}
+                    className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+                  >
+                    {route.is_enabled ? (
+                      <ToggleRight className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <ToggleLeft className="h-4 w-4 text-slate-400" />
+                    )}
+                  </button>
                   <button
                     onClick={() => startEdit(route)}
                     className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-500"
@@ -1073,6 +1101,21 @@ export default function RoutesPage() {
         </div>
       )}
 
+      <ConfirmDialog
+        open={Boolean(routeToDisable)}
+        onOpenChange={(open) => {
+          if (!open) setRouteToDisable(null);
+        }}
+        title={isZh ? "确认禁用路由" : "Confirm route disable"}
+        description={isZh ? "禁用后，该虚拟模型将不可用，确认禁用？" : "After disabling, the virtual model will be unavailable. Confirm disable?"}
+        cancelText={isZh ? "取消" : "Cancel"}
+        confirmText={isZh ? "禁用" : "Disable"}
+        onConfirm={() => {
+          if (!routeToDisable) return;
+          toggleEnabledMut.mutate({ id: routeToDisable.id, is_enabled: false });
+          setRouteToDisable(null);
+        }}
+      />
       <ConfirmDialog
         open={Boolean(routeToDelete)}
         onOpenChange={(open) => {


### PR DESCRIPTION
- Rename providers.is_active, routes.is_active, api_keys.status to is_enabled (BOOLEAN)
- Add non-breaking schema migration for SQLite and PostgreSQL
- Update all SQL queries, Rust models, proxy auth, admin service, yaml config
- Add enable/disable toggle buttons in WebUI list pages for all three resource for disabling providers and routes
- Unify disabled badge display: show danger badge only when resource is disabled
- Support Chinese/English in all new UI text

FIX #50 