### PR TITLE
refactor(providers): normalize authMode field/values and align OAuth form layout

### DIFF
--- a/crates/nyro-core/assets/providers.json
+++ b/crates/nyro-core/assets/providers.json
@@ -9,7 +9,7 @@
         "id": "default",
         "label": { "zh": "默认", "en": "Default" },
         "capabilitiesSource": "ai://models.dev/",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -25,7 +25,7 @@
         "baseUrls": { "openai": "https://api.openai.com/v1" },
         "modelsSource": "https://api.openai.com/v1/models",
         "capabilitiesSource": "ai://models.dev/openai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       },
       {
         "id": "codex",
@@ -33,7 +33,7 @@
         "baseUrls": { "openai_responses": "https://chatgpt.com/backend-api/codex" },
         "modelsSource": "https://chatgpt.com/backend-api/codex/models",
         "capabilitiesSource": "ai://models.dev/openai",
-        "auth_mode": "oauth",
+        "authMode": "oauth",
         "oauth": {
           "authBaseUrl": "https://auth.openai.com",
           "authorizeUrl": "https://auth.openai.com/oauth/authorize",
@@ -62,7 +62,7 @@
         "baseUrls": { "anthropic": "https://api.anthropic.com" },
         "modelsSource": "https://api.anthropic.com/v1/models",
         "capabilitiesSource": "ai://models.dev/anthropic",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -81,7 +81,7 @@
         },
         "modelsSource": "https://generativelanguage.googleapis.com/v1beta/openai/models",
         "capabilitiesSource": "ai://models.dev/google",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -97,7 +97,7 @@
         "baseUrls": { "openai": "https://api.x.ai/v1" },
         "modelsSource": "https://api.x.ai/v1/models",
         "capabilitiesSource": "ai://models.dev/xai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -116,7 +116,7 @@
         },
         "modelsSource": "https://api.deepseek.com/v1/models",
         "capabilitiesSource": "ai://models.dev/deepseek",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -135,7 +135,7 @@
         },
         "modelsSource": "https://api.moonshot.ai/v1/models",
         "capabilitiesSource": "ai://models.dev/moonshotai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       },
       {
         "id": "china",
@@ -146,7 +146,7 @@
         },
         "modelsSource": "https://api.moonshot.cn/v1/models",
         "capabilitiesSource": "ai://models.dev/moonshotai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -166,7 +166,7 @@
         "modelsSource": "ai://models.dev/minimax",
         "capabilitiesSource": "ai://models.dev/minimax",
         "staticModels": [],
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       },
       {
         "id": "china",
@@ -178,7 +178,7 @@
         "modelsSource": "ai://models.dev/minimax",
         "capabilitiesSource": "ai://models.dev/minimax",
         "staticModels": [],
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -197,7 +197,7 @@
         },
         "modelsSource": "https://open.bigmodel.cn/api/paas/v4/models",
         "capabilitiesSource": "ai://models.dev/zhipuai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       },
       {
         "id": "coding",
@@ -208,7 +208,7 @@
         },
         "modelsSource": "https://open.bigmodel.cn/api/coding/paas/v4/models",
         "capabilitiesSource": "ai://models.dev/zhipuai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -227,7 +227,7 @@
         },
         "modelsSource": "https://api.z.ai/api/paas/v4/models",
         "capabilitiesSource": "ai://models.dev/zai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       },
       {
         "id": "coding",
@@ -238,7 +238,7 @@
         },
         "modelsSource": "https://api.z.ai/api/coding/paas/v4/models",
         "capabilitiesSource": "ai://models.dev/zai",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -256,7 +256,7 @@
         },
         "modelsSource": "https://integrate.api.nvidia.com/v1/models",
         "capabilitiesSource": "ai://models.dev/nvidia",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -275,7 +275,7 @@
         },
         "modelsSource": "https://openrouter.ai/api/v1/models",
         "capabilitiesSource": "https://openrouter.ai/api/v1/models",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   },
@@ -295,7 +295,7 @@
         "apiKey": "sk-ollama",
         "modelsSource": "http://127.0.0.1:11434/v1/models",
         "capabilitiesSource": "http://127.0.0.1:11434/api/show",
