### PR TITLE
feat(protocol): PR2A vendor extension layer (core abstraction + ollama/openai/codex)

### DIFF
--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -34,6 +34,7 @@ pub mod ids;
 pub mod traits;
 pub mod registry;
 pub mod family;
+pub mod vendor;
 
 use std::collections::HashMap;
 

--- a/crates/nyro-core/src/protocol/vendor/defaults/anthropic.rs
+++ b/crates/nyro-core/src/protocol/vendor/defaults/anthropic.rs
@@ -1,0 +1,31 @@
+//! Anthropic family default. Mirrors the legacy `AnthropicAdapter`.
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use crate::protocol::ids::ProtocolFamily;
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+pub struct AnthropicDefault;
+
+impl VendorExtension for AnthropicDefault {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Family(ProtocolFamily::Anthropic)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "x-api-key",
+            HeaderValue::from_str(ctx.api_key).unwrap_or_else(|_| HeaderValue::from_static("")),
+        );
+        h.insert(
+            "anthropic-version",
+            HeaderValue::from_static("2023-06-01"),
+        );
+        h
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(AnthropicDefault) }
+}

--- a/crates/nyro-core/src/protocol/vendor/defaults/google.rs
+++ b/crates/nyro-core/src/protocol/vendor/defaults/google.rs
@@ -1,0 +1,25 @@
+//! Google (Gemini) family default. Mirrors the legacy `GeminiAdapter`.
+
+use crate::protocol::ids::ProtocolFamily;
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+pub struct GoogleDefault;
+
+impl VendorExtension for GoogleDefault {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Family(ProtocolFamily::Google)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        let url = format!("{}{path}", base_url.trim_end_matches('/'));
+        if url.contains('?') {
+            format!("{url}&key={}", ctx.api_key)
+        } else {
+            format!("{url}?key={}", ctx.api_key)
+        }
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(GoogleDefault) }
+}

--- a/crates/nyro-core/src/protocol/vendor/defaults/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/defaults/mod.rs
@@ -1,0 +1,11 @@
+//! Family-level no-op fallbacks. These match any provider whose
+//! protocol belongs to the family but whose vendor/channel does not
+//! have a more specific registration.
+
+mod anthropic;
+mod google;
+mod openai;
+
+pub use anthropic::AnthropicDefault;
+pub use google::GoogleDefault;
+pub use openai::OpenAiDefault;

--- a/crates/nyro-core/src/protocol/vendor/defaults/openai.rs
+++ b/crates/nyro-core/src/protocol/vendor/defaults/openai.rs
@@ -1,0 +1,49 @@
+//! OpenAI-compatible family default. Mirrors the legacy
+//! `OpenAICompatAdapter`.
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use crate::protocol::ids::ProtocolFamily;
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+pub struct OpenAiDefault;
+
+impl VendorExtension for OpenAiDefault {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Family(ProtocolFamily::OpenAI)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Ok(value) = HeaderValue::from_str(&format!("Bearer {}", ctx.api_key)) {
+            h.insert("Authorization", value);
+        }
+        h
+    }
+
+    fn build_url(&self, _ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        let base = base_url.trim_end_matches('/');
+        let adjusted = if has_non_root_path(base) && path.starts_with("/v1/") {
+            &path[3..]
+        } else {
+            path
+        };
+        format!("{base}{adjusted}")
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(OpenAiDefault) }
+}
+
+/// Returns true if `base` parses as a URL with a non-empty path
+/// component (e.g. `https://api.example.com/v1`).
+pub(crate) fn has_non_root_path(base: &str) -> bool {
+    reqwest::Url::parse(base)
+        .ok()
+        .map(|url| {
+            let pathname = url.path().trim_end_matches('/');
+            !pathname.is_empty() && pathname != "/"
+        })
+        .unwrap_or(false)
+}

