### PR TITLE
chore(release): prepare v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Nyro will be documented in this file.
 
 ---
 
+## v1.6.2
+
+> Released on 2026-04-19
+
+#### Features
+
+- **Request/response payload logging**: extend `request_logs` schema with `method`, `path`, `request_headers`, `request_body`, `response_headers`, `response_body` (non-breaking migrations for SQLite + Postgres via `ensure_request_log_column` / `ALTER TABLE IF NOT EXISTS`); capture ingress payloads across universal, Gemini and embeddings proxy entrypoints; aggregate streaming responses into a final JSON and persist as `response_body`; emit logs on all early-exit paths (decode failure, no route, auth failure, upstream error, cache-miss fallbacks) with full context; cache-hit paths now carry complete request/response bodies; embeddings proxy parses `usage.prompt_tokens` into `input_tokens`
+- **Redesigned log viewer**: compact 7-column list (Time / Status / Model / Protocol / Latency / Token / Type) with left-aligned rows and click-to-open detail dialog; new `LogDetailDialog` with meta header and four copy-enabled payload blocks (request headers/body, response headers/body) using lazy `get_log(id)` fetch and pretty-printed JSON; Token displayed with IN/OUT labels and K/M formatting (<1000 raw, <1M one-decimal K, ≥1M two-decimal M); green SSE / sky JSON type badges replace the boolean stream column; Settings page splits Log Configuration into its own half-width card next to Proxy Configuration with HelpCircle tooltips
+- **Log payload persistence toggle**: new `log_record_payloads` setting (default `true`) to disable request/response body storage for sensitive-data deployments
+
+#### Improvements
+
+- **Standalone provider config ergonomics**: `default_protocol` is now optional and auto-inferred from the first declared `endpoints` entry when omitted; add aliases `protocol` (for `default_protocol`) and `apikey` (for `api_key`); switch `endpoints` to `IndexMap` to preserve YAML declaration order; reject conflicting canonical + alias pairs (`default_protocol` + `protocol`, `api_key` + `apikey`) at deserialization time via `YamlProviderRaw` + `TryFrom`; emit a WARN log when protocol is inferred from multiple endpoints
+- **Log retention defaults rebalanced**: `DEFAULT_RETENTION_DAYS` 30 → 7, batch size 64 → 32, cleanup interval 60s → 600s to reduce storage growth and cleanup churn
+- **Split log API**: `query_logs` list now strips heavy fields (NULL bodies/headers); new `get_log(id)` endpoint fetches the full payload on demand
+
+#### Fixes
+
+- Fix `release-server` workflow missing `webui/dist` at compile time: `#[derive(RustEmbed)]` expansion failed because `WebUiAssets::get` was absent; add Node 20 + pnpm 9 setup and run `pnpm -C webui install/build` before `cargo build`
+
+---
+
 ## v1.6.1
 
 > Released on 2026-04-14

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -4,6 +4,28 @@ Nyro 的所有重要变更均记录在此文件中。
 
 ---
 
+## v1.6.2
+
+> 发布于 2026-04-19
+
+#### 功能
+
+- **请求/响应载荷日志**：扩展 `request_logs` 表结构，新增 `method`、`path`、`request_headers`、`request_body`、`response_headers`、`response_body` 字段，SQLite 与 Postgres 均提供非破坏性迁移（`ensure_request_log_column` / `ALTER TABLE IF NOT EXISTS`）；在 universal、Gemini、Embeddings 代理入口统一捕获入口请求方法/路径/头部/Body；流式响应聚合为完整 JSON 后持久化为 `response_body`；所有早退出路径（解码失败、无路由、鉴权失败、上游错误、缓存回退）均落库完整上下文；缓存命中路径同样携带完整请求/响应 Body；Embeddings 解析 `usage.prompt_tokens` 作为 `input_tokens`
+- **日志查看器重构**：紧凑 7 列列表（时间 / 状态 / 模型 / 协议 / 延迟 / Token / 类型），行点击打开详情；新增 `LogDetailDialog`，含元信息头部与 4 个可复制的请求/响应头与 Body 面板，通过 `get_log(id)` 按需懒加载完整载荷并格式化 JSON；Token 以 IN/OUT 标签与 K/M 格式展示（<1000 原值、<1M 保留一位 K、≥1M 保留两位 M）；SSE（绿）/JSON（天蓝）类型徽标替代布尔 stream 列；设置页将日志配置拆分为独立半宽卡片，与代理配置并列，新增 HelpCircle 提示
+- **日志载荷持久化开关**：新增 `log_record_payloads` 设置项（默认 `true`），可在敏感数据场景下关闭请求/响应 Body 的存储
+
+#### 改进
+
+- **Standalone Provider 配置体验优化**：`default_protocol` 改为可选，未设置时自动取 `endpoints` 声明顺序的首个协议；新增别名 `protocol`（对应 `default_protocol`）与 `apikey`（对应 `api_key`）；`endpoints` 切换为 `IndexMap` 保留 YAML 声明顺序；通过 `YamlProviderRaw` + `TryFrom` 在反序列化阶段拒绝规范名与别名同时出现（`default_protocol` + `protocol`、`api_key` + `apikey`）；多 endpoint 下未显式声明协议时输出 WARN 日志提示
+- **日志保留默认值调整**：`DEFAULT_RETENTION_DAYS` 30 → 7 天、批大小 64 → 32、清理周期 60s → 600s，降低存储增长与清理抖动
+- **日志接口拆分**：列表 `query_logs` 现已剔除重型字段（bodies/headers 置 NULL）；新增 `get_log(id)` 接口按需拉取完整载荷
+
+#### 修复
+
+- 修复 `release-server` 工作流编译期缺失 `webui/dist` 的问题：`#[derive(RustEmbed)]` 展开失败导致 `WebUiAssets::get` 缺失；新增 Node 20 + pnpm 9 安装步骤，并在 `cargo build` 之前执行 `pnpm -C webui install/build`
+
+---
+
 ## v1.6.1
 
 > 发布于 2026-04-14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/nyro-core", "src-tauri", "src-server"]
 
 [workspace.package]
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/nyroway/nyro"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/nicegui/static/tauri/tauri.conf.json",
   "productName": "Nyro",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "identifier": "com.nyro.ai-gateway",
   "build": {
     "frontendDist": "../webui/dist",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nyro-console",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
- Bump workspace, Tauri and webui versions to 1.6.2.
- Document v1.6.2 changes in CHANGELOG.md and CHANGELOG_CN.md:
  - Features: request/response payload logging, redesigned log viewer, log_record_payloads toggle (#63).
  - Improvements: standalone provider config aliases (protocol/apikey) and protocol inference (#57), log retention defaults, split query_logs / get_log API (#63).
  - Fixes: release-server workflow pre-builds webui/dist so RustEmbed can find the assets (#56).