### PR TITLE
feat(standalone): add provider config aliases and protocol inference

### DIFF
--- a/docs/standalone/README.md
+++ b/docs/standalone/README.md
@@ -96,6 +96,28 @@ routes:
         model: gpt-4o
 ```
 
+### 简化写法（等价）
+
+`default_protocol` / `api_key` 支持别名 `protocol` / `apikey`，单 endpoint 时 `protocol` 可省略（自动取 endpoints 的第一个协议）：
+
+```yaml
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-xxx
+
+routes:
+  - name: gpt-4o
+    vmodel: gpt-4o
+    targets:
+      - provider: openai
+        model: gpt-4o
+```
+
+> 规范名与别名**不能同时出现**（例如同时写 `default_protocol` 和 `protocol`），否则启动时报错。
+
 ---
 
 ## 配置字段说明
@@ -111,16 +133,18 @@ routes:
 
 ### providers[]
 
-| 字段 | 必填 | 说明 |
-|------|------|------|
-| `name` | 是 | Provider 名称，路由中通过此名称引用 |
-| `default_protocol` | 是 | 默认出口协议，必须在 `endpoints` 中有对应条目 |
-| `endpoints` | 是 | 协议 → 端点映射，key 为协议名（`openai` / `anthropic` / `gemini`） |
-| `api_key` | 是 | API 密钥，支持 `${ENV_VAR}` 环境变量引用 |
-| `use_proxy` | 否 | 是否使用系统 HTTP 代理（默认 `false`） |
-| `models_source` | 否 | 模型发现 URL 或 `ai://models.dev/{vendor}` |
-| `capabilities_source` | 否 | 模型能力发现 URL 或 `ai://models.dev/{vendor}` |
-| `static_models` | 否 | 静态模型列表，无 API 时的硬编码兜底 |
+| 字段 | 别名 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | — | 是 | Provider 名称，路由中通过此名称引用 |
+| `default_protocol` | `protocol` | 否 | 默认出口协议，必须在 `endpoints` 中有对应条目；省略时自动取 `endpoints` 声明顺序的第一个协议（多 endpoint 时会打印 WARN 日志建议显式设置） |
+| `endpoints` | — | 是 | 协议 → 端点映射，key 为协议名（`openai` / `anthropic` / `gemini`），保留 YAML 声明顺序 |
+| `api_key` | `apikey` | 是 | API 密钥，支持 `${ENV_VAR}` 环境变量引用 |
+| `use_proxy` | — | 否 | 是否使用系统 HTTP 代理（默认 `false`） |
+| `models_source` | — | 否 | 模型发现 URL 或 `ai://models.dev/{vendor}` |
+| `capabilities_source` | — | 否 | 模型能力发现 URL 或 `ai://models.dev/{vendor}` |
+| `static_models` | — | 否 | 静态模型列表，无 API 时的硬编码兜底 |
+
+> 规范名与别名互斥：同一 provider 下同时出现 `default_protocol` + `protocol`，或 `api_key` + `apikey`，启动时直接报错。
 
 ### routes[]
 

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -18,5 +18,6 @@ clap = { version = "4", features = ["derive", "env"] }
 shellexpand = "3"
 anyhow = { workspace = true }
 serde_yaml = "0.9"