--- a/crates/nyro-core/src/protocol/vendor/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/mod.rs
@@ -1,0 +1,143 @@
+//! Vendor extension layer.
+//!
+//! `VendorExtension` is the per-vendor (and optionally per-channel) hook
+//! point that replaces the old `ProviderAdapter` trait. Where the old
+//! adapter dispatched on a `Protocol` enum, vendor extensions dispatch
+//! on `(provider.vendor, provider.channel)` with a fallback to the
+//! protocol family. Three layers, resolved in priority order:
+//!
+//! 1. **Channel** — `VendorScope::Channel { vendor_id, channel_id }`
+//!    (e.g. `openai/codex`).
+//! 2. **Vendor** — `VendorScope::Vendor { vendor_id }` (e.g. `ollama`).
+//! 3. **Family** — `VendorScope::Family(ProtocolFamily::OpenAI)` —
+//!    last-resort defaults that match any provider whose protocol
+//!    belongs to the family.
+//!
+//! Extensions register themselves with `inventory::submit!` from their
+//! own module, so adding a new vendor is purely additive — no central
+//! match block to edit.
+//!
+//! ## Hook surface (9 hooks)
+//!
+//! - `auth_headers` / `build_url` — synchronous, replaces the old
+//!   `ProviderAdapter` surface.
+//! - `pre_encode` / `post_encode` — mutate `InternalRequest` and the
+//!   serialized body just before/after encoding.
+//! - `pre_parse` / `post_parse` — mutate the upstream JSON and decoded
+//!   `InternalResponse`.
+//! - `on_stream_raw_chunk` / `on_stream_delta` — vendor-specific stream
+//!   normalization at raw-text and decoded-event granularity.
+//! - `pre_request` — async hook for capability probing (Ollama) or
+//!   model-alias rewrites that must happen before encoding.
+//!
+//! All hooks have no-op defaults so vendors only override what they
+//! need.
+
+pub mod defaults;
+pub mod ollama;
+pub mod openai;
+pub mod registry;
+pub mod types;
+
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use serde_json::Value;
+
+use crate::Gateway;
+use crate::auth::types::StoredCredential;
+use crate::db::models::Provider;
+use crate::protocol::ids::ProtocolId;
+use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta};
+
+pub use registry::{VendorRegistration, VendorRegistry, VendorScope};
+pub use types::{
+    AuthMode, ChannelDef, Label, OAuthConfig, ProtocolBaseUrl, RuntimeConfig, VendorMetadata,
+};
+
+/// Runtime context handed to every hook.
+pub struct VendorCtx<'a> {
+    pub provider: &'a Provider,
+    pub protocol_id: ProtocolId,
+    pub api_key: &'a str,
+    pub actual_model: &'a str,
+    pub credential: Option<&'a StoredCredential>,
+}
+
+/// Per-vendor / per-channel extension. Implementations register via
+/// `inventory::submit!` from their own module.
+#[async_trait]
+pub trait VendorExtension: Send + Sync + 'static {
+    /// Identifies which provider rows this extension applies to.
+    fn scope(&self) -> VendorScope;
+
+    /// Static metadata for the WebUI / preset list. Channel-scoped
+    /// extensions return `None` because their data is folded into the
+    /// vendor-scoped `VendorMetadata`.
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        None
+    }
+
+    fn auth_headers(&self, _ctx: &VendorCtx<'_>) -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    fn build_url(&self, _ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        format!("{}{}", base_url.trim_end_matches('/'), path)
+    }
+
+    async fn pre_encode(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _req: &mut InternalRequest,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn post_encode(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _body: &mut Value,
+        _headers: &mut HeaderMap,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn pre_parse(&self, _ctx: &VendorCtx<'_>, _resp: &mut Value) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn post_parse(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _resp: &mut InternalResponse,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn on_stream_raw_chunk(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _chunk: &mut String,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn on_stream_delta(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _delta: &mut StreamDelta,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Async pre-flight hook. Used by Ollama to probe `/api/show` and
+    /// strip tool definitions when the model lacks tool support.
+    async fn pre_request(
+        &self,
+        _ctx: &VendorCtx<'_>,
+        _req: &mut InternalRequest,
+        _gw: &Gateway,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/nyro-core/src/protocol/vendor/ollama/capabilities.rs
+++ b/crates/nyro-core/src/protocol/vendor/ollama/capabilities.rs
@@ -1,0 +1,82 @@
+//! Ollama `/api/show` capability probing with TTL cache. Migrated
+//! verbatim from `proxy/adapter.rs`.
+
+use std::time::Duration;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use crate::Gateway;
+use crate::db::models::Provider;
+
+pub(super) const OLLAMA_CAPABILITY_CACHE_TTL_SECS: u64 = 3600;
+
+pub(super) async fn get_ollama_capabilities(
+    gw: &Gateway,
+    provider: &Provider,
+    model: &str,
+) -> anyhow::Result<Vec<String>> {
+    let ttl = Duration::from_secs(OLLAMA_CAPABILITY_CACHE_TTL_SECS);
+    if let Some(cached) = gw
+        .get_ollama_capabilities_cached(&provider.id, model, ttl)
+        .await
+    {
+        return Ok(cached);
+    }
+
+    let caps = fetch_ollama_capabilities(&gw.http_client, &provider.base_url, model).await?;
+    gw.set_ollama_capabilities_cache(&provider.id, model, caps.clone())
+        .await;
+    Ok(caps)
+}
+
+async fn fetch_ollama_capabilities(
+    http: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+) -> anyhow::Result<Vec<String>> {
+    let url = build_ollama_show_url(base_url)?;
+
+    let resp = http
+        .post(url)
+        .json(&serde_json::json!({ "name": model }))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!("ollama /api/show returned status {}", resp.status());
+    }
+
+    let json: Value = resp.json().await?;
+    let caps = json
+        .get("capabilities")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c.as_str().map(ToString::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Ok(caps)
+}
+
+fn build_ollama_show_url(base_url: &str) -> anyhow::Result<Url> {
+    let mut url = Url::parse(base_url)?;
+    let raw_path = url.path().trim_end_matches('/');
+    let path = if raw_path.is_empty() {
+        "/api/show".to_string()
+    } else if raw_path.ends_with("/v1") {
+        let prefix = raw_path.trim_end_matches("/v1");
+        if prefix.is_empty() {
+            "/api/show".to_string()
+        } else {
+            format!("{prefix}/api/show")
+        }
+    } else {
+        format!("{raw_path}/api/show")
+    };
+    url.set_path(&path);
+    url.set_query(None);
+    Ok(url)
+}

--- a/crates/nyro-core/src/protocol/vendor/ollama/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/ollama/mod.rs
@@ -1,0 +1,110 @@
+//! Ollama vendor extension. Auth/build_url reuse the OpenAI-compat
+//! defaults; the vendor-specific behaviour is the `pre_request` hook
+//! that probes `/api/show` and strips tool definitions when the model
+//! does not support tools.
+
+mod capabilities;
+
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+
+use crate::Gateway;
+use crate::protocol::types::InternalRequest;
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "ollama",
+    label: Label {
+        zh: "Ollama",
+        en: "Ollama",
+    },
+    icon: "ollama",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label {
+            zh: "默认",
+            en: "Default",
+        },
+        base_urls: &[
+            ProtocolBaseUrl {
+                protocol: "openai",
+                base_url: "http://127.0.0.1:11434/v1",
+            },
+            ProtocolBaseUrl {
+                protocol: "anthropic",
+                base_url: "http://127.0.0.1:11434",
+            },
+        ],
+        api_key: Some("sk-ollama"),
+        models_source: Some("http://127.0.0.1:11434/v1/models"),
+        capabilities_source: Some("http://127.0.0.1:11434/api/show"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct OllamaVendor;
+
+#[async_trait]
+impl VendorExtension for OllamaVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "ollama" }
+    }
+
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+
+    async fn pre_request(
+        &self,
+        ctx: &VendorCtx<'_>,
+        req: &mut InternalRequest,
+        gw: &Gateway,
+    ) -> anyhow::Result<()> {
+        if req.tools.is_none() && req.tool_choice.is_none() {
+            return Ok(());
+        }
+
+        let model = ctx.actual_model;
+        let caps = match capabilities::get_ollama_capabilities(gw, ctx.provider, model).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "failed to fetch capabilities for model {model}, skipping tools check: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        let supports_tools = caps.iter().any(|c| c == "tools");
+        if !supports_tools {
+            tracing::warn!(
+                "tools stripped for model {model} (tools not supported, capabilities: {caps:?})"
+            );
+            req.tools = None;
+            req.tool_choice = None;
+            req.extra.remove("tools");
+            req.extra.remove("tool_choice");
+        }
+        Ok(())
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(OllamaVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/openai/codex/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/openai/codex/mod.rs
@@ -1,0 +1,43 @@
+//! OpenAI Codex channel (ChatGPT-backed, OAuth).
+//!
+//! In the current architecture all codex-specific headers
+//! (`chatgpt-account-id`, `Authorization: Bearer <oauth_token>` …) are
+//! produced by `OpenAIOAuthDriver::bind_runtime` and injected through
+//! `RuntimeBinding.extra_headers`. This channel extension therefore
+//! exists primarily so the three-tier resolver can dispatch on
+//! `(vendor=openai, channel=codex)` — the actual hook bodies fall back
+//! to the OpenAI-compat defaults until PR3 wires the resolver into the
+//! request pipeline.
+//!
+//! Metadata for this channel lives on the parent vendor
+//! ([`super::METADATA`](super::OpenAiVendor)) so we return `None` from
+//! `metadata()` here; that keeps `VendorRegistry::list_metadata()`
+//! one-vendor-one-row.
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+pub struct OpenAiCodexChannel;
+
+impl VendorExtension for OpenAiCodexChannel {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Channel {
+            vendor_id: "openai",
+            channel_id: "codex",
+        }
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(OpenAiCodexChannel) }
+}

--- a/crates/nyro-core/src/protocol/vendor/openai/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/openai/mod.rs
@@ -1,0 +1,99 @@
+//! OpenAI vendor — direct API plus the Codex channel (OAuth via
+//! ChatGPT). Default-channel behaviour is identical to the OpenAI
+//! family fallback; the codex-specific HTTP headers (e.g.
+//! `chatgpt-account-id`) are injected by `OpenAIOAuthDriver` through
+//! `RuntimeBinding.extra_headers`, so this module currently only
+//! supplies metadata + dispatch — see PR3 for the runtime wiring.
+
+pub mod codex;
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, OAuthConfig, ProtocolBaseUrl, RuntimeConfig, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "openai",
+    label: Label {
+        zh: "OpenAI",
+        en: "OpenAI",
+    },
+    icon: "openai",
+    default_protocol: "openai",
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label {
+                zh: "默认",
+                en: "Default",
+            },
+            base_urls: &[ProtocolBaseUrl {
+                protocol: "openai",
+                base_url: "https://api.openai.com/v1",
+            }],
+            api_key: None,
+            models_source: Some("https://api.openai.com/v1/models"),
+            capabilities_source: Some("ai://models.dev/openai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "codex",
+            label: Label {
+                zh: "Codex",
+                en: "Codex",
+            },
+            base_urls: &[ProtocolBaseUrl {
+                protocol: "openai_responses",
+                base_url: "https://chatgpt.com/backend-api/codex",
+            }],
+            api_key: None,
+            models_source: Some("https://chatgpt.com/backend-api/codex/models"),
+            capabilities_source: Some("ai://models.dev/openai"),
+            static_models: &[],
+            auth_mode: AuthMode::OAuth,
+            oauth: Some(OAuthConfig {
+                auth_base_url: "https://auth.openai.com",
+                authorize_url: "https://auth.openai.com/oauth/authorize",
+                token_url: "https://auth.openai.com/oauth/token",
+                client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+                redirect_uri: "http://localhost:1455/auth/callback",
+                scope: "openid profile email offline_access",
+            }),
+            runtime: Some(RuntimeConfig {
+                api_base_url: "https://chatgpt.com/backend-api/codex",
+                models_url: "https://chatgpt.com/backend-api/codex/models",
+                models_client_version: "0.99.0",
+            }),
+        },
+    ],
+};
+
+pub struct OpenAiVendor;
+
+impl VendorExtension for OpenAiVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "openai" }
+    }
+
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(OpenAiVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/registry.rs
+++ b/crates/nyro-core/src/protocol/vendor/registry.rs
@@ -1,0 +1,123 @@
+//! Global registry of `VendorExtension` implementations.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::db::models::Provider;
+use crate::protocol::ids::{ProtocolFamily, ProtocolId};
+
+use super::types::VendorMetadata;
+use super::VendorExtension;
+
+/// Selector for `VendorExtension` matching. Resolution order:
+/// `Channel` → `Vendor` → `Family`.
+#[derive(Debug, Clone, Copy)]
+pub enum VendorScope {
+    Family(ProtocolFamily),
+    Vendor {
+        vendor_id: &'static str,
+    },
+    Channel {
+        vendor_id: &'static str,
+        channel_id: &'static str,
+    },
+}
+
+/// `inventory` registration record. Each vendor module submits one of
+/// these per extension instance.
+pub struct VendorRegistration {
+    pub make: fn() -> Box<dyn VendorExtension>,
+}
+
+inventory::collect!(VendorRegistration);
+
+/// Process-wide vendor registry.
+pub struct VendorRegistry {
+    extensions: Vec<Arc<dyn VendorExtension>>,
+}
+
+impl VendorRegistry {
+    pub fn global() -> &'static Self {
+        static INSTANCE: OnceLock<VendorRegistry> = OnceLock::new();
+        INSTANCE.get_or_init(Self::build)
+    }
+
+    fn build() -> Self {
+        let mut extensions: Vec<Arc<dyn VendorExtension>> = Vec::new();
+        for reg in inventory::iter::<VendorRegistration> {
+            extensions.push(Arc::from((reg.make)()));
+        }
+        Self { extensions }
+    }
+
+    /// Three-tier resolution: channel → vendor → family.
+    pub fn resolve(
+        &self,
+        provider: &Provider,
+        protocol_id: ProtocolId,
+    ) -> Option<&Arc<dyn VendorExtension>> {
+        let vendor_id = provider
+            .vendor
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+        let channel_id = provider
+            .channel
+            .as_deref()
+            .map(str::trim)
+            .filter(|c| !c.is_empty());
+
+        if let (Some(v), Some(c)) = (vendor_id, channel_id) {
+            for ext in &self.extensions {
+                if let VendorScope::Channel {
+                    vendor_id: vk,
+                    channel_id: ck,
+                } = ext.scope()
+                    && vk.eq_ignore_ascii_case(v)
+                    && ck.eq_ignore_ascii_case(c)
+                {
+                    return Some(ext);
+                }
+            }
+        }
+
+        if let Some(v) = vendor_id {
+            for ext in &self.extensions {
+                if let VendorScope::Vendor { vendor_id: vk } = ext.scope()
+                    && vk.eq_ignore_ascii_case(v)
+                {
+                    return Some(ext);
+                }
+            }
+        }
+
+        for ext in &self.extensions {
+            if let VendorScope::Family(family) = ext.scope()
+                && family == protocol_id.family
+            {
+                return Some(ext);
+            }
+        }
+
+        None
+    }
+
+    /// Static metadata sorted by vendor id. Used by the WebUI preset
+    /// list and (in PR5) replaces `assets/providers.json`.
+    pub fn list_metadata(&self) -> Vec<&'static VendorMetadata> {
+        let mut out: Vec<&'static VendorMetadata> = self
+            .extensions
+            .iter()
+            .filter_map(|ext| ext.metadata())
+            .collect();
+        out.sort_by_key(|m| m.id);
+        out.dedup_by_key(|m| m.id);
+        out
+    }
+
+    /// Look up metadata by vendor id.
+    pub fn metadata(&self, vendor_id: &str) -> Option<&'static VendorMetadata> {
+        self.list_metadata()
+            .into_iter()
+            .find(|m| m.id.eq_ignore_ascii_case(vendor_id))
+    }
+}

