### PR TITLE
feat(logs): capture request/response payloads and redesign log viewer

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -751,6 +751,10 @@ impl AdminService {
         self.gw.storage.logs().query(q).await
     }
 
+    pub async fn get_log(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
+        self.gw.storage.logs().find_by_id(id).await
+    }
+
     // ── Stats ──
 
     fn normalize_hours(hours: Option<i32>) -> Option<i32> {

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -58,6 +58,12 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     ensure_route_column(pool, "cache_semantic_ttl", "INTEGER").await?;
     ensure_route_column(pool, "cache_semantic_threshold", "REAL").await?;
     ensure_request_log_column(pool, "api_key_id", "TEXT").await?;
+    ensure_request_log_column(pool, "method", "TEXT").await?;
+    ensure_request_log_column(pool, "path", "TEXT").await?;
+    ensure_request_log_column(pool, "request_headers", "TEXT").await?;
+    ensure_request_log_column(pool, "request_body", "TEXT").await?;
+    ensure_request_log_column(pool, "response_headers", "TEXT").await?;
+    ensure_request_log_column(pool, "response_body", "TEXT").await?;
     ensure_api_key_tables(pool).await?;
     ensure_api_key_column(pool, "rpd", "INTEGER").await?;
     // Migrate: providers/routes is_active -> is_enabled
@@ -478,7 +484,13 @@ CREATE TABLE IF NOT EXISTS request_logs (
     is_stream         INTEGER DEFAULT 0,
     is_tool_call      INTEGER DEFAULT 0,
     error_message     TEXT,
-    response_preview  TEXT
+    response_preview  TEXT,
+    method            TEXT,
+    path              TEXT,
+    request_headers   TEXT,
+    request_body      TEXT,
+    response_headers  TEXT,
+    response_body     TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at);

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -160,6 +160,16 @@ pub struct RequestLog {
     pub is_tool_call: bool,
     pub error_message: Option<String>,
     pub response_preview: Option<String>,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_headers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_headers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_body: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/nyro-core/src/logging/mod.rs
+++ b/crates/nyro-core/src/logging/mod.rs
@@ -3,7 +3,10 @@ use tokio::sync::mpsc;
 use crate::protocol::types::TokenUsage;
 use crate::storage::DynStorage;
 
-const DEFAULT_RETENTION_DAYS: i64 = 30;
+const DEFAULT_RETENTION_DAYS: i64 = 7;
+const DEFAULT_RECORD_PAYLOADS: bool = true;
+pub const LOG_RECORD_PAYLOADS_KEY: &str = "log_record_payloads";
+pub const LOG_RETENTION_DAYS_KEY: &str = "log_retention_days";
 
 #[derive(Debug, Clone)]
 pub struct LogEntry {
@@ -20,18 +23,24 @@ pub struct LogEntry {
     pub is_tool_call: bool,
     pub error_message: Option<String>,
     pub response_preview: Option<String>,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    pub request_headers: Option<String>,
+    pub request_body: Option<String>,
+    pub response_headers: Option<String>,
+    pub response_body: Option<String>,
 }
 
 pub async fn run_collector(mut rx: mpsc::Receiver<LogEntry>, storage: DynStorage) {
-    let mut buffer: Vec<LogEntry> = Vec::with_capacity(64);
+    let mut buffer: Vec<LogEntry> = Vec::with_capacity(32);
     let mut flush_interval = tokio::time::interval(std::time::Duration::from_secs(2));
-    let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+    let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(600));
 
     loop {
         tokio::select! {
             Some(entry) = rx.recv() => {
                 buffer.push(entry);
-                if buffer.len() >= 64 {
+                if buffer.len() >= 32 {
                     flush(storage.clone(), &mut buffer).await;
                 }
             }
@@ -50,7 +59,7 @@ pub async fn run_collector(mut rx: mpsc::Receiver<LogEntry>, storage: DynStorage
 async fn cleanup_old_logs(storage: DynStorage) {
     let days = storage
         .settings()
-        .get("log_retention_days")
+        .get(LOG_RETENTION_DAYS_KEY)
         .await
         .ok()
         .flatten()
@@ -65,7 +74,27 @@ async fn cleanup_old_logs(storage: DynStorage) {
     }
 }
 
+async fn read_record_payloads(storage: &DynStorage) -> bool {
+    storage
+        .settings()
+        .get(LOG_RECORD_PAYLOADS_KEY)
+        .await
+        .ok()
+        .flatten()
+        .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "false" | "0" | "off" | "no"))
+        .unwrap_or(DEFAULT_RECORD_PAYLOADS)
+}
+
 async fn flush(storage: DynStorage, buffer: &mut Vec<LogEntry>) {
-    let entries = std::mem::take(buffer);
-    let _ = storage.logs().append_batch(entries).await;
+    let mut entries = std::mem::take(buffer);
+    let record_payloads = read_record_payloads(&storage).await;
+    if !record_payloads {
+        for entry in entries.iter_mut() {
+            entry.request_headers = None;
+            entry.request_body = None;
+            entry.response_headers = None;
+            entry.response_body = None;
+        }
     }
+    let _ = storage.logs().append_batch(entries).await;
+}

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -38,7 +38,7 @@ pub async fn openai_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::OpenAI).await
+    universal_proxy(gw, headers, body, Protocol::OpenAI, "/v1/chat/completions").await
 }
 
 // ── OpenAI Responses API ingress: POST /v1/responses ──
@@ -48,7 +48,7 @@ pub async fn responses_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::ResponsesAPI).await
+    universal_proxy(gw, headers, body, Protocol::ResponsesAPI, "/v1/responses").await
 }
 
 // ── OpenAI embeddings ingress: POST /v1/embeddings ──
@@ -57,6 +57,21 @@ pub async fn embeddings_proxy(
     headers: HeaderMap,
     Json(mut body): Json<Value>,
 ) -> Response {
+    const EMB_PATH: &str = "/v1/embeddings";
+    const EMB_METHOD: &str = "POST";
+    let start = Instant::now();
+    let request_headers = headers_to_json(&headers);
+    let request_body = serde_json::to_string(&body).ok();
+
+    let base_extras = |response_body: Option<String>, request_body_override: Option<String>| LogExtras {
+        method: Some(EMB_METHOD.to_string()),
+        path: Some(EMB_PATH.to_string()),
+        request_headers: request_headers.clone(),
+        request_body: request_body_override.or_else(|| request_body.clone()),
+        response_headers: None,
+        response_body,
+    };
+
     let request_model = body
         .get("model")
         .and_then(|v| v.as_str())
@@ -64,7 +79,19 @@ pub async fn embeddings_proxy(
         .filter(|v| !v.is_empty())
         .map(ToString::to_string);
     let Some(request_model) = request_model else {
-        return error_response(400, "model is required");
+        let msg = "model is required";
+        emit_log(
+            &gw, "openai", "openai", "", "",
+            None, "",
+            400, start.elapsed().as_millis() as f64,
+            TokenUsage::default(), false, false,
+            Some(msg.to_string()), None,
+            base_extras(
+                Some(serde_json::json!({ "error": { "message": msg } }).to_string()),
+                None,
+            ),
+        );
+        return error_response(400, msg);
     };
 
     let route = {
@@ -72,45 +99,92 @@ pub async fn embeddings_proxy(
         cache.match_route(&request_model).cloned()
     };
     let Some(route) = route else {
-        return error_response(404, &format!("no route for model: {request_model}"));
-    };
-    if !route.is_embedding_route() {
-        return error_response(
-            400,
-            &format!(
-                "route '{}' is type='{}', embeddings endpoint requires type='embedding'",
-                route.virtual_model,
-                route.normalized_route_type()
+        let msg = format!("no route for model: {request_model}");
+        emit_log(
+            &gw, "openai", "openai", &request_model, "",
+            None, "",
+            404, start.elapsed().as_millis() as f64,
+            TokenUsage::default(), false, false,
+            Some(msg.clone()), None,
+            base_extras(
+                Some(serde_json::json!({ "error": { "message": msg.clone() } }).to_string()),
+                None,
             ),
         );
+        return error_response(404, &msg);
+    };
+    if !route.is_embedding_route() {
+        let msg = format!(
+            "route '{}' is type='{}', embeddings endpoint requires type='embedding'",
+            route.virtual_model,
+            route.normalized_route_type()
+        );
+        emit_log(
+            &gw, "openai", "openai", &request_model, "",
+            None, "",
+            400, start.elapsed().as_millis() as f64,
+            TokenUsage::default(), false, false,
+            Some(msg.clone()), None,
+            base_extras(
+                Some(serde_json::json!({ "error": { "message": msg.clone() } }).to_string()),
+                None,
+            ),
+        );
+        return error_response(400, &msg);
     }
 
     let access_store = GatewayProxyAccessStore::new(&gw);
     let auth_key = match authorize_route_access(&access_store, &route, &headers).await {
         Ok(v) => v,
-        Err(resp) => return resp,
+        Err(resp) => {
+            let status = resp.status().as_u16() as i32;
+            emit_log(
+                &gw, "openai", "openai", &request_model, "",
+                None, "",
+                status, start.elapsed().as_millis() as f64,
+                TokenUsage::default(), false, false,
+                Some(format!("authorization failed: {status}")), None,
+                base_extras(None, None),
+            );
+            return resp;
+        }
     };
 
     let targets = load_route_targets(&gw, &route).await;
     if targets.is_empty() {
-        return error_response(503, "no route targets configured");
+        let msg = "no route targets configured";
+        emit_log(
+            &gw, "openai", "openai", &request_model, "",
+            auth_key.id.as_deref(), "",
+            503, start.elapsed().as_millis() as f64,
+            TokenUsage::default(), false, false,
+            Some(msg.to_string()), None,
+            base_extras(None, None),
+        );
+        return error_response(503, msg);
     }
     let ordered_targets = TargetSelector::select_ordered(&route.strategy, &targets);
-    let start = Instant::now();
     let mut last_error: Option<Response> = None;
+    let mut last_error_message: Option<String> = None;
+    let mut last_error_status: i32 = 502;
+    let mut last_error_body: Option<String> = None;
+    let mut last_error_provider: String = String::new();
+    let mut last_actual_model: String = request_model.clone();
     for target in ordered_targets {
         let provider = match get_provider(&access_store, &target.provider_id).await {
             Ok(p) => p,
             Err(_) => continue,
         };
         let Some(openai_base_url) = resolve_openai_base_url(&provider) else {
-            last_error = Some(error_response(
-                400,
-                &format!(
-                    "embedding route target provider '{}' does not expose an openai endpoint",
-                    provider.name
-                ),
-            ));
+            let msg = format!(
+                "embedding route target provider '{}' does not expose an openai endpoint",
+                provider.name
+            );
+            last_error_message = Some(msg.clone());
+            last_error_status = 400;
+            last_error_body = Some(serde_json::json!({ "error": { "message": msg.clone() } }).to_string());
+            last_error_provider = provider.name.clone();
+            last_error = Some(error_response(400, &msg));
             continue;
         };
         let actual_model = if target.model.is_empty() || target.model == "*" {
@@ -118,14 +192,31 @@ pub async fn embeddings_proxy(
         } else {
             target.model.clone()
         };
+        last_actual_model = actual_model.clone();
         if let Some(obj) = body.as_object_mut() {
             obj.insert("model".into(), Value::String(actual_model.clone()));
         }
+        let forwarded_body_str = serde_json::to_string(&body).ok();
         let adapter = adapter::get_adapter(&provider, Protocol::OpenAI);
         let client = match gw.http_client_for_provider(provider.use_proxy).await {
             Ok(http_client) => ProxyClient::new(http_client),
             Err(e) => {
-                last_error = Some(error_response(502, &format!("provider transport error: {e}")));
+                let msg = format!("provider transport error: {e}");
+                emit_log(
+                    &gw, "openai", "openai", &request_model, &actual_model,
+                    auth_key.id.as_deref(), &provider.name,
+                    502, start.elapsed().as_millis() as f64,
+                    TokenUsage::default(), false, false,
+                    Some(msg.clone()), None,
+                    base_extras(
+                        Some(serde_json::json!({ "error": { "message": msg.clone() } }).to_string()),
+                        forwarded_body_str.clone(),
+                    ),
+                );
+                last_error = Some(error_response(502, &msg));
+                last_error_message = Some(msg);
+                last_error_status = 502;
+                last_error_provider = provider.name.clone();
                 continue;
             }
         };
@@ -133,7 +224,7 @@ pub async fn embeddings_proxy(
             .call_non_stream(
                 adapter.as_ref(),
                 &openai_base_url,
-                "/v1/embeddings",
+                EMB_PATH,
                 &provider.api_key,
                 body.clone(),
                 reqwest::header::HeaderMap::new(),
@@ -141,6 +232,8 @@ pub async fn embeddings_proxy(
             .await;
         match call {
             Ok((payload, status)) if status < 400 => {
+                let usage = parse_embedding_usage(&payload);
+                let payload_str = serde_json::to_string(&payload).ok();
                 emit_log(
                     &gw,
                     "openai",
@@ -151,11 +244,12 @@ pub async fn embeddings_proxy(
                     &provider.name,
                     status as i32,
                     start.elapsed().as_millis() as f64,
-                    TokenUsage::default(),
+                    usage,
                     false,
                     false,
                     None,
                     None,
+                    base_extras(payload_str, forwarded_body_str),
                 );
                 return (
                     StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
@@ -164,17 +258,71 @@ pub async fn embeddings_proxy(
                     .into_response();
             }
             Ok((payload, status)) => {
+                let payload_str = serde_json::to_string(&payload).ok();
+                emit_log(
+                    &gw, "openai", "openai", &request_model, &actual_model,
+                    auth_key.id.as_deref(), &provider.name,
+                    status as i32, start.elapsed().as_millis() as f64,
+                    TokenUsage::default(), false, false,
+                    Some(format!("upstream {status}")), None,
+                    base_extras(payload_str.clone(), forwarded_body_str.clone()),
+                );
+                last_error_status = status as i32;
+                last_error_message = Some(format!("upstream {status}"));
+                last_error_body = payload_str;
+                last_error_provider = provider.name.clone();
                 last_error = Some((
                     StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
                     Json(payload),
                 ).into_response());
             }
             Err(e) => {
+                let msg = format!("upstream error: {e}");
+                emit_log(
+                    &gw, "openai", "openai", &request_model, &actual_model,
+                    auth_key.id.as_deref(), &provider.name,
+                    502, start.elapsed().as_millis() as f64,
+                    TokenUsage::default(), false, false,
+                    Some(msg.clone()), None,
+                    base_extras(
+                        Some(serde_json::json!({ "error": { "message": msg.clone() } }).to_string()),
+                        forwarded_body_str.clone(),
+                    ),
+                );
+                last_error_status = 502;
+                last_error_message = Some(msg.clone());
+                last_error_body = Some(serde_json::json!({ "error": { "message": msg } }).to_string());
+                last_error_provider = provider.name.clone();
                 last_error = Some(error_response(502, &format!("upstream error: {e}")));
             }
         }
     }
-    last_error.unwrap_or_else(|| error_response(502, "all route targets failed"))
+    // Fallthrough: all targets failed.
+    if last_error.is_none() {
+        let msg = "all route targets failed";
+        emit_log(
+            &gw, "openai", "openai", &request_model, &last_actual_model,
+            auth_key.id.as_deref(), &last_error_provider,
+            last_error_status, start.elapsed().as_millis() as f64,
+            TokenUsage::default(), false, false,
+            last_error_message.or(Some(msg.to_string())), None,
+            base_extras(last_error_body, None),
+        );
+        return error_response(502, msg);
+    }
+    last_error.unwrap()
+}
+
+fn parse_embedding_usage(payload: &Value) -> TokenUsage {
+    let prompt = payload
+        .get("usage")
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    TokenUsage {
+        input_tokens: prompt.max(0) as u32,
+        output_tokens: 0,
+    }
 }
 
 // ── Anthropic ingress: POST /v1/messages ──
@@ -184,7 +332,7 @@ pub async fn anthropic_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::Anthropic).await
+    universal_proxy(gw, headers, body, Protocol::Anthropic, "/v1/messages").await
 }
 
 // ── Gemini ingress: POST /v1beta/models/:model_action ──
@@ -200,14 +348,56 @@ pub async fn gemini_proxy(
         None => (model_action.clone(), "generateContent".to_string()),
     };
     let is_stream = action == "streamGenerateContent";
+    let path = format!("/v1beta/models/{model_action}");
 
+    let request_headers = headers_to_json(&headers);
+    let request_body = serde_json::to_string(&body).ok();
     let decoder = GeminiDecoder;
     let internal = match decoder.decode_with_model(body, &model, is_stream) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid Gemini request: {e}")),
+        Err(e) => {
+            emit_log(
+                &gw,
+                "gemini",
+                "gemini",
+                &model,
+                &model,
+                None,
+                "",
+                400,
+                0.0,
+                TokenUsage::default(),
+                false,
+                false,
+                Some(format!("invalid Gemini request: {e}")),
+                None,
+                LogExtras {
+                    method: Some("POST".to_string()),
+                    path: Some(path.clone()),
+                    request_headers: request_headers.clone(),
+                    request_body: request_body.clone(),
+                    response_headers: None,
+                    response_body: Some(
+                        serde_json::json!({ "error": { "message": format!("invalid Gemini request: {e}") } })
+                            .to_string(),
+                    ),
+                },
+            );
+            return error_response(400, &format!("invalid Gemini request: {e}"));
+        }
     };
 
-    proxy_pipeline(gw, headers, internal, Protocol::Gemini).await
+    proxy_pipeline(
+        gw,
+        headers,
+        internal,
+        Protocol::Gemini,
+        "POST",
+        &path,
+        request_headers,
+        request_body,
+    )
+    .await
 }
 
 // ── OpenAI models list ingress: GET /v1/models ──
@@ -264,14 +454,60 @@ pub async fn models_list(State(gw): State<Gateway>, headers: HeaderMap) -> Respo
 
 // ── Universal proxy pipeline ──
 
-async fn universal_proxy(gw: Gateway, headers: HeaderMap, body: Value, ingress: Protocol) -> Response {
+async fn universal_proxy(
+    gw: Gateway,
+    headers: HeaderMap,
+    body: Value,
+    ingress: Protocol,
+    path: &'static str,
+) -> Response {
+    let request_headers = headers_to_json(&headers);
+    let request_body = serde_json::to_string(&body).ok();
     let decoder = crate::protocol::get_decoder(ingress);
     let internal = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid request: {e}")),
+        Err(e) => {
+            let ingress_str = ingress.to_string();
+            let error_body = serde_json::json!({ "error": { "message": format!("invalid request: {e}") } }).to_string();
+            emit_log(
+                &gw,
+                &ingress_str,
+                &ingress_str,
+                "",
+                "",
+                None,
+                "",
+                400,
+                0.0,
+                TokenUsage::default(),
+                false,
+                false,
+                Some(format!("invalid request: {e}")),
+                None,
+                LogExtras {
+                    method: Some("POST".into()),
+                    path: Some(path.to_string()),
+                    request_headers: request_headers.clone(),
+                    request_body: request_body.clone(),
+                    response_headers: None,
+                    response_body: Some(error_body),
+                },
+            );
+            return error_response(400, &format!("invalid request: {e}"));
+        }
     };
 
-    proxy_pipeline(gw, headers, internal, ingress).await
+    proxy_pipeline(
+        gw,
+        headers,
+        internal,
+        ingress,
+        "POST",
+        path,
+        request_headers,
+        request_body,
+    )
+    .await
 }
 
 async fn proxy_pipeline(
@@ -279,7 +515,13 @@ async fn proxy_pipeline(
     headers: HeaderMap,
     internal: InternalRequest,
     ingress: Protocol,
+    method: &str,
+    path: &str,
+    request_headers_str: Option<String>,
+    request_body_str: Option<String>,
 ) -> Response {
+    let method_owned = method.to_string();
+    let path_owned = path.to_string();
     let start = Instant::now();
     let request_model = internal.model.clone();
     let is_stream = internal.stream;
@@ -291,23 +533,103 @@ async fn proxy_pipeline(
     };
     let route = match route {
         Some(r) => r,
-        None => return error_response(404, &format!("no route for model: {request_model}")),
+        None => {
+            let msg = format!("no route for model: {request_model}");
+            emit_log(
+                &gw,
+                &ingress_str,
+                &ingress_str,
+                &request_model,
+                "",
+                None,
+                "",
+                404,
+                start.elapsed().as_millis() as f64,
+                TokenUsage::default(),
+                is_stream,
+                false,
+                Some(msg.clone()),
+                None,
+                LogExtras {
+                    method: Some(method_owned.clone()),
+                    path: Some(path_owned.clone()),
+                    request_headers: request_headers_str.clone(),
+                    request_body: request_body_str.clone(),
+                    response_headers: None,
+                    response_body: Some(
+                        serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
+                    ),
+                },
+            );
+            return error_response(404, &msg);
+        }
     };
     if route.is_embedding_route() {
-        return error_response(
-            400,
-            &format!(
-                "route '{}' is type='embedding', use /v1/embeddings",
-                route.virtual_model
-            ),
+        let msg = format!(
+            "route '{}' is type='embedding', use /v1/embeddings",
+            route.virtual_model
         );
+        emit_log(
+            &gw,
+            &ingress_str,
+            &ingress_str,
+            &request_model,
+            "",
+            None,
+            "",
+            400,
+            start.elapsed().as_millis() as f64,
+            TokenUsage::default(),
+            is_stream,
+            false,
+            Some(msg.clone()),
+            None,
+            LogExtras {
+                method: Some(method_owned.clone()),
+                path: Some(path_owned.clone()),
+                request_headers: request_headers_str.clone(),
+                request_body: request_body_str.clone(),
+                response_headers: None,
+                response_body: Some(
+                    serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
+                ),
+            },
+        );
+        return error_response(400, &msg);
     }
 
     let access_store = GatewayProxyAccessStore::new(&gw);
 
     let auth_key = match authorize_route_access(&access_store, &route, &headers).await {
         Ok(v) => v,
-        Err(resp) => return resp,
+        Err(resp) => {
+            let status = resp.status().as_u16() as i32;
+            emit_log(
+                &gw,
+                &ingress_str,
+                &ingress_str,
+                &request_model,
+                "",
+                None,
+                "",
+                status,
+                start.elapsed().as_millis() as f64,
+                TokenUsage::default(),
+                is_stream,
+                false,
+                Some(format!("authorization failed: {status}")),
+                None,
+                LogExtras {
+                    method: Some(method_owned.clone()),
+                    path: Some(path_owned.clone()),
+                    request_headers: request_headers_str.clone(),
+                    request_body: request_body_str.clone(),
+                    response_headers: None,
+                    response_body: None,
+                },
+            );
+            return resp;
+        }
     };
 
     let cache_config = gw.effective_cache_config().await;
@@ -356,6 +678,7 @@ async fn proxy_pipeline(
                         cache_config.exact.stream_replay_tps,
                         cache_config.exact.expose_headers,
                     );
+                    let cached_usage = cached_entry.usage.clone();
                     emit_log(
                         &gw,
                         &ingress_str,
@@ -366,11 +689,19 @@ async fn proxy_pipeline(
                         &cached_entry.provider_name,
                         cached_entry.status_code as i32,
                         start.elapsed().as_millis() as f64,
-                        cached_entry.usage,
+                        cached_usage,
                         is_stream,
                         false,
                         None,
                         None,
+                        LogExtras {
+                            method: Some(method_owned.clone()),
+                            path: Some(path_owned.clone()),
+                            request_headers: request_headers_str.clone(),
+                            request_body: request_body_str.clone(),
+                            response_headers: None,
+                            response_body: serde_json::to_string(&cached_entry.payload).ok(),
+                        },
                     );
                     return response;
                 }
@@ -398,6 +729,7 @@ async fn proxy_pipeline(
                                     cache_config.exact.stream_replay_tps,
                                     cache_config.exact.expose_headers,
                                 );
+                                let cached_usage = cached_entry.usage.clone();
                                 emit_log(
                                     &gw,
                                     &ingress_str,
@@ -408,11 +740,19 @@ async fn proxy_pipeline(
                                     &cached_entry.provider_name,
                                     cached_entry.status_code as i32,
                                     start.elapsed().as_millis() as f64,
-                                    cached_entry.usage,
+                                    cached_usage,
                                     is_stream,
                                     false,
                                     None,
                                     None,
+                                    LogExtras {
+                                        method: Some(method_owned.clone()),
+                                        path: Some(path_owned.clone()),
+                                        request_headers: request_headers_str.clone(),
+                                        request_body: request_body_str.clone(),
+                                        response_headers: None,
+                                        response_body: serde_json::to_string(&cached_entry.payload).ok(),
+                                    },
                                 );
                                 return response;
                             }
@@ -457,6 +797,7 @@ async fn proxy_pipeline(
                                 cache_config.semantic.stream_replay_tps,
                                 cache_config.semantic.expose_headers,
                             );
+                            let cached_usage = cached_entry.usage.clone();
                             emit_log(
                                 &gw,
                                 &ingress_str,
@@ -467,11 +808,19 @@ async fn proxy_pipeline(
                                 &cached_entry.provider_name,
                                 cached_entry.status_code as i32,
                                 start.elapsed().as_millis() as f64,
-                                cached_entry.usage,
+                                cached_usage,
                                 is_stream,
                                 false,
                                 None,
                                 None,
+                                LogExtras {
+                                    method: Some(method_owned.clone()),
+                                    path: Some(path_owned.clone()),
+                                    request_headers: request_headers_str.clone(),
+                                    request_body: request_body_str.clone(),
+                                    response_headers: None,
+                                    response_body: serde_json::to_string(&cached_entry.payload).ok(),
+                                },
                             );
                             return response;
                         }
@@ -500,10 +849,58 @@ async fn proxy_pipeline(
 
     let targets = load_route_targets(&gw, &route).await;
     if targets.is_empty() {
+        emit_log(
+            &gw,
+            &ingress_str,
+            &ingress_str,
+            &request_model,
+            "",
+            auth_key.id.as_deref(),
+            "",
+            503,
+            start.elapsed().as_millis() as f64,
+            TokenUsage::default(),
+            is_stream,
+            false,
+            Some("no route targets configured".to_string()),
+            None,
+            LogExtras {
+                method: Some(method_owned.clone()),
+                path: Some(path_owned.clone()),
+                request_headers: request_headers_str.clone(),
+                request_body: request_body_str.clone(),
+                response_headers: None,
+                response_body: None,
+            },
+        );
         return error_response(503, "no route targets configured");
     }
     let ordered_targets = TargetSelector::select_ordered(&route.strategy, &targets);
     if ordered_targets.is_empty() {
+        emit_log(
+            &gw,
+            &ingress_str,
+            &ingress_str,
+            &request_model,
+            "",
+            auth_key.id.as_deref(),
+            "",
+            503,
+            start.elapsed().as_millis() as f64,
+            TokenUsage::default(),
+            is_stream,
+            false,
+            Some("no route targets configured".to_string()),
+            None,
+            LogExtras {
+                method: Some(method_owned.clone()),
+                path: Some(path_owned.clone()),
+                request_headers: request_headers_str.clone(),
+                request_body: request_body_str.clone(),
+                response_headers: None,
+                response_body: None,
+            },
+        );
         return error_response(503, "no route targets configured");
     }
 
@@ -601,6 +998,10 @@ async fn proxy_pipeline(
                 singleflight_leader.as_ref().map(|(k, _)| k.as_str()),
                 singleflight_leader.as_ref().map(|(_, tx)| tx.clone()),
                 miss_expose_headers,
+                &method_owned,
+                &path_owned,
+                request_headers_str.clone(),
+                request_body_str.clone(),
             )
             .await
         } else {
@@ -627,6 +1028,10 @@ async fn proxy_pipeline(
                 Some(exact_ttl),
                 semantic_write_ctx.clone(),
                 miss_expose_headers,
+                &method_owned,
+                &path_owned,
+                request_headers_str.clone(),
+                request_body_str.clone(),
             )
             .await
         };
@@ -649,7 +1054,33 @@ async fn proxy_pipeline(
     }
 
     finalize_singleflight(&gw, singleflight_leader.as_ref(), false).await;
-    last_response.unwrap_or_else(|| error_response(502, "all route targets failed"))
+    last_response.unwrap_or_else(|| {
+        emit_log(
+            &gw,
+            &ingress_str,
+            &ingress_str,
+            &request_model,
+            "",
+            auth_key.id.as_deref(),
+            "",
+            502,
+            start.elapsed().as_millis() as f64,
+            TokenUsage::default(),
+            is_stream,
+            false,
+            Some("all route targets failed".to_string()),
+            None,
+            LogExtras {
+                method: Some(method_owned.clone()),
+                path: Some(path_owned.clone()),
+                request_headers: request_headers_str.clone(),
+                request_body: request_body_str.clone(),
+                response_headers: None,
+                response_body: None,
+            },
+        );
+        error_response(502, "all route targets failed")
+    })
 }
 
 
@@ -677,8 +1108,20 @@ async fn handle_non_stream(
     exact_cache_ttl: Option<Duration>,
     semantic_write_ctx: Option<SemanticWriteContext>,
     expose_headers: bool,
+    ingress_method: &str,
+    ingress_path: &str,
+    request_headers_str: Option<String>,
+    request_body_str: Option<String>,
 ) -> Response {
     let credential_to_use = credential.to_string();
+    let make_extras = |response_body: Option<String>| LogExtras {
+        method: Some(ingress_method.to_string()),
+        path: Some(ingress_path.to_string()),
+        request_headers: request_headers_str.clone(),
+        request_body: request_body_str.clone(),
+        response_headers: None,
+        response_body,
+    };
     let call_result = match client
         .call_non_stream(
             adapter,
@@ -698,6 +1141,9 @@ async fn handle_non_stream(
                 &provider.name, 502, start.elapsed().as_millis() as f64,
                 TokenUsage::default(), false, false,
                 Some(e.to_string()), None,
+                make_extras(Some(
+                    serde_json::json!({ "error": { "message": format!("upstream error: {e}") } }).to_string(),
+                )),
             );
             return error_response(502, &format!("upstream error: {e}"));
         }
@@ -706,13 +1152,15 @@ async fn handle_non_stream(
     let (resp, status) = call_result;
 
     if status >= 400 {
-        let preview = serde_json::to_string(&resp).ok().map(|s| s.chars().take(500).collect());
+        let body_str = serde_json::to_string(&resp).ok();
+        let preview = body_str.as_ref().map(|s| s.chars().take(500).collect());
         emit_log(
             &gw, ingress_str, egress_str, request_model, actual_model,
             api_key_id,
             &provider.name, status as i32, start.elapsed().as_millis() as f64,
             TokenUsage::default(), false, false,
-            preview.clone(), None,
+            preview, None,
+            make_extras(body_str),
         );
         return (
             StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
@@ -726,7 +1174,19 @@ async fn handle_non_stream(
 
     let mut internal_resp = match parser.parse_response(resp) {
         Ok(r) => r,
-        Err(e) => return error_response(500, &format!("parse error: {e}")),
+        Err(e) => {
+            emit_log(
+                &gw, ingress_str, egress_str, request_model, actual_model,
+                api_key_id,
+                &provider.name, 500, start.elapsed().as_millis() as f64,
+                TokenUsage::default(), false, false,
+                Some(format!("parse error: {e}")), None,
+                make_extras(Some(
+                    serde_json::json!({ "error": { "message": format!("parse error: {e}") } }).to_string(),
+                )),
+            );
+            return error_response(500, &format!("parse error: {e}"));
+        }
     };
     crate::protocol::semantic::reasoning::normalize_response_reasoning(&mut internal_resp);
     crate::protocol::semantic::response_items::populate_response_items(&mut internal_resp);
@@ -735,8 +1195,9 @@ async fn handle_non_stream(
     let usage = internal_resp.usage.clone();
     let output = formatter.format_response(&internal_resp);
 
-    let response_preview = serde_json::to_string(&output)
-        .ok()
+    let response_body_full = serde_json::to_string(&output).ok();
+    let response_preview = response_body_full
+        .as_ref()
         .map(|s| s.chars().take(500).collect());
 
     emit_log(
@@ -744,6 +1205,7 @@ async fn handle_non_stream(
         api_key_id,
         &provider.name, status as i32, start.elapsed().as_millis() as f64,
         usage.clone(), false, is_tool, None, response_preview,
+        make_extras(response_body_full),
     );
 
     let mut response = (
@@ -819,8 +1281,26 @@ async fn handle_stream(
     singleflight_key: Option<&str>,
     singleflight_tx: Option<broadcast::Sender<Vec<u8>>>,
     expose_headers: bool,
+    ingress_method: &str,
+    ingress_path: &str,
+    request_headers_str: Option<String>,
+    request_body_str: Option<String>,
 ) -> Response {
     let credential_to_use = credential.to_string();
+    let make_extras_owned = {
+        let method = ingress_method.to_string();
+        let path_s = ingress_path.to_string();
+        let rh = request_headers_str.clone();
+        let rb = request_body_str.clone();
+        move |response_body: Option<String>| LogExtras {
+            method: Some(method.clone()),
+            path: Some(path_s.clone()),
+            request_headers: rh.clone(),
+            request_body: rb.clone(),
+            response_headers: None,
+            response_body,
+        }
+    };
     let call_result = match client
         .call_stream(
             adapter,
@@ -840,6 +1320,9 @@ async fn handle_stream(
                 &provider.name, 502, start.elapsed().as_millis() as f64,
                 TokenUsage::default(), true, false,
                 Some(e.to_string()), None,
+                make_extras_owned(Some(
+                    serde_json::json!({ "error": { "message": format!("upstream error: {e}") } }).to_string(),
+                )),
             );
             return error_response(502, &format!("upstream error: {e}"));
         }
@@ -852,12 +1335,14 @@ async fn handle_stream(
             .json()
             .await
             .unwrap_or_else(|_| serde_json::json!({"error": {"message": "upstream error"}}));
+        let err_body_str = serde_json::to_string(&err_body).ok();
         emit_log(
             &gw, ingress_str, egress_str, request_model, actual_model,
             api_key_id,
             &provider.name, status as i32, start.elapsed().as_millis() as f64,
             TokenUsage::default(), true, false,
             Some(err_body.to_string()), None,
+            make_extras_owned(err_body_str),
         );
         return (
             StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
@@ -884,6 +1369,10 @@ async fn handle_stream(
     let leader_tx_owned = singleflight_tx.clone();
     let exact_cache_ttl_owned = exact_cache_ttl;
     let semantic_write_ctx_owned = semantic_write_ctx.clone();
+    let ingress_method_owned = ingress_method.to_string();
+    let ingress_path_owned = ingress_path.to_string();
+    let request_headers_owned = request_headers_str.clone();
+    let request_body_owned = request_body_str.clone();
 
     tokio::spawn(async move {
         let mut accumulator = StreamResponseAccumulator::default();
@@ -932,11 +1421,24 @@ async fn handle_stream(
             internal.stop_reason = Some("stop".to_string());
         }
 
+        // For streaming responses, aggregate the final internal response and render
+        // an equivalent non-streaming JSON for response_body logging.
+        let aggregated_formatter = crate::protocol::get_response_formatter(ingress);
+        let aggregated_output = aggregated_formatter.format_response(&internal);
+        let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
         emit_log(
             &gw_log, &ingress_s, &egress_s, &req_model, &act_model,
             key_id.as_deref(),
             &provider_name, 200, start.elapsed().as_millis() as f64,
             internal.usage.clone(), true, !internal.tool_calls.is_empty(), None, None,
+            LogExtras {
+                method: Some(ingress_method_owned.clone()),
+                path: Some(ingress_path_owned.clone()),
+                request_headers: request_headers_owned.clone(),
+                request_body: request_body_owned.clone(),
+                response_headers: None,
+                response_body: aggregated_body_str,
+            },
         );
 
         let mut singleflight_payload: Option<Vec<u8>> = None;
@@ -1786,6 +2288,17 @@ async fn resolve_provider_credential(gw: &Gateway, provider: &Provider) -> anyho
     Ok(provider.api_key.clone())
 }
 
+#[derive(Default, Clone)]
+pub(crate) struct LogExtras {
+    pub method: Option<String>,
+    pub path: Option<String>,
+    pub request_headers: Option<String>,
+    pub request_body: Option<String>,
+    pub response_headers: Option<String>,
+    pub response_body: Option<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
 fn emit_log(
     gw: &Gateway,
     ingress: &str,
@@ -1801,6 +2314,7 @@ fn emit_log(
     is_tool_call: bool,
     error_message: Option<String>,
     response_preview: Option<String>,
+    extras: LogExtras,
 ) {
     let _ = gw.log_tx.try_send(LogEntry {
         api_key_id: api_key_id.map(ToString::to_string),
@@ -1816,5 +2330,32 @@ fn emit_log(
         is_tool_call,
         error_message,
         response_preview,
+        method: extras.method,
+        path: extras.path,
+        request_headers: extras.request_headers,
+        request_body: extras.request_body,
+        response_headers: extras.response_headers,
+        response_body: extras.response_body,
     });
+}
+
+/// Serialize an axum HeaderMap to a flat JSON object string.
+fn headers_to_json(headers: &HeaderMap) -> Option<String> {
+    let mut map = serde_json::Map::with_capacity(headers.len());
+    for (name, value) in headers.iter() {
+        let val = value
+            .to_str()
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or_else(|_| Value::String(format!("0x{}", hex_encode(value.as_bytes()))));
+        map.insert(name.as_str().to_ascii_lowercase(), val);
+    }
+    serde_json::to_string(&Value::Object(map)).ok()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use tokio::sync::RwLock;
 
 use crate::db::models::{
-    CreateProvider, CreateRoute, LogPage, LogQuery, ModelStats, Provider, ProviderStats, Route,
-    StatsHourly, StatsOverview, UpdateProvider, UpdateRoute,
+    CreateProvider, CreateRoute, LogPage, LogQuery, ModelStats, Provider, ProviderStats,
+    RequestLog, Route, StatsHourly, StatsOverview, UpdateProvider, UpdateRoute,
 };
 use crate::logging::LogEntry;
 
@@ -187,6 +187,10 @@ impl LogStore for MemoryStorage {
             items: vec![],
             total: 0,
         })
+    }
+
+    async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<RequestLog>> {
+        Ok(None)
     }
 
     async fn cleanup_before(&self, _cutoff: &str) -> anyhow::Result<u64> {

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -837,8 +837,9 @@ impl LogStore for PostgresLogStore {
                 r#"INSERT INTO request_logs
                     (id, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model,
                      provider_name, status_code, duration_ms, input_tokens, output_tokens,
-                     is_stream, is_tool_call, error_message, response_preview)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)"#,
+                     is_stream, is_tool_call, error_message, response_preview,
+                     method, path, request_headers, request_body, response_headers, response_body)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)"#,
             )
             .bind(&id)
             .bind(&entry.api_key_id)
@@ -855,6 +856,12 @@ impl LogStore for PostgresLogStore {
             .bind(entry.is_tool_call)
             .bind(&entry.error_message)
             .bind(&entry.response_preview)
+            .bind(&entry.method)
+            .bind(&entry.path)
+            .bind(&entry.request_headers)
+            .bind(&entry.request_body)
+            .bind(&entry.response_headers)
+            .bind(&entry.response_body)
             .execute(&self.pool)
             .await?;
         }
@@ -863,8 +870,9 @@ impl LogStore for PostgresLogStore {
 
     async fn query(&self, query: LogQuery) -> anyhow::Result<LogPage> {
         let mut count_sql = String::from("SELECT COUNT(*) AS total FROM request_logs WHERE 1=1");
+        // List query skips heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
-            "SELECT id, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview FROM request_logs WHERE 1=1",
+            "SELECT id, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, NULL::text AS request_headers, NULL::text AS request_body, NULL::text AS response_headers, NULL::text AS response_body FROM request_logs WHERE 1=1",
         );
         let mut idx = 1;
         let mut bind_values: Vec<String> = Vec::new();
@@ -913,6 +921,16 @@ impl LogStore for PostgresLogStore {
             .fetch_all(&self.pool)
             .await?;
         Ok(LogPage { items, total })
+    }
+
+    async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
+        let row = sqlx::query_as::<_, RequestLog>(
+            "SELECT id, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, request_headers, request_body, response_headers, response_body FROM request_logs WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
     }
 
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64> {
@@ -1402,8 +1420,21 @@ CREATE TABLE IF NOT EXISTS request_logs (
     is_stream BOOLEAN DEFAULT FALSE,
     is_tool_call BOOLEAN DEFAULT FALSE,
     error_message TEXT,
-    response_preview TEXT
+    response_preview TEXT,
+    method TEXT,
+    path TEXT,
+    request_headers TEXT,
+    request_body TEXT,
+    response_headers TEXT,
+    response_body TEXT
 );
+
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS method TEXT;
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS path TEXT;
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS request_headers TEXT;
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS request_body TEXT;
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS response_headers TEXT;
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS response_body TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at);
 CREATE INDEX IF NOT EXISTS idx_logs_provider ON request_logs(provider_name);

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -878,8 +878,9 @@ impl LogStore for SqliteLogStore {
                 r#"INSERT INTO request_logs
                     (id, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model,
                      provider_name, status_code, duration_ms, input_tokens, output_tokens,
-                     is_stream, is_tool_call, error_message, response_preview)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                     is_stream, is_tool_call, error_message, response_preview,
+                     method, path, request_headers, request_body, response_headers, response_body)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
             )
             .bind(&id)
             .bind(&entry.api_key_id)
@@ -896,6 +897,12 @@ impl LogStore for SqliteLogStore {
             .bind(entry.is_tool_call as i32)
             .bind(&entry.error_message)
             .bind(&entry.response_preview)
+            .bind(&entry.method)
+            .bind(&entry.path)
+            .bind(&entry.request_headers)
+            .bind(&entry.request_body)
+            .bind(&entry.response_headers)
+            .bind(&entry.response_body)
             .execute(&self.pool)
             .await?;
         }
@@ -904,8 +911,9 @@ impl LogStore for SqliteLogStore {
 
     async fn query(&self, query: LogQuery) -> anyhow::Result<LogPage> {
         let mut count_sql = String::from("SELECT COUNT(*) AS total FROM request_logs WHERE 1=1");
+        // List query skips the heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
-            "SELECT id, created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview FROM request_logs WHERE 1=1",
+            "SELECT id, created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, NULL AS request_headers, NULL AS request_body, NULL AS response_headers, NULL AS response_body FROM request_logs WHERE 1=1",
         );
         let mut bind_values: Vec<String> = Vec::new();
         if let Some(provider) = query.provider.filter(|v| !v.is_empty()) {
@@ -943,6 +951,16 @@ impl LogStore for SqliteLogStore {
             .fetch_all(&self.pool)
             .await?;
         Ok(LogPage { items, total })
+    }
+
+    async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
+        let row = sqlx::query_as::<_, RequestLog>(
+            "SELECT id, created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, request_headers, request_body, response_headers, response_body FROM request_logs WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
     }
 
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64> {

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 
 use crate::db::models::{
     ApiKeyWithBindings, CreateApiKey, CreateProvider, CreateRoute, CreateRouteTarget, LogPage,
-    LogQuery, ModelStats, Provider, ProviderStats, Route, RouteTarget, StatsHourly, StatsOverview,
-    UpdateApiKey, UpdateProvider, UpdateRoute,
+    LogQuery, ModelStats, Provider, ProviderStats, RequestLog, Route, RouteTarget, StatsHourly,
+    StatsOverview, UpdateApiKey, UpdateProvider, UpdateRoute,
 };
 use crate::logging::LogEntry;
 
@@ -119,6 +119,7 @@ pub trait AuthAccessStore: Send + Sync {
 pub trait LogStore: Send + Sync {
     async fn append_batch(&self, entries: Vec<LogEntry>) -> anyhow::Result<()>;
     async fn query(&self, query: LogQuery) -> anyhow::Result<LogPage>;
+    async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>>;
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64>;
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview>;
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>>;

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -64,6 +64,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .route("/api-keys", get(list_api_keys_handler).post(create_api_key_handler))
         .route("/api-keys/:id", api_keys_item)
         .route("/logs", get(query_logs_handler))
+        .route("/logs/:id", get(get_log_handler))
         .route("/stats/overview", get(stats_overview))
         .route("/stats/hourly", get(stats_hourly))
         .route("/stats/models", get(stats_by_model))
@@ -293,6 +294,17 @@ struct LogQueryParams {
     model: Option<String>,
     status_min: Option<i32>,
     status_max: Option<i32>,
+}
+
+async fn get_log_handler(
+    State(gw): State<Gateway>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    match gw.admin().get_log(&id).await {
+        Ok(Some(v)) => Json(serde_json::json!({ "data": v })).into_response(),
+        Ok(None) => (axum::http::StatusCode::NOT_FOUND, Json(serde_json::json!({ "error": "not found" }))).into_response(),
+        Err(e) => err(e),
+    }
 }
 
 async fn query_logs_handler(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -155,6 +155,11 @@ pub async fn query_logs(gw: State<'_, Gateway>, query: LogQuery) -> Result<LogPa
     gw.admin().query_logs(query).await.map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn get_log(gw: State<'_, Gateway>, id: String) -> Result<Option<RequestLog>, String> {
+    gw.admin().get_log(&id).await.map_err(|e| e.to_string())
+}
+
 // ── Stats ──
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ pub fn run() {
             commands::update_api_key,
             commands::delete_api_key,
             commands::query_logs,
+            commands::get_log,
             commands::get_stats_overview,
             commands::get_stats_hourly,
             commands::get_stats_by_model,

--- a/webui/src/components/log-detail-dialog.tsx
+++ b/webui/src/components/log-detail-dialog.tsx
@@ -1,0 +1,199 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Check, Copy, Loader2 } from "lucide-react";
+
+import { backend } from "@/lib/backend";
+import { useLocale } from "@/lib/i18n";
+import type { RequestLog } from "@/lib/types";
+import { formatDuration, formatLogTime, formatTokenCount, tryPrettyJson } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface LogDetailDialogProps {
+  logId: string | null;
+  summary?: RequestLog | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function LogDetailDialog({ logId, summary, open, onOpenChange }: LogDetailDialogProps) {
+  const { locale } = useLocale();
+  const isZh = locale === "zh-CN";
+
+  const { data, isLoading } = useQuery<RequestLog | null>({
+    queryKey: ["log-detail", logId],
+    queryFn: () => backend("get_log", { id: logId! }),
+    enabled: open && !!logId,
+  });
+
+  const log = data ?? summary ?? null;
+
+  const method = log?.method ?? "–";
+  const path = log?.path ?? "–";
+  const statusCode = log?.status_code;
+  const statusOk = (statusCode ?? 0) < 400;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(92vw,960px)] max-h-[88vh] overflow-hidden flex flex-col gap-4">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span>{isZh ? "请求详情" : "Request Detail"}</span>
+            {isLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" /> : null}
+          </DialogTitle>
+          <DialogDescription>
+            {log ? formatLogTime(log.created_at) : ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <Badge variant="outline" className="font-mono">{method}</Badge>
+          <span className="font-mono text-slate-600 break-all">{path}</span>
+          <span
+            className={cn(
+              "inline-flex rounded-full px-2 py-0.5 font-medium",
+              statusOk ? "bg-green-50 text-green-700" : "bg-red-50 text-red-600",
+            )}
+          >
+            {statusCode ?? "–"}
+          </span>
+          {log?.is_stream ? (
+            <Badge variant="outline" className="border-green-200 bg-green-50 text-green-700">
+              SSE
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700">
+              JSON
+            </Badge>
+          )}
+          {log?.provider_name ? (
+            <Badge variant="outline">{log.provider_name}</Badge>
+          ) : null}
+          {log?.actual_model ? (
+            <span className="text-slate-500 font-mono">{log.actual_model}</span>
+          ) : null}
+          {log?.duration_ms != null ? (
+            <span className="text-slate-500">{formatDuration(log.duration_ms)}</span>
+          ) : null}
+          {log ? (
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-flex items-center gap-1 text-sky-600">
+                <span className="text-[10px] font-semibold tracking-wide">IN</span>
+                <span title={String(log.input_tokens)}>
+                  {formatTokenCount(log.input_tokens)}
+                </span>
+              </span>
+              <span className="inline-flex items-center gap-1 text-emerald-600">
+                <span className="text-[10px] font-semibold tracking-wide">OUT</span>
+                <span title={String(log.output_tokens)}>
+                  {formatTokenCount(log.output_tokens)}
+                </span>
+              </span>
+            </span>
+          ) : null}
+          {log?.ingress_protocol || log?.egress_protocol ? (
+            <span className="text-slate-400">
+              {log?.ingress_protocol ?? "–"} → {log?.egress_protocol ?? "–"}
+            </span>
+          ) : null}
+        </div>
+
+        {log?.error_message ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+            {log.error_message}
+          </div>
+        ) : null}
+
+        <div className="flex-1 space-y-3 overflow-y-auto pr-1">
+          <PayloadBlock
+            title={isZh ? "请求头" : "Request Headers"}
+            content={log?.request_headers}
+            isZh={isZh}
+          />
+          <PayloadBlock
+            title={isZh ? "请求体" : "Request Body"}
+            content={log?.request_body}
+            isZh={isZh}
+          />
+          <PayloadBlock
+            title={isZh ? "响应头" : "Response Headers"}
+            content={log?.response_headers}
+            isZh={isZh}
+          />
+          <PayloadBlock
+            title={isZh ? "响应体" : "Response Body"}
+            content={log?.response_body}
+            isZh={isZh}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PayloadBlockProps {
+  title: string;
+  content: string | null | undefined;
+  isZh: boolean;
+}
+
+function PayloadBlock({ title, content, isZh }: PayloadBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const pretty = tryPrettyJson(content);
+  const hasContent = !!(content && content.trim());
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(t);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    if (!hasContent) return;
+    try {
+      await navigator.clipboard.writeText(pretty);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50/60">
+      <div className="flex items-center justify-between border-b border-slate-200 px-3 py-1.5">
+        <span className="text-xs font-medium text-slate-600">{title}</span>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          disabled={!hasContent}
+          onClick={handleCopy}
+          className="h-7 gap-1 px-2 text-xs"
+        >
+          {copied ? (
+            <>
+              <Check className="h-3.5 w-3.5" />
+              {isZh ? "已复制" : "Copied"}
+            </>
+          ) : (
+            <>
+              <Copy className="h-3.5 w-3.5" />
+              {isZh ? "复制" : "Copy"}
+            </>
+          )}
+        </Button>
+      </div>
+      <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all px-3 py-2 font-mono text-[11px] leading-relaxed text-slate-700">
+        {hasContent ? pretty : <span className="text-slate-400">{isZh ? "（无内容）" : "(empty)"}</span>}
+      </pre>
+    </div>
+  );
+}

--- a/webui/src/lib/format.ts
+++ b/webui/src/lib/format.ts
@@ -1,0 +1,47 @@
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return "–";
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(2)} s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)} m`;
+  return `${(ms / 3_600_000).toFixed(1)} h`;
+}
+
+export function formatLogTime(createdAt: string | null | undefined): string {
+  if (!createdAt) return "–";
+  const normalized = createdAt.includes("T") ? createdAt : createdAt.replace(" ", "T") + "Z";
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) return createdAt;
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  const ss = String(date.getSeconds()).padStart(2, "0");
+  return `${mm}/${dd} ${hh}:${mi}:${ss}`;
+}
+
+export function formatTokenCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "0";
+  const n = Math.max(0, Math.floor(value));
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+export function tryPrettyJson(raw: string | null | undefined): string {
+  if (raw == null) return "";
+  if (typeof raw !== "string") {
+    try {
+      return JSON.stringify(raw, null, 2);
+    } catch {
+      return String(raw);
+    }
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) return raw;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -75,6 +75,17 @@ export interface RequestLog {
   is_stream: boolean;
   is_tool_call: boolean;
   error_message?: string;
+  response_preview?: string;
+  method?: string;
+  path?: string;
+  request_headers?: string;
+  request_body?: string;
+  response_headers?: string;
+  response_body?: string;
+}
+
+export function getRouteType(log: Pick<RequestLog, "path">): "chat" | "embedding" {
+  return log.path === "/v1/embeddings" ? "embedding" : "chat";
 }
 
 export interface LogPage {

--- a/webui/src/pages/logs.tsx
+++ b/webui/src/pages/logs.tsx
@@ -1,10 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, ScrollText } from "lucide-react";
+
 import { backend } from "@/lib/backend";
-import type { LogPage, LogQuery, Provider } from "@/lib/types";
-import { ScrollText, ChevronLeft, ChevronRight } from "lucide-react";
+import type { LogPage, LogQuery, Provider, RequestLog } from "@/lib/types";
+import { getRouteType } from "@/lib/types";
+import { formatDuration, formatLogTime, formatTokenCount } from "@/lib/format";
+import { cn } from "@/lib/utils";
 import { useLocale } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -12,29 +17,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { LogDetailDialog } from "@/components/log-detail-dialog";
 
-const PAGE_SIZE = 12;
+const PAGE_SIZE = 11;
 const ALL_OPTION = "__all__";
 
 export default function LogsPage() {
   const { locale } = useLocale();
   const isZh = locale === "zh-CN";
-  const dateTimeFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(isZh ? "zh-CN" : "en-US", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: false,
-      }),
-    [isZh],
-  );
 
   const [page, setPage] = useState(0);
   const [filter, setFilter] = useState<LogQuery>({ limit: PAGE_SIZE, offset: 0 });
+  const [selected, setSelected] = useState<RequestLog | null>(null);
 
   const query: LogQuery = { ...filter, limit: PAGE_SIZE, offset: page * PAGE_SIZE };
 
@@ -51,13 +45,11 @@ export default function LogsPage() {
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
   const providerOptions = useMemo(
     () => [
       { value: "", label: isZh ? "全部提供商" : "All Providers" },
-      ...providers.map((provider) => ({
-        value: provider.name,
-        label: provider.name,
-      })),
+      ...providers.map((p) => ({ value: p.name, label: p.name })),
     ],
     [providers, isZh],
   );
@@ -69,6 +61,7 @@ export default function LogsPage() {
     ],
     [isZh],
   );
+
   const providerFilterValue = filter.provider ?? ALL_OPTION;
   const statusFilterValue =
     (filter.status_min ?? null) === 200 && (filter.status_max ?? null) === 299
@@ -76,16 +69,6 @@ export default function LogsPage() {
       : (filter.status_min ?? null) === 400 && (filter.status_max ?? null) == null
         ? "error"
         : ALL_OPTION;
-  const formatLogTime = (value: string | undefined) => {
-    if (!value) return "–";
-    const normalized = value.includes("T") ? value : value.replace(" ", "T");
-    const hasZone = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(normalized);
-    const parsed = new Date(hasZone ? normalized : `${normalized}Z`);
-    if (Number.isNaN(parsed.getTime())) {
-      return value.replace("T", " ").slice(0, 19);
-    }
-    return dateTimeFormatter.format(parsed);
-  };
 
   return (
     <div className="space-y-5">
@@ -155,49 +138,112 @@ export default function LogsPage() {
             <table className="w-full text-sm">
               <thead className="border-b border-slate-200/80 bg-slate-50/50 text-slate-500">
                 <tr>
-                  <th className="px-4 py-3 text-left font-medium">{isZh ? "时间" : "Time"}</th>
-                  <th className="px-4 py-3 text-left font-medium">{isZh ? "模型" : "Model"}</th>
-                  <th className="px-4 py-3 text-left font-medium">{isZh ? "提供商" : "Provider"}</th>
-                  <th className="px-4 py-3 text-left font-medium">{isZh ? "协议" : "Protocol"}</th>
-                  <th className="px-4 py-3 text-center font-medium">{isZh ? "状态" : "Status"}</th>
-                  <th className="px-4 py-3 text-right font-medium">{isZh ? "延迟" : "Latency"}</th>
-                  <th className="px-4 py-3 text-right font-medium">{isZh ? "Token" : "Tokens"}</th>
-                  <th className="px-4 py-3 text-center font-medium">{isZh ? "流式" : "Stream"}</th>
+                  <th className="px-3 py-2.5 text-left font-medium whitespace-nowrap">
+                    {isZh ? "时间" : "Time"}
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium">
+                    {isZh ? "状态" : "Status"}
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium">
+                    {isZh ? "模型" : "Model"}
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium">
+                    {isZh ? "协议" : "Protocol"}
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium">
+                    {isZh ? "耗时" : "Latency"}
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium">Token</th>
+                  <th className="px-3 py-2.5 text-left font-medium">
+                    {isZh ? "类型" : "Type"}
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {items.map((log) => (
-                  <tr key={log.id} className="border-t border-slate-100 text-slate-700 hover:bg-slate-50/50">
-                    <td className="px-4 py-2.5 text-xs text-slate-500 whitespace-nowrap">
-                      {formatLogTime(log.created_at)}
-                    </td>
-                    <td className="px-4 py-2.5 font-medium">{log.actual_model ?? "–"}</td>
-                    <td className="px-4 py-2.5">{log.provider_name ?? "–"}</td>
-                    <td className="px-4 py-2.5">
-                      <span className="text-xs text-slate-500">
-                        {log.ingress_protocol} → {log.egress_protocol}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-center">
-                      <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                        (log.status_code ?? 0) < 400
-                          ? "bg-green-50 text-green-700"
-                          : "bg-red-50 text-red-600"
-                      }`}>
-                        {log.status_code ?? "–"}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-xs">
-                      {log.duration_ms != null ? `${log.duration_ms.toFixed(0)}ms` : "–"}
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-xs">
-                      {log.input_tokens + log.output_tokens}
-                    </td>
-                    <td className="px-4 py-2.5 text-center text-xs">
-                      {log.is_stream ? "SSE" : "–"}
-                    </td>
-                  </tr>
-                ))}
+                {items.map((log) => {
+                  const routeType = getRouteType(log);
+                  const statusOk = (log.status_code ?? 0) < 400;
+                  return (
+                    <tr
+                      key={log.id}
+                      onClick={() => setSelected(log)}
+                      className="cursor-pointer border-t border-slate-100 text-slate-700 transition-colors hover:bg-slate-50"
+                    >
+                      <td className="px-3 py-2 text-xs text-slate-500 whitespace-nowrap">
+                        {formatLogTime(log.created_at)}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={cn(
+                            "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
+                            statusOk ? "bg-green-50 text-green-700" : "bg-red-50 text-red-600",
+                          )}
+                        >
+                          {log.status_code ?? "–"}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex flex-col leading-tight">
+                          <span className="text-xs font-medium text-slate-800">
+                            {log.request_model ?? "–"}
+                          </span>
+                          <span className="text-[11px] text-slate-500">
+                            {log.provider_name ?? "–"}
+                            {log.actual_model ? `: ${log.actual_model}` : ""}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                          <span>
+                            {(log.ingress_protocol ?? "–")} → {(log.egress_protocol ?? "–")}
+                          </span>
+                          {routeType === "embedding" ? (
+                            <Badge variant="outline" className="text-[10px]">EMB</Badge>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">
+                        {formatDuration(log.duration_ms)}
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex flex-col items-start leading-tight text-[11px] tabular-nums">
+                          <span className="inline-flex items-center gap-1 text-sky-600">
+                            <span className="font-semibold tracking-wide">IN</span>
+                            <span title={String(log.input_tokens)}>
+                              {formatTokenCount(log.input_tokens)}
+                            </span>
+                          </span>
+                          {routeType === "embedding" && log.output_tokens === 0 ? null : (
+                            <span className="inline-flex items-center gap-1 text-emerald-600">
+                              <span className="font-semibold tracking-wide">OUT</span>
+                              <span title={String(log.output_tokens)}>
+                                {formatTokenCount(log.output_tokens)}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        {log.is_stream ? (
+                          <Badge
+                            variant="outline"
+                            className="border-green-200 bg-green-50 text-[10px] text-green-700"
+                          >
+                            SSE
+                          </Badge>
+                        ) : (
+                          <Badge
+                            variant="outline"
+                            className="border-sky-200 bg-sky-50 text-[10px] text-sky-700"
+                          >
+                            JSON
+                          </Badge>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -227,6 +273,15 @@ export default function LogsPage() {
           </div>
         </div>
       )}
+
+      <LogDetailDialog
+        logId={selected?.id ?? null}
+        summary={selected}
+        open={!!selected}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      />
     </div>
   );
 }

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -12,6 +12,7 @@ import type {
 import { useLocale } from "@/lib/i18n";
 import {
   Download,
+  HelpCircle,
   Upload,
   Save,
   Loader2,
@@ -22,6 +23,33 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+function HelpHint({ text }: { text: string }) {
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex h-4 w-4 items-center justify-center text-slate-400 hover:text-slate-600"
+            aria-label="help"
+          >
+            <HelpCircle className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 function ToggleStatusLabel({ enabled, isZh }: { enabled: boolean; isZh: boolean }) {
   return (
@@ -49,6 +77,10 @@ export default function SettingsPage() {
     queryKey: ["setting", "log_retention_days"],
     queryFn: () => backend("get_setting", { key: "log_retention_days" }),
   });
+  const { data: logRecordPayloadsSetting } = useQuery<string | null>({
+    queryKey: ["setting", "log_record_payloads"],
+    queryFn: () => backend("get_setting", { key: "log_record_payloads" }),
+  });
   const { data: proxyEnabledSetting } = useQuery<string | null>({
     queryKey: ["setting", "proxy_enabled"],
     queryFn: () => backend("get_setting", { key: "proxy_enabled" }),
@@ -71,9 +103,12 @@ export default function SettingsPage() {
   });
 
   const [retentionInput, setRetentionInput] = useState<string>("");
-  const retentionBaseline = (retentionDays ?? "30").trim();
+  const retentionBaseline = (retentionDays ?? "7").trim();
   const retentionCurrent = retentionInput.trim();
   const retentionDirty = retentionCurrent !== retentionBaseline;
+  const logRecordPayloadsEnabled = !["false", "0", "off", "no"].includes(
+    (logRecordPayloadsSetting ?? "true").trim().toLowerCase(),
+  );
   const [proxyEnabled, setProxyEnabled] = useState(false);
   const [proxyUrl, setProxyUrl] = useState("");
   const [proxyBypass, setProxyBypass] = useState("");
@@ -132,7 +167,7 @@ export default function SettingsPage() {
   }, [normalizedProxyEnabledSetting, proxyUrlSetting, proxyBypassSetting]);
 
   useEffect(() => {
-    setRetentionInput(retentionDays ?? "30");
+    setRetentionInput(retentionDays ?? "7");
   }, [retentionDays]);
 
   useEffect(() => {
@@ -156,6 +191,14 @@ export default function SettingsPage() {
     mutationFn: (value: string) =>
       backend("set_setting", { key: "log_retention_days", value }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["setting", "log_retention_days"] }),
+    onError: (error: unknown) => {
+      showErrorDialog("保存设置失败", "Failed to save settings", error);
+    },
+  });
+  const saveLogRecordPayloads = useMutation({
+    mutationFn: (value: boolean) =>
+      backend("set_setting", { key: "log_record_payloads", value: value ? "true" : "false" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["setting", "log_record_payloads"] }),
     onError: (error: unknown) => {
       showErrorDialog("保存设置失败", "Failed to save settings", error);
     },
@@ -646,23 +689,24 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      <div className="glass rounded-2xl p-6 space-y-5">
-        <h2 className="text-lg font-semibold text-slate-900">{isZh ? "代理配置" : "Proxy Configuration"}</h2>
-        <div className="rounded-xl bg-slate-50 p-4 space-y-3">
-          <div className="space-y-1.5">
-            <label className="ml-1 text-xs text-slate-700">{isZh ? "代理" : "Proxy"}</label>
-            <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
-              <div className="flex items-center gap-2">
-                <ToggleStatusLabel enabled={proxyEnabled} isZh={isZh} />
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        {/* Proxy Configuration */}
+        <div className="glass rounded-2xl p-6 space-y-5">
+          <h2 className="text-lg font-semibold text-slate-900">{isZh ? "代理配置" : "Proxy Configuration"}</h2>
+          <div className="rounded-xl bg-slate-50 p-4 space-y-3">
+            <div className="space-y-1.5">
+              <label className="ml-1 text-xs text-slate-700">{isZh ? "代理" : "Proxy"}</label>
+              <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <ToggleStatusLabel enabled={proxyEnabled} isZh={isZh} />
+                </div>
+                <Switch
+                  checked={proxyEnabled}
+                  disabled={saveProxyToggle.isPending}
+                  onCheckedChange={setProxyEnabled}
+                />
               </div>
-              <Switch
-                checked={proxyEnabled}
-                disabled={saveProxyToggle.isPending}
-                onCheckedChange={setProxyEnabled}
-              />
             </div>
-          </div>
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
             <div className="space-y-1.5">
               <label className="ml-1 text-xs text-slate-700">{isZh ? "代理 URL" : "Proxy URL"}</label>
               <Input
@@ -679,141 +723,150 @@ export default function SettingsPage() {
                 onChange={(e) => setProxyBypass(e.target.value)}
               />
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              onClick={handleSaveProxy}
-              disabled={saveProxyToggle.isPending || !proxyDirty}
-              size="sm"
-              className="flex items-center gap-1.5"
-            >
-              {saveProxyToggle.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Save className="h-3.5 w-3.5" />
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={handleSaveProxy}
+                disabled={saveProxyToggle.isPending || !proxyDirty}
+                size="sm"
+                className="flex items-center gap-1.5"
+              >
+                {saveProxyToggle.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                {isZh ? "保存" : "Save"}
+              </Button>
+              {proxyDirty && (
+                <p className="text-xs text-amber-600">
+                  {isZh ? "配置已修改，保存后生效" : "Unsaved changes, save to apply"}
+                </p>
               )}
-              {isZh ? "保存" : "Save"}
-            </Button>
-            {proxyDirty && (
-              <p className="text-xs text-amber-600">
-                {isZh ? "配置已修改，保存后生效" : "Unsaved changes, save to apply"}
-              </p>
-            )}
+            </div>
+          </div>
+        </div>
+
+        {/* Log Configuration */}
+        <div className="glass rounded-2xl p-6 space-y-5">
+          <h2 className="text-lg font-semibold text-slate-900">{isZh ? "日志配置" : "Log Configuration"}</h2>
+          <div className="rounded-xl bg-slate-50 p-4 space-y-3">
+            <div className="space-y-1.5">
+              <label className="ml-1 flex items-center gap-1 text-xs text-slate-700">
+                {isZh ? "保留时长（天）" : "Retention Period (days)"}
+                <HelpHint
+                  text={
+                    isZh
+                      ? "自动删除超过设置时长的日志"
+                      : "Auto-delete logs older than the configured period"
+                  }
+                />
+              </label>
+              <Input
+                type="number"
+                min={1}
+                max={365}
+                value={retentionInput}
+                onChange={(e) => setRetentionInput(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="ml-1 flex items-center gap-1 text-xs text-slate-700">
+                {isZh ? "记录 Payloads" : "Record Payloads"}
+                <HelpHint
+                  text={
+                    isZh
+                      ? "关闭后不再记录请求头、请求体、响应头和响应体"
+                      : "When off, request/response headers and bodies are no longer recorded"
+                  }
+                />
+              </label>
+              <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <ToggleStatusLabel enabled={logRecordPayloadsEnabled} isZh={isZh} />
+                </div>
+                <Switch
+                  checked={logRecordPayloadsEnabled}
+                  disabled={saveLogRecordPayloads.isPending}
+                  onCheckedChange={(checked) => saveLogRecordPayloads.mutate(checked)}
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => saveSetting.mutate(retentionInput)}
+                disabled={saveSetting.isPending || !retentionDirty}
+                size="sm"
+                className="flex items-center gap-1.5"
+              >
+                {saveSetting.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                {isZh ? "保存" : "Save"}
+              </Button>
+              {retentionDirty ? (
+                <p className="text-xs text-amber-600">
+                  {isZh ? "配置已修改，保存后生效" : "Unsaved changes, save to apply"}
+                </p>
+              ) : saveSetting.isSuccess ? (
+                <p className="text-xs text-green-600">{isZh ? "保存成功" : "Saved successfully"}</p>
+              ) : null}
+            </div>
           </div>
         </div>
       </div>
 
-      {/* Log Retention & Config */}
+      {/* Config Backup */}
       <div className="glass rounded-2xl p-6 space-y-5">
-        <h2 className="text-lg font-semibold text-slate-900">{isZh ? "其他配置" : "Other Configuration"}</h2>
-
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-          {/* Log Retention */}
-          <div className="rounded-xl bg-slate-50 p-4">
-            <div className="flex h-full flex-col">
-              <div className="space-y-3">
-                <div>
-                  <p className="text-sm font-medium text-slate-700">{isZh ? "日志保留" : "Log Retention"}</p>
-                  <p className="text-xs text-slate-500">
-                    {isZh ? "自动删除超过 N 天的日志" : "Auto-delete logs older than N days"}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Input
-                    type="number"
-                    min={1}
-                    max={365}
-                    value={retentionInput}
-                    onChange={(e) => setRetentionInput(e.target.value)}
-                    className="w-24"
-                  />
-                  <span className="text-sm text-slate-500">{isZh ? "天" : "days"}</span>
-                  <Button
-                    onClick={() => saveSetting.mutate(retentionInput)}
-                    disabled={saveSetting.isPending || !retentionDirty}
-                    size="sm"
-                    className="ml-auto flex items-center gap-1.5"
-                  >
-                    {saveSetting.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Save className="h-3.5 w-3.5" />
-                    )}
-                    {isZh ? "保存" : "Save"}
-                  </Button>
-                </div>
-              </div>
-              <div className="mt-1 min-h-[0.875rem]">
-                {retentionDirty ? (
-                  <p className="text-xs text-amber-600">
-                    {isZh ? "配置已修改，保存后生效" : "Unsaved changes, save to apply"}
-                  </p>
-                ) : saveSetting.isSuccess ? (
-                  <p className="text-xs text-green-600">{isZh ? "保存成功" : "Saved successfully"}</p>
-                ) : null}
-              </div>
-            </div>
+        <h2 className="text-lg font-semibold text-slate-900">{isZh ? "配置备份" : "Config Backup"}</h2>
+        <div className="flex flex-wrap items-center gap-3 rounded-xl bg-slate-50 px-4 py-3">
+          <p className="text-xs text-slate-500">
+            {isZh ? "导出或导入提供商、路由和设置" : "Export or import providers, routes & settings"}
+          </p>
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              onClick={() => exportMut.mutate()}
+              disabled={exportMut.isPending}
+              size="sm"
+              className="flex items-center gap-1.5"
+            >
+              {exportMut.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
+              {isZh ? "导出" : "Export"}
+            </Button>
+            <Button
+              onClick={() => fileRef.current?.click()}
+              disabled={importMut.isPending}
+              variant="secondary"
+              size="sm"
+              className="flex items-center gap-1.5"
+            >
+              {importMut.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Upload className="h-3.5 w-3.5" />
+              )}
+              {isZh ? "导入" : "Import"}
+            </Button>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".json"
+              className="hidden"
+              onChange={handleImportFile}
+            />
           </div>
-
-          {/* Import / Export */}
-          <div className="rounded-xl bg-slate-50 p-4">
-            <div className="flex h-full flex-col">
-              <div className="space-y-3">
-                <div>
-                  <p className="text-sm font-medium text-slate-700">{isZh ? "配置备份" : "Config Backup"}</p>
-                  <p className="text-xs text-slate-500">
-                    {isZh ? "导出或导入提供商、路由和设置" : "Export or import providers, routes & settings"}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    onClick={() => exportMut.mutate()}
-                    disabled={exportMut.isPending}
-                    size="sm"
-                    className="flex items-center gap-1.5"
-                  >
-                    {exportMut.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Download className="h-3.5 w-3.5" />
-                    )}
-                    {isZh ? "导出" : "Export"}
-                  </Button>
-                  <Button
-                    onClick={() => fileRef.current?.click()}
-                    disabled={importMut.isPending}
-                    variant="secondary"
-                    size="sm"
-                    className="flex items-center gap-1.5"
-                  >
-                    {importMut.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Upload className="h-3.5 w-3.5" />
-                    )}
-                    {isZh ? "导入" : "Import"}
-                  </Button>
-                  <input
-                    ref={fileRef}
-                    type="file"
-                    accept=".json"
-                    className="hidden"
-                    onChange={handleImportFile}
-                  />
-                </div>
-              </div>
-              <div className="mt-2 min-h-4">
-                {importMut.isSuccess && importMut.data && (
-                  <p className="text-xs text-green-600">
-                    {isZh
-                      ? `已导入：${(importMut.data as ImportResult).providers_imported} 个提供商，${(importMut.data as ImportResult).routes_imported} 条路由，${(importMut.data as ImportResult).settings_imported} 项设置`
-                      : `Imported: ${(importMut.data as ImportResult).providers_imported} providers, ${(importMut.data as ImportResult).routes_imported} routes, ${(importMut.data as ImportResult).settings_imported} settings`}
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-
+          {importMut.isSuccess && importMut.data && (
+            <p className="w-full text-xs text-green-600">
+              {isZh
+                ? `已导入：${(importMut.data as ImportResult).providers_imported} 个提供商，${(importMut.data as ImportResult).routes_imported} 条路由，${(importMut.data as ImportResult).settings_imported} 项设置`
+                : `Imported: ${(importMut.data as ImportResult).providers_imported} providers, ${(importMut.data as ImportResult).routes_imported} routes, ${(importMut.data as ImportResult).settings_imported} settings`}
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Backend:
- Extend request_logs schema with method, path, request_headers, request_body, response_headers, response_body (SQLite + Postgres migrations via ensure_request_log_column / ALTER TABLE IF NOT EXISTS)
- Capture ingress method/path/headers/body across universal, gemini and embeddings proxy entrypoints; aggregate final JSON for streaming responses and persist as response_body
- Emit logs on all early-exit error paths (decode failure, no route, auth failure, upstream error, cache miss fallbacks) with full context
- Cache-hit paths now include complete request/response bodies
- Embeddings proxy: log every success/error branch and parse usage.prompt_tokens into input_tokens
- Split API: query_logs list strips heavy fields (NULL bodies/headers); new get_log(id) endpoint fetches full payload on demand
- Settings: DEFAULT_RETENTION_DAYS 30 -> 7, batch size 64 -> 32, cleanup interval 60s -> 600s; new log_record_payloads toggle (default true) to disable payload persistence

Frontend:
- Compact 7-column log list (Time / Status / Model / Protocol / Latency / Token / Type), left-aligned, row click opens detail
- New LogDetailDialog with meta header and four copy-enabled payload blocks (request headers/body, response headers/body) using lazy get_log fetch and pretty-printed JSON
- Token display with IN/OUT labels and K/M formatting (<1000 raw, <1M 1-decimal K, >=1M 2-decimal M)
- Type badge: green SSE / sky JSON replaces boolean stream column
- Settings: split Log Configuration into its own half-width card next to Proxy Configuration; rename to "Retention Period" + "Record Payloads" with HelpCircle tooltips; tighten Config Backup layout

FIX #62 