+indexmap = { version = "2", features = ["serde"] }
 chrono = { workspace = true }
 rust-embed = { version = "8", features = ["compression"] }

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use nyro_core::cache::{CacheConfig, ExactCacheConfig, SemanticCacheConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -76,17 +77,89 @@ fn default_proxy_port() -> u16 {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(try_from = "YamlProviderRaw")]
 pub struct YamlProvider {
     pub name: String,
-    pub default_protocol: String,
-    #[serde(default)]
-    pub endpoints: HashMap<String, YamlEndpoint>,
+    pub default_protocol: Option<String>,
+    pub endpoints: IndexMap<String, YamlEndpoint>,
     pub api_key: String,
-    #[serde(default)]
     pub use_proxy: bool,
     pub models_source: Option<String>,
     pub capabilities_source: Option<String>,
     pub static_models: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YamlProviderRaw {
+    pub name: String,
+    #[serde(default)]
+    pub default_protocol: Option<String>,
+    #[serde(default)]
+    pub protocol: Option<String>,
+    #[serde(default)]
+    pub endpoints: IndexMap<String, YamlEndpoint>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub apikey: Option<String>,
+    #[serde(default)]
+    pub use_proxy: bool,
+    #[serde(default)]
+    pub models_source: Option<String>,
+    #[serde(default)]
+    pub capabilities_source: Option<String>,
+    #[serde(default)]
+    pub static_models: Option<Vec<String>>,
+}
+
+impl TryFrom<YamlProviderRaw> for YamlProvider {
+    type Error = String;
+
+    fn try_from(r: YamlProviderRaw) -> Result<Self, Self::Error> {
+        let default_protocol = match (r.default_protocol, r.protocol) {
+            (Some(_), Some(_)) => {
+                return Err(format!(
+                    "provider '{}': 'default_protocol' and its alias 'protocol' cannot both be set",
+                    r.name
+                ));
+            }
+            (Some(v), None) | (None, Some(v)) => Some(v),
+            (None, None) => None,
+        };
+        let api_key = match (r.api_key, r.apikey) {
+            (Some(_), Some(_)) => {
+                return Err(format!(
+                    "provider '{}': 'api_key' and its alias 'apikey' cannot both be set",
+                    r.name
+                ));
+            }
+            (Some(v), None) | (None, Some(v)) => v,
+            (None, None) => {
+                return Err(format!("provider '{}': 'api_key' is required", r.name));
+            }
+        };
+        Ok(YamlProvider {
+            name: r.name,
+            default_protocol,
+            endpoints: r.endpoints,
+            api_key,
+            use_proxy: r.use_proxy,
+            models_source: r.models_source,
+            capabilities_source: r.capabilities_source,
+            static_models: r.static_models,
+        })
+    }
+}
+
+impl YamlProvider {
+    /// Resolve the effective default protocol: explicit value if set,
+    /// otherwise the first endpoint key in YAML declaration order.
+    pub fn resolved_protocol(&self) -> Option<&str> {
+        if let Some(p) = self.default_protocol.as_deref() {
+            return Some(p);
+        }
+        self.endpoints.keys().next().map(String::as_str)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -155,11 +228,25 @@ impl YamlConfig {
                     p.name
                 );
             }
-            if !p.endpoints.contains_key(&p.default_protocol) {
+            let resolved = p.resolved_protocol().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "providers[{i}] ({}): unable to determine protocol from endpoints",
+                    p.name
+                )
+            })?;
+            if !p.endpoints.contains_key(resolved) {
                 anyhow::bail!(
-                    "providers[{i}] ({}): default_protocol '{}' has no matching endpoint",
+                    "providers[{i}] ({}): protocol '{}' has no matching endpoint in 'endpoints'",
                     p.name,
-                    p.default_protocol
+                    resolved
+                );
+            }
+            if p.default_protocol.is_none() && p.endpoints.len() > 1 {
+                tracing::warn!(
+                    "providers[{i}] ({}): 'protocol' not set and 'endpoints' has {} entries; inferring '{}' as default (set 'protocol' explicitly to silence this warning)",
+                    p.name,
+                    p.endpoints.len(),
+                    resolved
                 );
             }
         }