--- a/crates/nyro-core/src/protocol/vendor/types.rs
+++ b/crates/nyro-core/src/protocol/vendor/types.rs
@@ -1,0 +1,115 @@
+//! Vendor metadata types — colocated with vendor implementations.
+//!
+//! These structures replace the shape of `assets/providers.json`. Each
+//! vendor module owns a `const METADATA: VendorMetadata` and registers
+//! itself via `inventory::submit!`. PR5 will remove `providers.json`
+//! once `VendorRegistry::list_metadata()` is wired into all consumers.
+//!
+//! Field naming mirrors the JSON schema (camelCase on the wire) so the
+//! migration is a structural rename, not a semantic redesign.
+
+use serde::Serialize;
+
+/// Bilingual label.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct Label {
+    pub zh: &'static str,
+    pub en: &'static str,
+}
+
+/// Authentication mode advertised to the WebUI.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthMode {
+    ApiKey,
+    OAuth,
+    SetupToken,
+}
+
+/// (protocol_alias, base_url) pair. Protocol uses the legacy alias
+/// (`openai` / `anthropic` / `gemini` / `openai_responses`) so the JSON
+/// equivalence test in PR2A can compare byte-for-byte against
+/// `providers.json`.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ProtocolBaseUrl {
+    pub protocol: &'static str,
+    pub base_url: &'static str,
+}
+
+/// OAuth configuration for a channel. Mirrors the `oauth` block in
+/// `providers.json`.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthConfig {
+    pub auth_base_url: &'static str,
+    pub authorize_url: &'static str,
+    pub token_url: &'static str,
+    pub client_id: &'static str,
+    pub redirect_uri: &'static str,
+    pub scope: &'static str,
+}
+
+/// Runtime hints used by OAuth drivers (currently only Codex).
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeConfig {
+    pub api_base_url: &'static str,
+    pub models_url: &'static str,
+    pub models_client_version: &'static str,
+}
+
+/// One channel under a vendor (e.g. `openai/default`, `openai/codex`,
+/// `moonshotai/china`).
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelDef {
+    pub id: &'static str,
+    pub label: Label,
+    /// Per-protocol base URLs — empty slice means "inherit vendor / let
+    /// the user configure manually".
+    #[serde(serialize_with = "serialize_base_urls")]
+    pub base_urls: &'static [ProtocolBaseUrl],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models_source: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities_source: Option<&'static str>,
+    #[serde(skip_serializing_if = "<[&str]>::is_empty")]
+    pub static_models: &'static [&'static str],
+    pub auth_mode: AuthMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<OAuthConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeConfig>,
+}
+
+/// Top-level vendor entry. One `VendorMetadata` per vendor, regardless
+/// of how many channels it exposes.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorMetadata {
+    pub id: &'static str,
+    pub label: Label,
+    pub icon: &'static str,
+    /// Legacy alias (`openai`, `anthropic`, `gemini`, …). Resolved to a
+    /// canonical [`ProtocolId`](super::super::ids::ProtocolId) via
+    /// `ProtocolRegistry::resolve_alias` at runtime.
+    pub default_protocol: &'static str,
+    pub channels: &'static [ChannelDef],
+}
+
+fn serialize_base_urls<S>(
+    base_urls: &&[ProtocolBaseUrl],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeMap;
+    let mut map = serializer.serialize_map(Some(base_urls.len()))?;
+    for entry in base_urls.iter() {
+        map.serialize_entry(entry.protocol, entry.base_url)?;
+    }
+    map.end()
+}

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -1,0 +1,284 @@
+//! PR2A acceptance: VendorRegistry resolves (channel → vendor → family)
+//! correctly, every registered extension produces auth/url output that
+//! matches the legacy `ProviderAdapter` surface, and `list_metadata()`
+//! is field-equivalent to `assets/providers.json` for the three
+//! vendors migrated in PR2A (`openai`, `ollama`, plus the OpenAI/codex
+//! channel).
+
+use nyro_core::auth::types::StoredCredential;
+use nyro_core::db::models::Provider;
+use nyro_core::protocol::ids::{
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+    ProtocolId,
+};
+use nyro_core::protocol::vendor::{VendorCtx, VendorRegistry, VendorScope};
+use serde_json::Value;
+
+fn make_provider(vendor: Option<&str>, channel: Option<&str>) -> Provider {
+    Provider {
+        id: "test".into(),
+        name: "test".into(),
+        vendor: vendor.map(str::to_string),
+        protocol: "openai".into(),
+        base_url: "https://api.example.com/v1".into(),
+        default_protocol: "openai".into(),
+        protocol_endpoints: "{}".into(),
+        preset_key: None,
+        channel: channel.map(str::to_string),
+        models_source: None,
+        capabilities_source: None,
+        static_models: None,
+        api_key: "sk-test".into(),
+        auth_mode: "apikey".into(),
+        use_proxy: false,
+        last_test_success: None,
+        last_test_at: None,
+        is_enabled: true,
+        created_at: String::new(),
+        updated_at: String::new(),
+    }
+}
+
+fn ctx<'a>(
+    provider: &'a Provider,
+    protocol_id: ProtocolId,
+    api_key: &'a str,
+    actual_model: &'a str,
+    credential: Option<&'a StoredCredential>,
+) -> VendorCtx<'a> {
+    VendorCtx {
+        provider,
+        protocol_id,
+        api_key,
+        actual_model,
+        credential,
+    }
+}
+
+// ── 1. Three-tier resolution ──────────────────────────────────────────────
+
+#[test]
+fn resolve_channel_scope_takes_priority() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(Some("openai"), Some("codex"));
+    let ext = reg
+        .resolve(&p, OPENAI_RESPONSES_V1)
+        .expect("codex channel ext");
+    assert!(matches!(
+        ext.scope(),
+        VendorScope::Channel {
+            vendor_id: "openai",
+            channel_id: "codex",
+        }
+    ));
+}
+
+#[test]
+fn resolve_falls_back_to_vendor_when_channel_unknown() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(Some("openai"), Some("unknown-channel"));
+    let ext = reg.resolve(&p, OPENAI_CHAT_V1).expect("openai vendor ext");
+    assert!(matches!(
+        ext.scope(),
+        VendorScope::Vendor { vendor_id: "openai" }
+    ));
+}
+
+#[test]
+fn resolve_falls_back_to_family_when_vendor_unknown() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(Some("unmapped-vendor"), None);
+    let openai = reg.resolve(&p, OPENAI_CHAT_V1).expect("openai family");
+    let anthropic = reg
+        .resolve(&p, ANTHROPIC_MESSAGES_2023_06_01)
+        .expect("anthropic family");
+    let google = reg.resolve(&p, GOOGLE_GENERATE_V1BETA).expect("google family");
+
+    assert!(matches!(
+        openai.scope(),
+        VendorScope::Family(nyro_core::protocol::ids::ProtocolFamily::OpenAI)
+    ));
+    assert!(matches!(
+        anthropic.scope(),
+        VendorScope::Family(nyro_core::protocol::ids::ProtocolFamily::Anthropic)
+    ));
+    assert!(matches!(
+        google.scope(),
+        VendorScope::Family(nyro_core::protocol::ids::ProtocolFamily::Google)
+    ));
+}
+
+#[test]
+fn resolve_uses_family_when_vendor_field_blank() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(None, None);
+    let ext = reg
+        .resolve(&p, ANTHROPIC_MESSAGES_2023_06_01)
+        .expect("family fallback");
+    assert!(matches!(
+        ext.scope(),
+        VendorScope::Family(nyro_core::protocol::ids::ProtocolFamily::Anthropic)
+    ));
+}
+
+#[test]
+fn ollama_vendor_resolves_even_without_channel() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(Some("ollama"), None);
+    let ext = reg.resolve(&p, OPENAI_CHAT_V1).expect("ollama vendor");
+    assert!(matches!(
+        ext.scope(),
+        VendorScope::Vendor { vendor_id: "ollama" }
+    ));
+}
+
+// ── 2. auth_headers / build_url legacy parity ─────────────────────────────
+
+#[test]
+fn openai_family_default_emits_bearer() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(None, None);
+    let ext = reg.resolve(&p, OPENAI_CHAT_V1).unwrap();
+    let h = ext.auth_headers(&ctx(&p, OPENAI_CHAT_V1, "sk-abc", "gpt-4", None));
+    assert_eq!(h.get("Authorization").unwrap(), "Bearer sk-abc");
+}
+
+#[test]
+fn anthropic_family_default_emits_x_api_key_and_version() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(None, None);
+    let ext = reg.resolve(&p, ANTHROPIC_MESSAGES_2023_06_01).unwrap();
+    let h = ext.auth_headers(&ctx(
+        &p,
+        ANTHROPIC_MESSAGES_2023_06_01,
+        "sk-ant",
+        "claude",
+        None,
+    ));
+    assert_eq!(h.get("x-api-key").unwrap(), "sk-ant");
+    assert_eq!(h.get("anthropic-version").unwrap(), "2023-06-01");
+}
+
+#[test]
+fn google_family_default_appends_key_query_param() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(None, None);
+    let ext = reg.resolve(&p, GOOGLE_GENERATE_V1BETA).unwrap();
+    let c = ctx(&p, GOOGLE_GENERATE_V1BETA, "AIzaXYZ", "gemini-1.5", None);
+
+    let url1 = ext.build_url(&c, "https://generativelanguage.googleapis.com", "/v1beta/models");
+    assert_eq!(
+        url1,
+        "https://generativelanguage.googleapis.com/v1beta/models?key=AIzaXYZ"
+    );
+
+    let url2 = ext.build_url(
+        &c,
+        "https://generativelanguage.googleapis.com/v1beta",
+        "/models?alt=sse",
+    );
+    assert_eq!(
+        url2,
+        "https://generativelanguage.googleapis.com/v1beta/models?alt=sse&key=AIzaXYZ"
+    );
+}
+
+#[test]
+fn openai_compat_strips_v1_when_base_already_has_path() {
+    let reg = VendorRegistry::global();
+    let p = make_provider(None, None);
+    let ext = reg.resolve(&p, OPENAI_CHAT_V1).unwrap();
+    let c = ctx(&p, OPENAI_CHAT_V1, "k", "m", None);
+
+    let stripped = ext.build_url(&c, "https://api.deepseek.com/v1", "/v1/chat/completions");
+    assert_eq!(stripped, "https://api.deepseek.com/v1/chat/completions");
+
+    let preserved = ext.build_url(&c, "https://api.openai.com", "/v1/chat/completions");
+    assert_eq!(preserved, "https://api.openai.com/v1/chat/completions");
+}
+
+// ── 3. list_metadata field-level equivalence ──────────────────────────────
+
+#[test]
+fn list_metadata_contains_openai_and_ollama() {
+    let reg = VendorRegistry::global();
+    let metas = reg.list_metadata();
+    let ids: Vec<&str> = metas.iter().map(|m| m.id).collect();
+    assert!(ids.contains(&"openai"), "missing openai metadata: {ids:?}");
+    assert!(ids.contains(&"ollama"), "missing ollama metadata: {ids:?}");
+}
+
+#[test]
+fn openai_metadata_matches_providers_json() {
+    let reg = VendorRegistry::global();
+    let meta = reg.metadata("openai").expect("openai metadata");
+    let ours: Value = serde_json::to_value(meta).unwrap();
+
+    let presets: Value = serde_json::from_str(include_str!(
+        "../assets/providers.json"
+    ))
+    .unwrap();
+    let theirs = presets
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["id"] == "openai")
+        .expect("openai entry in providers.json");
+
+    assert_field_eq(&ours, theirs, "id");
+    assert_field_eq(&ours, theirs, "label");
+    assert_field_eq(&ours, theirs, "icon");
+    assert_field_eq(&ours, theirs, "defaultProtocol");
+
+    let ours_channels = ours["channels"].as_array().unwrap();
+    let theirs_channels = theirs["channels"].as_array().unwrap();
+    assert_eq!(ours_channels.len(), theirs_channels.len());
+    for (oc, tc) in ours_channels.iter().zip(theirs_channels.iter()) {
+        assert_field_eq(oc, tc, "id");
+        assert_field_eq(oc, tc, "label");
+        assert_field_eq(oc, tc, "baseUrls");
+        assert_field_eq(oc, tc, "modelsSource");
+        assert_field_eq(oc, tc, "capabilitiesSource");
+        assert_field_eq(oc, tc, "authMode");
+        assert_field_eq(oc, tc, "oauth");
+        assert_field_eq(oc, tc, "runtime");
+    }
+}
+
+#[test]
+fn ollama_metadata_matches_providers_json() {
+    let reg = VendorRegistry::global();
+    let meta = reg.metadata("ollama").expect("ollama metadata");
+    let ours: Value = serde_json::to_value(meta).unwrap();
+
+    let presets: Value = serde_json::from_str(include_str!(
+        "../assets/providers.json"
+    ))
+    .unwrap();
+    let theirs = presets
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["id"] == "ollama")
+        .expect("ollama entry in providers.json");
+
+    assert_field_eq(&ours, theirs, "id");
+    assert_field_eq(&ours, theirs, "label");
+    assert_field_eq(&ours, theirs, "icon");
+    assert_field_eq(&ours, theirs, "defaultProtocol");
+
+    let oc = &ours["channels"][0];
+    let tc = &theirs["channels"][0];
+    assert_field_eq(oc, tc, "id");
+    assert_field_eq(oc, tc, "baseUrls");
+    assert_field_eq(oc, tc, "apiKey");
+    assert_field_eq(oc, tc, "modelsSource");
+    assert_field_eq(oc, tc, "capabilitiesSource");
+    assert_field_eq(oc, tc, "authMode");
+}
+
+fn assert_field_eq(a: &Value, b: &Value, key: &str) {
+    let av = a.get(key).cloned().unwrap_or(Value::Null);
+    let bv = b.get(key).cloned().unwrap_or(Value::Null);
+    assert_eq!(av, bv, "field `{key}` differs:\n  ours   = {av}\n  theirs = {bv}");
+}


