### PR TITLE
ci(release-server): build webui before cargo build

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -39,6 +39,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install frontend dependencies
+        run: pnpm -C webui install --frozen-lockfile
+
+      - name: Build webui
+        run: pnpm -C webui build
+
       - name: Build nyro-server
         run: cargo build -p nyro-server --release
 


### PR DESCRIPTION
RustEmbed requires webui/dist/ at compile time; without it the #[derive(RustEmbed)] expansion fails and WebUiAssets::get is missing. Add Node 20 + pnpm 9 setup and run pnpm -C webui install/build.