-        "auth_mode": "api_key"
+        "authMode": "apikey"
       }
     ]
   }

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -38,7 +38,7 @@ struct ProviderPresetSnapshot {
 #[derive(Debug, Deserialize)]
 struct ProviderChannelPresetSnapshot {
     id: String,
-    #[serde(default = "default_provider_auth_mode")]
+    #[serde(default = "default_provider_auth_mode", rename = "authMode")]
     auth_mode: String,
 }
 
@@ -2419,7 +2419,7 @@ fn resolve_provider_credential(provider: &Provider) -> anyhow::Result<String> {
     let effective_auth_mode = provider.effective_auth_mode();
     let auth_mode = effective_auth_mode.trim();
     let credential = match auth_mode {
-        "api_key" | "" => provider.api_key.trim(),
+        "apikey" | "" => provider.api_key.trim(),
         "oauth" => provider
             .access_token
             .as_deref()
@@ -2437,7 +2437,7 @@ fn resolve_provider_credential(provider: &Provider) -> anyhow::Result<String> {
         anyhow::bail!(
             "provider credential is empty for auth_mode={} ({source})",
             if auth_mode.is_empty() {
-                "api_key"
+                "apikey"
             } else {
                 auth_mode
             }
@@ -2756,7 +2756,7 @@ fn parse_provider_presets_snapshot() -> anyhow::Result<Vec<Value>> {
                     for channel in channels {
                         if let Some(channel_obj) = channel.as_object_mut() {
                             channel_obj
-                                .entry("auth_mode".to_string())
+                                .entry("authMode".to_string())
                                 .or_insert_with(|| Value::String(default_provider_auth_mode()));
                         }
                     }

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -76,7 +76,10 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     migrate_api_key_status_to_is_enabled(pool).await?;
     ensure_route_targets_table(pool).await?;
     ensure_cache_entries_table(pool).await?;
-    ensure_provider_column(pool, "auth_mode", "TEXT NOT NULL DEFAULT 'api_key'").await?;
+    ensure_provider_column(pool, "auth_mode", "TEXT NOT NULL DEFAULT 'apikey'").await?;
+    sqlx::query("UPDATE providers SET auth_mode = 'apikey' WHERE auth_mode = 'api_key'")
+        .execute(pool)
+        .await?;
     ensure_provider_column(pool, "access_token", "TEXT").await?;
     ensure_provider_column(pool, "refresh_token", "TEXT").await?;
     ensure_provider_column(pool, "expires_at", "TEXT").await?;
@@ -434,7 +437,7 @@ CREATE TABLE IF NOT EXISTS providers (
     capabilities_source TEXT,
     static_models TEXT,
     api_key     TEXT NOT NULL,
-    auth_mode   TEXT NOT NULL DEFAULT 'api_key' CHECK (auth_mode IN ('api_key', 'oauth')),
+    auth_mode   TEXT NOT NULL DEFAULT 'apikey' CHECK (auth_mode IN ('apikey', 'oauth')),
     access_token TEXT,
     refresh_token TEXT,
     expires_at  TEXT,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -7,11 +7,11 @@ use sqlx::FromRow;
 const PROVIDER_PRESETS_SNAPSHOT: &str = include_str!("../../assets/providers.json");
 
 pub fn default_provider_auth_mode() -> String {
-    "api_key".to_string()
+    "apikey".to_string()
 }
 
 pub fn is_valid_provider_auth_mode(value: &str) -> bool {
-    matches!(value.trim(), "api_key" | "oauth")
+    matches!(value.trim(), "apikey" | "oauth")
 }
 
 fn resolve_preset_channel_auth_mode(preset_key: Option<&str>, channel_id: Option<&str>) -> Option<String> {
@@ -33,9 +33,9 @@ fn resolve_preset_channel_auth_mode(preset_key: Option<&str>, channel_id: Option
         .or_else(|| channels.iter().find(|item| item.get("id").and_then(Value::as_str) == Some("default")))?;
     Some(
         channel
-            .get("auth_mode")
+            .get("authMode")
             .and_then(Value::as_str)
-            .unwrap_or("api_key")
+            .unwrap_or("apikey")
             .trim()
             .to_string(),
     )

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -1117,7 +1117,7 @@ impl StorageBootstrap for PostgresBootstrap {
         sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS use_proxy BOOLEAN NOT NULL DEFAULT FALSE")
             .execute(self.adapter.pool())
             .await?;
-        sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS auth_mode TEXT NOT NULL DEFAULT 'api_key'")
+        sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS auth_mode TEXT NOT NULL DEFAULT 'apikey'")
             .execute(self.adapter.pool())
             .await?;
         sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS access_token TEXT")
@@ -1127,6 +1127,12 @@ impl StorageBootstrap for PostgresBootstrap {
             .execute(self.adapter.pool())
             .await?;
         sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ")
+            .execute(self.adapter.pool())
+            .await?;
+        sqlx::query("ALTER TABLE providers DROP CONSTRAINT IF EXISTS providers_auth_mode_check")
+            .execute(self.adapter.pool())
+            .await?;
+        sqlx::query("UPDATE providers SET auth_mode = 'apikey' WHERE auth_mode = 'api_key'")
             .execute(self.adapter.pool())
             .await?;
         sqlx::query(
@@ -1139,7 +1145,7 @@ BEGIN
     ) THEN
         ALTER TABLE providers
         ADD CONSTRAINT providers_auth_mode_check
-        CHECK (auth_mode IN ('api_key', 'oauth'));
+        CHECK (auth_mode IN ('apikey', 'oauth'));
     END IF;
 END $$;"#,
         )
@@ -1297,7 +1303,7 @@ fn is_pg_permission_error(error: &anyhow::Error) -> bool {
 
 fn provider_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'api_key') AS auth_mode, access_token, refresh_token, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, COALESCE(use_proxy, FALSE) AS use_proxy, last_test_success, to_char(last_test_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS last_test_at, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM providers",
+        "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'apikey') AS auth_mode, access_token, refresh_token, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, COALESCE(use_proxy, FALSE) AS use_proxy, last_test_success, to_char(last_test_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS last_test_at, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS updated_at FROM providers",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1413,7 +1419,7 @@ CREATE TABLE IF NOT EXISTS providers (
     capabilities_source TEXT,
     static_models TEXT,
     api_key TEXT NOT NULL,
-    auth_mode TEXT NOT NULL DEFAULT 'api_key' CHECK (auth_mode IN ('api_key', 'oauth')),
+    auth_mode TEXT NOT NULL DEFAULT 'apikey' CHECK (auth_mode IN ('apikey', 'oauth')),
     access_token TEXT,
     refresh_token TEXT,
     expires_at TIMESTAMPTZ,

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -127,7 +127,7 @@ struct SqliteProviderStore {
 impl ProviderStore for SqliteProviderStore {
     async fn list(&self) -> anyhow::Result<Vec<Provider>> {
         Ok(sqlx::query_as::<_, Provider>(
-            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'api_key') AS auth_mode, access_token, refresh_token, expires_at, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers ORDER BY created_at DESC",
+            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'apikey') AS auth_mode, access_token, refresh_token, expires_at, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -135,7 +135,7 @@ impl ProviderStore for SqliteProviderStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Provider>> {
         Ok(sqlx::query_as::<_, Provider>(
-            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'api_key') AS auth_mode, access_token, refresh_token, expires_at, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers WHERE id = ?",
+            "SELECT id, name, vendor, protocol, base_url, COALESCE(default_protocol, protocol) AS default_protocol, COALESCE(protocol_endpoints, '{}') AS protocol_endpoints, preset_key, channel, models_source, capabilities_source, static_models, api_key, COALESCE(auth_mode, 'apikey') AS auth_mode, access_token, refresh_token, expires_at, COALESCE(use_proxy, 0) AS use_proxy, last_test_success, last_test_at, COALESCE(is_enabled, 1) AS is_enabled, created_at, updated_at FROM providers WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -341,7 +341,7 @@ pub fn build_providers(yaml: &YamlConfig) -> Vec<Provider> {
                 capabilities_source: yp.capabilities_source.clone(),
                 static_models: yp.static_models.as_ref().map(|v| v.join("\n")),
                 api_key: yp.api_key.clone(),
-                auth_mode: "api_key".to_string(),
+                auth_mode: "apikey".to_string(),
                 access_token: None,
                 refresh_token: None,
                 expires_at: None,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -8,7 +8,7 @@ export interface Provider {
   protocol_endpoints: string;
   api_key?: string;
   use_proxy: boolean;
-  auth_mode?: "api_key" | "oauth";
+  auth_mode?: "apikey" | "oauth";
   oauth_status?: ProviderOAuthStatus;
   oauth_expires_at?: string | null;
   oauth_last_error?: string | null;
@@ -165,7 +165,7 @@ export interface ProviderChannelPreset {
     zh: string;
     en: string;
   };
-  auth_mode?: "api_key" | "oauth";
+  authMode?: "apikey" | "oauth";
   baseUrls: Partial<Record<ProviderProtocol, string>>;
   modelsSource?: string;
   capabilitiesSource?: string;
@@ -193,7 +193,7 @@ export interface CreateProvider {
   default_protocol?: string;
   protocol_endpoints?: string;
   use_proxy?: boolean;
-  auth_mode?: "api_key" | "oauth";
+  auth_mode?: "apikey" | "oauth";
   preset_key?: string;
   channel?: string;
   models_source?: string;
@@ -210,7 +210,7 @@ export interface UpdateProvider {
   default_protocol?: string;
   protocol_endpoints?: string;
   use_proxy?: boolean;
-  auth_mode?: "api_key" | "oauth";
+  auth_mode?: "apikey" | "oauth";
   preset_key?: string;
   channel?: string;
   models_source?: string;

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -74,7 +74,7 @@ const emptyCreate: CreateProvider = {
   protocol: "openai",
   base_url: "https://api.openai.com",
   use_proxy: false,
-  auth_mode: "api_key",
+  auth_mode: "apikey",
   preset_key: "",
   channel: "",
   models_source: "",
@@ -317,14 +317,14 @@ function presetChannels(preset?: ProviderPreset | null) {
 function presetChannelAuthMode(
   preset?: ProviderPreset | null,
   channelId?: string | null,
-): "api_key" | "oauth" {
+): "apikey" | "oauth" {
   const channel = presetChannels(preset).find((item) => item.id === channelId) ?? presetChannels(preset)[0];
-  return channel?.auth_mode === "oauth" ? "oauth" : "api_key";
+  return channel?.authMode === "oauth" ? "oauth" : "apikey";
 }
 
-function normalizeAuthMode(mode?: string | null): "api_key" | "oauth" {
-  if (!mode) return "api_key";
-  return mode.trim().toLowerCase() === "oauth" ? "oauth" : "api_key";
+function normalizeAuthMode(mode?: string | null): "apikey" | "oauth" {
+  if (!mode) return "apikey";
+  return mode.trim().toLowerCase() === "oauth" ? "oauth" : "apikey";
 }
 
 function mergeProviderOAuthStatus(provider: Provider, status: ProviderOAuthStatusData): Provider {
@@ -518,7 +518,7 @@ export default function ProvidersPage() {
     capabilities_source: "",
     static_models: "",
     api_key: "",
-    auth_mode: "api_key",
+    auth_mode: "apikey",
   });
   const [editEndpointRows, setEditEndpointRows] = useState<ProtocolEndpointRow[]>([
     { protocol: "openai", base_url: "https://api.openai.com" },
@@ -984,15 +984,23 @@ export default function ProvidersPage() {
     setEditError(null);
     setShowEditApiKey(false);
     const endpointRows = endpointRowsFromProvider(p);
+    const presetForEdit = providerPresets.find(
+      (item) => item.id === (p.preset_key || DEFAULT_PRESET_ID),
+    );
+    const channel = p.channel || "default";
+    const savedProtocol = (p.default_protocol || p.protocol) as ProviderProtocol;
+    const safeProtocol = presetForEdit
+      ? resolvePresetProtocol(presetForEdit, channel, savedProtocol)
+      : savedProtocol;
     setEditForm({
       id: p.id,
       name: p.name,
       vendor: p.vendor ?? (p.preset_key || undefined),
-      protocol: p.default_protocol || p.protocol,
+      protocol: safeProtocol,
       base_url: p.base_url,
       use_proxy: p.use_proxy,
       preset_key: p.preset_key || DEFAULT_PRESET_ID,
-      channel: p.channel || "default",
+      channel,
       models_source: p.models_source ?? "",
       capabilities_source: p.capabilities_source ?? "",
       static_models: p.static_models ?? "",
@@ -1193,7 +1201,7 @@ export default function ProvidersPage() {
               handlePresetChange(initialPresetId);
             } else {
               setSelectedPresetId("");
-              setForm({ ...emptyCreate, auth_mode: "api_key" });
+              setForm({ ...emptyCreate, auth_mode: "apikey" });
             }
           }}
           className="flex items-center gap-2"
@@ -1290,14 +1298,6 @@ export default function ProvidersPage() {
                     </ToggleGroupItem>
                   ))}
                 </ToggleGroup>
-              </div>
-              <div className="space-y-2">
-                <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
-                <Input
-                  placeholder={isZh ? "例如 OpenAI 生产" : "e.g. OpenAI Production"}
-                  value={form.name}
-                  onChange={(e) => setForm({ ...form, name: e.target.value })}
-                />
               </div>
 {showCreateOAuthGuide ? (
                 <div className="col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -1427,6 +1427,14 @@ export default function ProvidersPage() {
                   </div>
                 </div>
               ) : null}
+              <div className="space-y-2">
+                <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
+                <Input
+                  placeholder={isZh ? "例如 OpenAI 生产" : "e.g. OpenAI Production"}
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                />
+              </div>
               <div className="space-y-2">
                 <FieldLabel>{isZh ? "默认协议" : "Default Protocol"}</FieldLabel>
                 <Select
@@ -1638,7 +1646,7 @@ export default function ProvidersPage() {
                     createMut.isPending
                     || createOAuthMut.isPending
                     || !form.name.trim()
-                    || (createResolvedAuthMode === "api_key" && !form.api_key)
+                    || (createResolvedAuthMode === "apikey" && !form.api_key)
                     || (createResolvedAuthMode === "oauth" && !createOAuthReady)
                   }
                 >
@@ -1821,6 +1829,72 @@ export default function ProvidersPage() {
                         ))}
                       </ToggleGroup>
                     </div>
+                    {editingResolvedAuthMode === "oauth" ? (
+                      <div className="col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-4">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-800">
+                              {isZh ? "OAuth 授权" : "OAuth Authorization"}
+                            </p>
+                            <p className="mt-1 text-xs text-slate-500">
+                              {isZh ? "查看并管理当前 Provider 的 OAuth 授权状态。" : "View and manage the OAuth authorization of this provider."}
+                            </p>
+                          </div>
+                          <Badge variant={editOAuthStatus?.status === "connected" ? "success" : editOAuthStatus?.status === "error" ? "danger" : "secondary"}>
+                            {editOAuthStatusQuery.isLoading
+                              ? (isZh ? "读取中" : "Loading")
+                              : editOAuthStatus?.status || (isZh ? "未知" : "Unknown")}
+                          </Badge>
+                        </div>
+                        {editRequiresNewOAuthProvider ? (
+                          <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                            {isZh ? "已有 Provider 不能在编辑时直接切到 OAuth 渠道，请新建一个 OAuth Provider。" : "Existing providers cannot switch directly to an OAuth channel while editing. Create a new OAuth provider instead."}
+                          </div>
+                        ) : (
+                          <div className="mt-4 space-y-3">
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                              <div className="text-xs font-medium text-slate-700">
+                                {isZh ? "当前授权状态" : "Authorization Status"}
+                              </div>
+                              <div className="mt-1 text-xs text-slate-500 break-all">
+                                {editOAuthStatusQuery.isLoading
+                                  ? (isZh ? "正在读取授权状态..." : "Loading authorization status...")
+                                  : editOAuthStatus?.status === "connected"
+                                    ? (isZh ? "授权有效，可正常使用当前 Provider。" : "Authorization is valid. The provider is ready to use.")
+                                    : editOAuthStatus?.status === "error"
+                                      ? (isZh ? "授权出现错误，请刷新或重新授权。" : "Authorization encountered an error. Please refresh or re-authorize.")
+                                      : editOAuthStatus?.status === "pending"
+                                        ? (isZh ? "授权正在进行或待完成。" : "Authorization is in progress or pending.")
+                                        : editOAuthStatus?.status
+                                          ? (isZh ? `当前状态：${editOAuthStatus.status}` : `Current status: ${editOAuthStatus.status}`)
+                                          : (isZh ? "未知的授权状态。" : "Unknown authorization status.")}
+                              </div>
+                            </div>
+                            {editOAuthStatus?.last_error ? (
+                              <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-600">{editOAuthStatus.last_error}</p>
+                            ) : null}
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={() => reconnectOAuthMut.mutate(p.id)}
+                                disabled={reconnectOAuthMut.isPending || logoutOAuthMut.isPending}
+                              >
+                                {reconnectOAuthMut.isPending ? (isZh ? "刷新中..." : "Refreshing...") : (isZh ? "刷新授权" : "Refresh Auth")}
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={() => logoutOAuthMut.mutate(p.id)}
+                                disabled={logoutOAuthMut.isPending || reconnectOAuthMut.isPending}
+                              >
+                                {logoutOAuthMut.isPending ? (isZh ? "断开中..." : "Disconnecting...") : (isZh ? "断开授权" : "Disconnect")}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ) : null}
                     <div className="space-y-2">
                       <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
                       <Input
@@ -1829,51 +1903,7 @@ export default function ProvidersPage() {
                         onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
                       />
                     </div>
-                    {editingResolvedAuthMode === "oauth" ? (
-                      <div className="space-y-2">
-                        <FieldLabel>{isZh ? "OAuth 授权" : "OAuth Authorization"}</FieldLabel>
-                        <div className={`rounded-xl border px-4 py-3 text-sm ${editRequiresNewOAuthProvider ? "border-amber-200 bg-amber-50 text-amber-700" : "border-slate-200 bg-white text-slate-700"}`}>
-                          {editRequiresNewOAuthProvider ? (
-                            <p>{isZh ? "已有 Provider 不能在编辑时直接切到 OAuth 渠道，请新建一个 OAuth Provider。" : "Existing providers cannot switch directly to an OAuth channel while editing. Create a new OAuth provider instead."}</p>
-                          ) : (
-                            <div className="space-y-3">
-                              <div className="flex items-center justify-between gap-3">
-                                <div>
-                                  <div className="font-medium text-slate-900">{isZh ? "当前授权状态" : "Authorization Status"}</div>
-                                  <div className="mt-1 text-xs text-slate-500 break-all">{editOAuthStatus?.resource_url || (isZh ? "已连接到当前 OAuth Provider" : "Connected to the current OAuth provider")}</div>
-                                </div>
-                                <Badge variant={editOAuthStatus?.status === "connected" ? "success" : editOAuthStatus?.status === "error" ? "danger" : "secondary"}>
-                                  {editOAuthStatusQuery.isLoading
-                                    ? (isZh ? "读取中" : "Loading")
-                                    : editOAuthStatus?.status || (isZh ? "未知" : "Unknown")}
-                                </Badge>
-                              </div>
-                              {editOAuthStatus?.last_error ? (
-                                <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-600">{editOAuthStatus.last_error}</p>
-                              ) : null}
-                              <div className="flex flex-wrap gap-2">
-                                <Button
-                                  type="button"
-                                  variant="secondary"
-                                  onClick={() => reconnectOAuthMut.mutate(p.id)}
-                                  disabled={reconnectOAuthMut.isPending || logoutOAuthMut.isPending}
-                                >
-                                  {reconnectOAuthMut.isPending ? (isZh ? "刷新中..." : "Refreshing...") : (isZh ? "刷新授权" : "Refresh Auth")}
-                                </Button>
-                                <Button
-                                  type="button"
-                                  variant="secondary"
-                                  onClick={() => logoutOAuthMut.mutate(p.id)}
-                                  disabled={logoutOAuthMut.isPending || reconnectOAuthMut.isPending}
-                                >
-                                  {logoutOAuthMut.isPending ? (isZh ? "断开中..." : "Disconnecting...") : (isZh ? "断开授权" : "Disconnect")}
-                                </Button>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    ) : (
+                    {editingResolvedAuthMode !== "oauth" ? (
                       <div className="space-y-2">
                         <FieldLabel>{isZh ? "API Key" : "API Key"}</FieldLabel>
                         <div className="relative">
@@ -1894,7 +1924,7 @@ export default function ProvidersPage() {
                           </button>
                         </div>
                       </div>
-                    )}
+                    ) : null}
                     <div className="space-y-2">
                       <FieldLabel>{isZh ? "默认协议" : "Default Protocol"}</FieldLabel>
                       <Select


### PR DESCRIPTION
- rename preset JSON field auth_mode -> authMode; narrow value space "api_key" -> "apikey" across JSON, DB, Rust and TypeScript
- add SQLite/Postgres startup migration: UPDATE legacy "api_key" rows to "apikey" and rebuild CHECK constraint
- keep DB column / Rust struct / API field name auth_mode unchanged
- reshape provider create/edit forms so the OAuth panel spans full row and "Name + Default Protocol" share one row below it
- align edit-mode OAuth panel visual style with the create-mode panel (slate-50 card, top-left title + badge, status description text)
- fix default protocol not echoed on edit by falling back through resolvePresetProtocol when the stored value is outside the current channel's protocol list

FIX #72 