### PR DESCRIPTION
- Introduce `VendorExtension` trait (9 hooks: auth_headers/build_url/ pre_encode/post_encode/pre_parse/post_parse/on_stream_raw_chunk/ on_stream_delta/pre_request), `VendorCtx`, `VendorScope`, `VendorRegistration`, and a global `VendorRegistry` resolved with inventory + OnceLock.

- Three-tier resolution `Channel -> Vendor -> Family` replaces the old `Protocol`-only `ProviderAdapter` dispatch. Family-level no-op fallbacks (OpenAiDefault / AnthropicDefault / GoogleDefault) are bit-for-bit equivalent to the legacy adapters and ship as a default registration each.

- Migrate Ollama: `pre_request` hook + /api/show capability probe with TTL cache, plus `const METADATA` matching providers.json byte-for-byte.

- OpenAI vendor + Codex channel: vendor-level metadata covers both channels; the codex channel stub registers the (vendor=openai, channel=codex) scope so PR3 can dispatch to it. Codex-specific HTTP headers continue to flow through `OpenAIOAuthDriver::bind_runtime` / `RuntimeBinding.extra_headers` until PR3 wires the resolver in.

- `VendorMetadata` serde output mirrors providers.json schema; PR5 will delete the JSON once all consumers switch to `VendorRegistry::list_metadata()`.

- Tests (tests/vendor_registry.rs, 12 cases): three-tier resolution, legacy auth/url parity for the four families, field-level equivalence with providers.json for `openai` and `ollama`.

PR2B will follow with the remaining simple vendors and second-phase stubs (azure-foundry / aws-bedrock / google-vertex / channel placeholders).