@@ -226,7 +313,8 @@ pub fn build_providers(yaml: &YamlConfig) -> Vec<Provider> {
         .enumerate()
         .map(|(i, yp)| {
             let id = format!("yaml-provider-{i}");
-            let default_ep = yp.endpoints.get(&yp.default_protocol);
+            let resolved_protocol = yp.resolved_protocol().unwrap_or_default().to_string();
+            let default_ep = yp.endpoints.get(&resolved_protocol);
             let base_url = default_ep.map(|e| e.base_url.clone()).unwrap_or_default();
             let endpoints_json: HashMap<String, serde_json::Value> = yp
                 .endpoints
@@ -243,9 +331,9 @@ pub fn build_providers(yaml: &YamlConfig) -> Vec<Provider> {
                 id,
                 name: yp.name.clone(),
                 vendor: None,
-                protocol: yp.default_protocol.clone(),
+                protocol: resolved_protocol.clone(),
                 base_url,
-                default_protocol: yp.default_protocol.clone(),
+                default_protocol: resolved_protocol,
                 protocol_endpoints: serde_json::to_string(&endpoints_json).unwrap_or_default(),
                 preset_key: None,
                 channel: None,
@@ -327,5 +415,163 @@ fn parse_route_type(raw: &str) -> anyhow::Result<&'static str> {
         "chat" => Ok("chat"),
         "embedding" => Ok("embedding"),
         _ => anyhow::bail!("unsupported route type"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_provider(yaml: &str) -> Result<YamlProvider, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
+    }
+
+    #[test]
+    fn canonical_names_work() {
+        let yaml = r#"
+name: openai
+default_protocol: openai
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+api_key: sk-canonical
+"#;
+        let p = parse_provider(yaml).expect("should parse");
+        assert_eq!(p.default_protocol.as_deref(), Some("openai"));
+        assert_eq!(p.api_key, "sk-canonical");
+        assert_eq!(p.resolved_protocol(), Some("openai"));
+    }
+
+    #[test]
+    fn alias_protocol_and_apikey_work() {
+        let yaml = r#"
+name: openai
+protocol: openai
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+apikey: sk-alias
+"#;
+        let p = parse_provider(yaml).expect("should parse");
+        assert_eq!(p.default_protocol.as_deref(), Some("openai"));
+        assert_eq!(p.api_key, "sk-alias");
+    }
+
+    #[test]
+    fn omitted_protocol_single_endpoint_is_inferred() {
+        let yaml = r#"
+name: openai
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+api_key: sk-x
+"#;
+        let p = parse_provider(yaml).expect("should parse");
+        assert!(p.default_protocol.is_none());
+        assert_eq!(p.resolved_protocol(), Some("openai"));
+    }
+
+    #[test]
+    fn omitted_protocol_multi_endpoint_uses_first_declared() {
+        let yaml = r#"
+name: deepseek
+endpoints:
+  anthropic:
+    base_url: https://api.deepseek.com/anthropic
+  openai:
+    base_url: https://api.deepseek.com/v1
+apikey: sk-x
+"#;
+        let p = parse_provider(yaml).expect("should parse");
+        assert!(p.default_protocol.is_none());
+        assert_eq!(p.resolved_protocol(), Some("anthropic"));
+    }
+
+    #[test]
+    fn conflict_default_protocol_and_protocol_rejects() {
+        let yaml = r#"
+name: openai
+default_protocol: openai
+protocol: anthropic
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+api_key: sk-x
+"#;
+        let err = parse_provider(yaml).expect_err("should reject").to_string();
+        assert!(
+            err.contains("default_protocol") && err.contains("protocol"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn conflict_api_key_and_apikey_rejects() {
+        let yaml = r#"
+name: openai
+protocol: openai
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+api_key: sk-a
+apikey: sk-b
+"#;
+        let err = parse_provider(yaml).expect_err("should reject").to_string();
+        assert!(
+            err.contains("api_key") && err.contains("apikey"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_api_key_rejects() {
+        let yaml = r#"
+name: openai
+protocol: openai
+endpoints:
+  openai:
+    base_url: https://api.openai.com/v1
+"#;
+        let err = parse_provider(yaml).expect_err("should reject").to_string();
+        assert!(err.contains("api_key"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_accepts_inferred_protocol() {
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+routes:
+  - name: gpt-4o
+    vmodel: gpt-4o
+    targets:
+      - provider: openai
+        model: gpt-4o
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+    }
+
+    #[test]
+    fn validate_rejects_unknown_protocol_without_matching_endpoint() {
+        let yaml = r#"
+providers:
+  - name: openai
+    protocol: gemini
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    api_key: sk-x
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("protocol 'gemini'") && err.contains("no matching endpoint"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
- Make `default_protocol` optional; infer from first declared endpoint when omitted (switch endpoints to IndexMap to preserve YAML order).
- Add aliases: `protocol` for `default_protocol`, `apikey` for `api_key`.
- Reject conflicting canonical + alias pairs at deserialization time via `YamlProviderRaw` + `TryFrom` to avoid silent ambiguity.
- Emit a WARN log when protocol is inferred from multiple endpoints.
- Update standalone docs with alias column and simplified example.
- Add unit tests covering canonical/alias writes, inference, and alias conflicts.