### PR TITLE
feat(protocol): PR2B vendor presets + cloud-platform placeholders (2/6)

### DIFF
--- a/crates/nyro-core/assets/providers.json
+++ b/crates/nyro-core/assets/providers.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "custom",
+    "id": "nyro",
     "label": { "zh": "自定义", "en": "Custom" },
     "icon": "nyro",
     "defaultProtocol": "openai",
@@ -183,7 +183,7 @@
     ]
   },
   {
-    "id": "zhipu",
+    "id": "zhipuai",
     "label": { "zh": "Zhipu AI", "en": "Zhipu AI" },
     "icon": "zhipu",
     "defaultProtocol": "openai",

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -2488,7 +2488,7 @@ fn normalize_name(name: &str, field: &str) -> anyhow::Result<String> {
 fn normalize_vendor(vendor: Option<&str>) -> Option<String> {
     vendor
         .map(str::trim)
-        .filter(|v| !v.is_empty() && *v != "custom")
+        .filter(|v| !v.is_empty() && *v != "nyro")
         .map(|v| v.to_lowercase())
 }
 

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -87,6 +87,7 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     migrate_oauth_credentials_from_providers(pool).await?;
     ensure_semantic_cache_vectors_table(pool, vector_dimensions).await?;
     backfill_provider_vendor(pool).await?;
+    migrate_vendor_renames(pool).await?;
     backfill_route_fields(pool).await?;
     backfill_route_targets(pool).await?;
     Ok(())
@@ -102,10 +103,47 @@ async fn backfill_provider_vendor(pool: &SqlitePool) -> anyhow::Result<()> {
              WHERE (vendor IS NULL OR trim(vendor) = '') \
                AND preset_key IS NOT NULL \
                AND trim(preset_key) != '' \
-               AND lower(trim(preset_key)) != 'custom'",
+               AND lower(trim(preset_key)) != 'nyro'",
         )
         .execute(pool)
         .await?;
+    }
+    Ok(())
+}
+
+/// Rename legacy vendor / preset_key values to their new canonical
+/// form (PR2B):
+///
+/// - `custom` → `nyro`
+/// - `zhipu`  → `zhipuai`
+///
+/// Idempotent: re-running the migration on already-normalized data is
+/// a no-op.
+async fn migrate_vendor_renames(pool: &SqlitePool) -> anyhow::Result<()> {
+    const RENAMES: &[(&str, &str)] = &[("custom", "nyro"), ("zhipu", "zhipuai")];
+
+    if column_exists(pool, "providers", "vendor").await? {
+        for (from, to) in RENAMES {
+            sqlx::query(
+                "UPDATE providers SET vendor = ?1 WHERE lower(trim(vendor)) = ?2",
+            )
+            .bind(to)
+            .bind(from)
+            .execute(pool)
+            .await?;
+        }
+    }
+
+    if column_exists(pool, "providers", "preset_key").await? {
+        for (from, to) in RENAMES {
+            sqlx::query(
+                "UPDATE providers SET preset_key = ?1 WHERE lower(trim(preset_key)) = ?2",
+            )
+            .bind(to)
+            .bind(from)
+            .execute(pool)
+            .await?;
+        }
     }
     Ok(())
 }

--- a/crates/nyro-core/src/protocol/vendor/anthropic/claude_code/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/anthropic/claude_code/mod.rs
@@ -1,0 +1,9 @@
+//! Placeholder for the Anthropic Claude Code OAuth channel.
+//!
+//! Not registered with `inventory` yet — the OAuth driver, runtime
+//! binding, and metadata will land in a follow-up PR. Keeping this
+//! module here reserves the directory layout so future work is purely
+//! additive (one `inventory::submit!` and channel metadata in
+//! `protocol/vendor/anthropic/mod.rs::METADATA.channels`).
+
+// TODO: implement OAuth handshake, runtime binding, METADATA entry.

--- a/crates/nyro-core/src/protocol/vendor/anthropic/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/anthropic/mod.rs
@@ -1,0 +1,70 @@
+//! Anthropic vendor (direct API). Reuses the Anthropic family default
+//! for headers/URL.
+//!
+//! `claude-code` is a planned OAuth channel — see the placeholder
+//! submodule (`claude_code`) which is intentionally not registered
+//! until its OAuth driver lands.
+
+pub mod claude_code;
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::AnthropicDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "anthropic",
+    label: Label {
+        zh: "Anthropic",
+        en: "Anthropic",
+    },
+    icon: "anthropic",
+    default_protocol: "anthropic",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label {
+            zh: "默认",
+            en: "Default",
+        },
+        base_urls: &[ProtocolBaseUrl {
+            protocol: "anthropic",
+            base_url: "https://api.anthropic.com",
+        }],
+        api_key: None,
+        models_source: Some("https://api.anthropic.com/v1/models"),
+        capabilities_source: Some("ai://models.dev/anthropic"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct AnthropicVendor;
+
+impl VendorExtension for AnthropicVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor {
+            vendor_id: "anthropic",
+        }
+    }
+
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        AnthropicDefault.auth_headers(ctx)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        AnthropicDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(AnthropicVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/aws_bedrock/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/aws_bedrock/mod.rs
@@ -1,0 +1,12 @@
+//! Placeholder for the AWS Bedrock vendor.
+//!
+//! Not registered with `inventory` yet. Bedrock requires SigV4
+//! request signing (see `sigv4.rs`) and a small response wrapper layer
+//! (see `wrapper.rs`) on top of the Anthropic / Cohere / Meta dialects
+//! it forwards. The full implementation will arrive in a follow-up PR.
+
+pub mod sigv4;
+pub mod wrapper;
+
+// TODO: METADATA + VendorExtension impl wiring auth_headers to SigV4
+// signing and post_parse to the Bedrock response wrapper.

--- a/crates/nyro-core/src/protocol/vendor/aws_bedrock/sigv4.rs
+++ b/crates/nyro-core/src/protocol/vendor/aws_bedrock/sigv4.rs
@@ -1,0 +1,5 @@
+//! Placeholder for AWS SigV4 request signing used by the Bedrock
+//! vendor. Empty until the Bedrock implementation lands.
+
+// TODO: implement SigV4 canonical-request construction, signing key
+// derivation, and `Authorization` header generation.

--- a/crates/nyro-core/src/protocol/vendor/aws_bedrock/wrapper.rs
+++ b/crates/nyro-core/src/protocol/vendor/aws_bedrock/wrapper.rs
@@ -1,0 +1,4 @@
+//! Placeholder for Bedrock's request/response wrapper transformations
+//! (e.g. unwrapping the `body`-encoded inner protocol payloads).
+
+// TODO: implement wrapper logic for Bedrock-specific payload framing.

--- a/crates/nyro-core/src/protocol/vendor/azure_foundry/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/azure_foundry/mod.rs
@@ -1,0 +1,12 @@
+//! Placeholder for the Azure AI Foundry vendor.
+//!
+//! Not registered with `inventory` yet. Foundry exposes an
+//! OpenAI-compatible surface plus its own `model-deployment`
+//! conventions; the implementation will arrive in a follow-up PR
+//! together with its bearer-token / Entra ID auth driver.
+//!
+//! Note: per design discussion we will *only* support the Foundry
+//! flavour and rely on Foundry's compat layer for Azure OpenAI; the
+//! legacy `deployment_map.rs` shape is not preserved.
+
+// TODO: METADATA + VendorExtension impl + bearer / Entra ID auth driver.

--- a/crates/nyro-core/src/protocol/vendor/deepseek/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/deepseek/mod.rs
@@ -1,0 +1,59 @@
+//! DeepSeek vendor (OpenAI-compatible, exposes both OpenAI and
+//! Anthropic-style endpoints — auth/url stay OpenAI-compat for both).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "deepseek",
+    label: Label { zh: "DeepSeek", en: "DeepSeek" },
+    icon: "deepseek",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label { zh: "默认", en: "Default" },
+        base_urls: &[
+            ProtocolBaseUrl {
+                protocol: "openai",
+                base_url: "https://api.deepseek.com/v1",
+            },
+            ProtocolBaseUrl {
+                protocol: "anthropic",
+                base_url: "https://api.deepseek.com/anthropic",
+            },
+        ],
+        api_key: None,
+        models_source: Some("https://api.deepseek.com/v1/models"),
+        capabilities_source: Some("ai://models.dev/deepseek"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct DeepseekVendor;
+
+impl VendorExtension for DeepseekVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "deepseek" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(DeepseekVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/google/gemini_cli/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/google/gemini_cli/mod.rs
@@ -1,0 +1,7 @@
+//! Placeholder for the Google Gemini-CLI OAuth channel.
+//!
+//! Not registered with `inventory` yet — implementation lands together
+//! with its OAuth driver. The directory exists to reserve the layout
+//! so future work is purely additive.
+
+// TODO: implement OAuth handshake, runtime binding, METADATA entry.

--- a/crates/nyro-core/src/protocol/vendor/google/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/google/mod.rs
@@ -1,0 +1,76 @@
+//! Google vendor (Gemini direct API). Reuses the Google family default
+//! for `?key=` query-string auth.
+//!
+//! `gemini-cli` is a planned OAuth channel — see the placeholder
+//! submodule (`gemini_cli`) which is intentionally not registered
+//! until its OAuth driver lands.
+
+pub mod gemini_cli;
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::GoogleDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "google",
+    label: Label {
+        zh: "Google",
+        en: "Google",
+    },
+    icon: "google",
+    default_protocol: "gemini",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label {
+            zh: "默认",
+            en: "Default",
+        },
+        base_urls: &[
+            ProtocolBaseUrl {
+                protocol: "openai",
+                base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
+            },
+            ProtocolBaseUrl {
+                protocol: "gemini",
+                base_url: "https://generativelanguage.googleapis.com",
+            },
+        ],
+        api_key: None,
+        models_source: Some("https://generativelanguage.googleapis.com/v1beta/openai/models"),
+        capabilities_source: Some("ai://models.dev/google"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct GoogleVendor;
+
+impl VendorExtension for GoogleVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor {
+            vendor_id: "google",
+        }
+    }
+
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        GoogleDefault.auth_headers(ctx)
+    }
+
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        GoogleDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(GoogleVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/google_vertex/auth.rs
+++ b/crates/nyro-core/src/protocol/vendor/google_vertex/auth.rs
@@ -1,0 +1,4 @@
+//! Placeholder for Vertex AI authentication (Google Cloud service
+//! accounts / Application Default Credentials).
+
+// TODO: implement OAuth2 access-token acquisition + caching.

--- a/crates/nyro-core/src/protocol/vendor/google_vertex/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/google_vertex/mod.rs
@@ -1,0 +1,12 @@
+//! Placeholder for the Google Vertex AI vendor.
+//!
+//! Not registered with `inventory` yet. Vertex requires Google Cloud
+//! service-account or ADC auth (see `auth.rs`) and project/region URL
+//! construction (see `url.rs`). The full implementation will arrive
+//! in a follow-up PR.
+
+pub mod auth;
+pub mod url;
+
+// TODO: METADATA + VendorExtension impl wiring auth_headers to GCP
+// access tokens and build_url to projects/{project}/locations/{region}.

--- a/crates/nyro-core/src/protocol/vendor/google_vertex/url.rs
+++ b/crates/nyro-core/src/protocol/vendor/google_vertex/url.rs
@@ -1,0 +1,4 @@
+//! Placeholder for Vertex AI URL construction
+//! (`projects/{project}/locations/{region}/publishers/...`).
+
+// TODO: implement project/region/publisher path templating.

--- a/crates/nyro-core/src/protocol/vendor/minimax/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/minimax/mod.rs
@@ -1,0 +1,82 @@
+//! MiniMax vendor (OpenAI-compatible). Two channels: global
+//! (`default`) and China site (`china`).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "minimax",
+    label: Label { zh: "MiniMax", en: "MiniMax" },
+    icon: "minimax",
+    default_protocol: "openai",
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label { zh: "默认", en: "Default" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.minimax.io/v1",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.minimax.io/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("ai://models.dev/minimax"),
+            capabilities_source: Some("ai://models.dev/minimax"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "china",
+            label: Label { zh: "中国站", en: "China" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.minimaxi.com/v1",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.minimaxi.com/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("ai://models.dev/minimax"),
+            capabilities_source: Some("ai://models.dev/minimax"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+    ],
+};
+
+pub struct MinimaxVendor;
+
+impl VendorExtension for MinimaxVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "minimax" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(MinimaxVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/mod.rs
@@ -34,10 +34,30 @@
 //! need.
 
 pub mod defaults;
-pub mod ollama;
-pub mod openai;
 pub mod registry;
 pub mod types;
+
+// ── Phase 1: vendors backed by `assets/providers.json` (PR2A + PR2B) ──
+pub mod anthropic;
+pub mod deepseek;
+pub mod google;
+pub mod minimax;
+pub mod moonshotai;
+pub mod nvidia;
+pub mod nyro;
+pub mod ollama;
+pub mod openai;
+pub mod openrouter;
+pub mod xai;
+pub mod zai;
+pub mod zhipuai;
+
+// ── Phase 2: placeholders. Modules exist to reserve the layout but
+//    are not registered with `inventory` until their auth/runtime
+//    implementations land in follow-up PRs. ──
+pub mod aws_bedrock;
+pub mod azure_foundry;
+pub mod google_vertex;
 
 use async_trait::async_trait;
 use reqwest::header::HeaderMap;

--- a/crates/nyro-core/src/protocol/vendor/moonshotai/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/moonshotai/mod.rs
@@ -1,0 +1,83 @@
+//! Moonshot AI vendor (OpenAI-compatible). Two channels: global
+//! (`default`) and China site (`china`) — the only difference is the
+//! base URLs.
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "moonshotai",
+    label: Label { zh: "Moonshot AI", en: "Moonshot AI" },
+    icon: "kimi",
+    default_protocol: "openai",
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label { zh: "默认", en: "Default" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.moonshot.ai/v1",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.moonshot.ai/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://api.moonshot.ai/v1/models"),
+            capabilities_source: Some("ai://models.dev/moonshotai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "china",
+            label: Label { zh: "中国站", en: "China" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.moonshot.cn/v1",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.moonshot.cn/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://api.moonshot.cn/v1/models"),
+            capabilities_source: Some("ai://models.dev/moonshotai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+    ],
+};
+
+pub struct MoonshotaiVendor;
+
+impl VendorExtension for MoonshotaiVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "moonshotai" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(MoonshotaiVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/nvidia/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/nvidia/mod.rs
@@ -1,0 +1,52 @@
+//! NVIDIA vendor (OpenAI-compatible).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "nvidia",
+    label: Label { zh: "NVIDIA", en: "NVIDIA" },
+    icon: "nvidia",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label { zh: "默认", en: "Default" },
+        base_urls: &[ProtocolBaseUrl {
+            protocol: "openai",
+            base_url: "https://integrate.api.nvidia.com/v1",
+        }],
+        api_key: None,
+        models_source: Some("https://integrate.api.nvidia.com/v1/models"),
+        capabilities_source: Some("ai://models.dev/nvidia"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct NvidiaVendor;
+
+impl VendorExtension for NvidiaVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "nvidia" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(NvidiaVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/nyro/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/nyro/mod.rs
@@ -1,0 +1,53 @@
+//! Nyro vendor preset — the user-defined / "Custom" template.
+//!
+//! Behaviour delegates to the OpenAI family default; metadata exists
+//! so the WebUI can render the "Nyro (Custom)" preset card. Renamed
+//! from `custom` in PR2B to align with the product brand; the legacy
+//! values `custom`/`preset_key='custom'` are migrated to `nyro` in
+//! `db::migrate` for SQLite and the Postgres bootstrap.
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{AuthMode, ChannelDef, Label, VendorMetadata};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "nyro",
+    label: Label { zh: "自定义", en: "Custom" },
+    icon: "nyro",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label { zh: "默认", en: "Default" },
+        base_urls: &[],
+        api_key: None,
+        models_source: None,
+        capabilities_source: Some("ai://models.dev/"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct NyroVendor;
+
+impl VendorExtension for NyroVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "nyro" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(NyroVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/openrouter/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/openrouter/mod.rs
@@ -1,0 +1,58 @@
+//! OpenRouter vendor (OpenAI-compatible aggregator).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "openrouter",
+    label: Label { zh: "OpenRouter", en: "OpenRouter" },
+    icon: "openrouter",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label { zh: "默认", en: "Default" },
+        base_urls: &[
+            ProtocolBaseUrl {
+                protocol: "openai",
+                base_url: "https://openrouter.ai/api/v1",
+            },
+            ProtocolBaseUrl {
+                protocol: "anthropic",
+                base_url: "https://openrouter.ai/api",
+            },
+        ],
+        api_key: None,
+        models_source: Some("https://openrouter.ai/api/v1/models"),
+        capabilities_source: Some("https://openrouter.ai/api/v1/models"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct OpenrouterVendor;
+
+impl VendorExtension for OpenrouterVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "openrouter" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(OpenrouterVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/types.rs
+++ b/crates/nyro-core/src/protocol/vendor/types.rs
@@ -66,8 +66,12 @@ pub struct ChannelDef {
     pub id: &'static str,
     pub label: Label,
     /// Per-protocol base URLs — empty slice means "inherit vendor / let
-    /// the user configure manually".
-    #[serde(serialize_with = "serialize_base_urls")]
+    /// the user configure manually" and is omitted from the serialized
+    /// metadata so it lines up with the legacy `providers.json` shape.
+    #[serde(
+        serialize_with = "serialize_base_urls",
+        skip_serializing_if = "<[ProtocolBaseUrl]>::is_empty"
+    )]
     pub base_urls: &'static [ProtocolBaseUrl],
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<&'static str>,

--- a/crates/nyro-core/src/protocol/vendor/xai/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/xai/mod.rs
@@ -1,0 +1,52 @@
+//! xAI vendor (OpenAI-compatible).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "xai",
+    label: Label { zh: "xAI", en: "xAI" },
+    icon: "xai",
+    default_protocol: "openai",
+    channels: &[ChannelDef {
+        id: "default",
+        label: Label { zh: "默认", en: "Default" },
+        base_urls: &[ProtocolBaseUrl {
+            protocol: "openai",
+            base_url: "https://api.x.ai/v1",
+        }],
+        api_key: None,
+        models_source: Some("https://api.x.ai/v1/models"),
+        capabilities_source: Some("ai://models.dev/xai"),
+        static_models: &[],
+        auth_mode: AuthMode::ApiKey,
+        oauth: None,
+        runtime: None,
+    }],
+};
+
+pub struct XaiVendor;
+
+impl VendorExtension for XaiVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "xai" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(XaiVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/zai/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/zai/mod.rs
@@ -1,0 +1,82 @@
+//! Z.ai vendor (OpenAI-compatible). Two channels: regular (`default`)
+//! and Coding Plan (`coding`).
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "zai",
+    label: Label { zh: "Z.ai", en: "Z.ai" },
+    icon: "zai",
+    default_protocol: "openai",
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label { zh: "默认", en: "Default" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.z.ai/api/paas/v4",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.z.ai/api/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://api.z.ai/api/paas/v4/models"),
+            capabilities_source: Some("ai://models.dev/zai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "coding",
+            label: Label { zh: "Coding Plan", en: "Coding Plan" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://api.z.ai/api/coding/paas/v4",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://api.z.ai/api/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://api.z.ai/api/coding/paas/v4/models"),
+            capabilities_source: Some("ai://models.dev/zai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+    ],
+};
+
+pub struct ZaiVendor;
+
+impl VendorExtension for ZaiVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "zai" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(ZaiVendor) }
+}

--- a/crates/nyro-core/src/protocol/vendor/zhipuai/mod.rs
+++ b/crates/nyro-core/src/protocol/vendor/zhipuai/mod.rs
@@ -1,0 +1,86 @@
+//! Zhipu AI vendor (OpenAI-compatible). Two channels: regular
+//! (`default`) and Coding Plan (`coding`).
+//!
+//! Renamed from `zhipu` in PR2B to match the upstream brand and
+//! `models.dev` namespace; legacy `vendor='zhipu'` rows are rewritten
+//! to `vendor='zhipuai'` by the storage migrations.
+
+use reqwest::header::HeaderMap;
+
+use crate::protocol::vendor::defaults::OpenAiDefault;
+use crate::protocol::vendor::types::{
+    AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata,
+};
+use crate::protocol::vendor::{VendorCtx, VendorExtension, VendorRegistration, VendorScope};
+
+const METADATA: VendorMetadata = VendorMetadata {
+    id: "zhipuai",
+    label: Label { zh: "Zhipu AI", en: "Zhipu AI" },
+    icon: "zhipu",
+    default_protocol: "openai",
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label { zh: "默认", en: "Default" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://open.bigmodel.cn/api/paas/v4",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://open.bigmodel.cn/api/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://open.bigmodel.cn/api/paas/v4/models"),
+            capabilities_source: Some("ai://models.dev/zhipuai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "coding",
+            label: Label { zh: "Coding Plan", en: "Coding Plan" },
+            base_urls: &[
+                ProtocolBaseUrl {
+                    protocol: "openai",
+                    base_url: "https://open.bigmodel.cn/api/coding/paas/v4",
+                },
+                ProtocolBaseUrl {
+                    protocol: "anthropic",
+                    base_url: "https://open.bigmodel.cn/api/anthropic",
+                },
+            ],
+            api_key: None,
+            models_source: Some("https://open.bigmodel.cn/api/coding/paas/v4/models"),
+            capabilities_source: Some("ai://models.dev/zhipuai"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+    ],
+};
+
+pub struct ZhipuaiVendor;
+
+impl VendorExtension for ZhipuaiVendor {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Vendor { vendor_id: "zhipuai" }
+    }
+    fn metadata(&self) -> Option<&'static VendorMetadata> {
+        Some(&METADATA)
+    }
+    fn auth_headers(&self, ctx: &VendorCtx<'_>) -> HeaderMap {
+        OpenAiDefault.auth_headers(ctx)
+    }
+    fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
+        OpenAiDefault.build_url(ctx, base_url, path)
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(ZhipuaiVendor) }
+}

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -1334,6 +1334,23 @@ END $$;"#,
         .execute(self.adapter.pool())
         .await?;
         ensure_semantic_cache_vectors_table(self.adapter.pool(), self.vector_dimensions).await?;
+        // PR2B: rename legacy vendor / preset_key values to their new
+        // canonical form (`custom` → `nyro`, `zhipu` → `zhipuai`).
+        // Idempotent: a no-op on already-normalized rows.
+        for (from, to) in [("custom", "nyro"), ("zhipu", "zhipuai")] {
+            sqlx::query("UPDATE providers SET vendor = $1 WHERE lower(btrim(vendor)) = $2")
+                .bind(to)
+                .bind(from)
+                .execute(self.adapter.pool())
+                .await?;
+            sqlx::query(
+                "UPDATE providers SET preset_key = $1 WHERE lower(btrim(preset_key)) = $2",
+            )
+            .bind(to)
+            .bind(from)
+            .execute(self.adapter.pool())
+            .await?;
+        }
         Ok(())
     }
 
@@ -1483,7 +1500,7 @@ fn api_key_with_bindings(row: ApiKey, route_ids: Vec<String>) -> ApiKeyWithBindi
 fn normalize_provider_vendor(vendor: Option<&str>) -> Option<String> {
     vendor
         .map(str::trim)
-        .filter(|v| !v.is_empty() && *v != "custom")
+        .filter(|v| !v.is_empty() && *v != "nyro")
         .map(|v| v.to_lowercase())
 }
 

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -468,7 +468,7 @@ impl ProviderStore for SqliteProviderStore {
 fn normalize_provider_vendor(vendor: Option<&str>) -> Option<String> {
     vendor
         .map(str::trim)
-        .filter(|v| !v.is_empty() && *v != "custom")
+        .filter(|v| !v.is_empty() && *v != "nyro")
         .map(|v| v.to_lowercase())
 }
 

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -197,88 +197,115 @@ fn openai_compat_strips_v1_when_base_already_has_path() {
     assert_eq!(preserved, "https://api.openai.com/v1/chat/completions");
 }
 
-// ── 3. list_metadata field-level equivalence ──────────────────────────────
+// ── 3. list_metadata field-level equivalence with providers.json ──────────
 
-#[test]
-fn list_metadata_contains_openai_and_ollama() {
-    let reg = VendorRegistry::global();
-    let metas = reg.list_metadata();
-    let ids: Vec<&str> = metas.iter().map(|m| m.id).collect();
-    assert!(ids.contains(&"openai"), "missing openai metadata: {ids:?}");
-    assert!(ids.contains(&"ollama"), "missing ollama metadata: {ids:?}");
+const PROVIDERS_JSON: &str = include_str!("../assets/providers.json");
+
+fn providers_json() -> Vec<Value> {
+    let v: Value = serde_json::from_str(PROVIDERS_JSON).unwrap();
+    v.as_array().unwrap().clone()
 }
 
 #[test]
-fn openai_metadata_matches_providers_json() {
+fn list_metadata_covers_every_providers_json_entry() {
     let reg = VendorRegistry::global();
-    let meta = reg.metadata("openai").expect("openai metadata");
-    let ours: Value = serde_json::to_value(meta).unwrap();
+    let registered: std::collections::HashSet<&str> =
+        reg.list_metadata().into_iter().map(|m| m.id).collect();
 
-    let presets: Value = serde_json::from_str(include_str!(
-        "../assets/providers.json"
-    ))
-    .unwrap();
-    let theirs = presets
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|p| p["id"] == "openai")
-        .expect("openai entry in providers.json");
+    let mut missing = Vec::new();
+    for entry in providers_json() {
+        let id = entry["id"].as_str().unwrap();
+        if !registered.contains(id) {
+            missing.push(id.to_string());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "providers.json entries not migrated to vendor metadata: {missing:?}"
+    );
+}
 
-    assert_field_eq(&ours, theirs, "id");
-    assert_field_eq(&ours, theirs, "label");
-    assert_field_eq(&ours, theirs, "icon");
-    assert_field_eq(&ours, theirs, "defaultProtocol");
+#[test]
+fn metadata_field_equivalence_for_every_vendor() {
+    let reg = VendorRegistry::global();
+    for entry in providers_json() {
+        let id = entry["id"].as_str().unwrap();
+        let meta = reg
+            .metadata(id)
+            .unwrap_or_else(|| panic!("missing vendor metadata: {id}"));
+        let ours = serde_json::to_value(meta).unwrap();
 
-    let ours_channels = ours["channels"].as_array().unwrap();
-    let theirs_channels = theirs["channels"].as_array().unwrap();
-    assert_eq!(ours_channels.len(), theirs_channels.len());
-    for (oc, tc) in ours_channels.iter().zip(theirs_channels.iter()) {
-        assert_field_eq(oc, tc, "id");
-        assert_field_eq(oc, tc, "label");
-        assert_field_eq(oc, tc, "baseUrls");
-        assert_field_eq(oc, tc, "modelsSource");
-        assert_field_eq(oc, tc, "capabilitiesSource");
-        assert_field_eq(oc, tc, "authMode");
-        assert_field_eq(oc, tc, "oauth");
-        assert_field_eq(oc, tc, "runtime");
+        // top-level vendor fields
+        for k in ["id", "label", "icon", "defaultProtocol"] {
+            assert_field_eq(&ours, &entry, k, id);
+        }
+
+        // channels: structural compare
+        let ours_channels = ours["channels"].as_array().unwrap();
+        let theirs_channels = entry["channels"].as_array().unwrap();
+        assert_eq!(
+            ours_channels.len(),
+            theirs_channels.len(),
+            "{id}: channel count differs",
+        );
+        for (oc, tc) in ours_channels.iter().zip(theirs_channels.iter()) {
+            let ctx = format!("{id}/{}", oc["id"].as_str().unwrap_or("?"));
+            for k in [
+                "id",
+                "label",
+                "baseUrls",
+                "apiKey",
+                "modelsSource",
+                "capabilitiesSource",
+                "authMode",
+                "oauth",
+                "runtime",
+            ] {
+                assert_field_eq(oc, tc, k, &ctx);
+            }
+            // staticModels is normalized: missing == empty array
+            let ours_sm = oc.get("staticModels").cloned().unwrap_or(Value::Null);
+            let theirs_sm = tc.get("staticModels").cloned().unwrap_or(Value::Null);
+            assert!(
+                static_models_equal(&ours_sm, &theirs_sm),
+                "{ctx}: staticModels differs:\n  ours   = {ours_sm}\n  theirs = {theirs_sm}",
+            );
+        }
     }
 }
 
-#[test]
-fn ollama_metadata_matches_providers_json() {
-    let reg = VendorRegistry::global();
-    let meta = reg.metadata("ollama").expect("ollama metadata");
-    let ours: Value = serde_json::to_value(meta).unwrap();
-
-    let presets: Value = serde_json::from_str(include_str!(
-        "../assets/providers.json"
-    ))
-    .unwrap();
-    let theirs = presets
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|p| p["id"] == "ollama")
-        .expect("ollama entry in providers.json");
-
-    assert_field_eq(&ours, theirs, "id");
-    assert_field_eq(&ours, theirs, "label");
-    assert_field_eq(&ours, theirs, "icon");
-    assert_field_eq(&ours, theirs, "defaultProtocol");
-
-    let oc = &ours["channels"][0];
-    let tc = &theirs["channels"][0];
-    assert_field_eq(oc, tc, "id");
-    assert_field_eq(oc, tc, "baseUrls");
-    assert_field_eq(oc, tc, "apiKey");
-    assert_field_eq(oc, tc, "modelsSource");
-    assert_field_eq(oc, tc, "capabilitiesSource");
-    assert_field_eq(oc, tc, "authMode");
+fn static_models_equal(a: &Value, b: &Value) -> bool {
+    let normalize = |v: &Value| -> Value {
+        match v {
+            Value::Null => Value::Array(vec![]),
+            Value::Array(arr) => Value::Array(arr.clone()),
+            other => other.clone(),
+        }
+    };
+    normalize(a) == normalize(b)
 }
 
-fn assert_field_eq(a: &Value, b: &Value, key: &str) {
+fn assert_field_eq(a: &Value, b: &Value, key: &str, ctx: &str) {
     let av = a.get(key).cloned().unwrap_or(Value::Null);
     let bv = b.get(key).cloned().unwrap_or(Value::Null);
-    assert_eq!(av, bv, "field `{key}` differs:\n  ours   = {av}\n  theirs = {bv}");
+    assert_eq!(
+        av, bv,
+        "{ctx}: field `{key}` differs:\n  ours   = {av}\n  theirs = {bv}",
+    );
+}
+
+// ── 4. Phase-2 placeholder vendors must NOT be auto-registered ────────────
+
+#[test]
+fn placeholder_vendors_are_not_registered() {
+    let reg = VendorRegistry::global();
+    let registered: std::collections::HashSet<&str> =
+        reg.list_metadata().into_iter().map(|m| m.id).collect();
+
+    for placeholder in ["azure-foundry", "aws-bedrock", "google-vertex"] {
+        assert!(
+            !registered.contains(placeholder),
+            "placeholder vendor `{placeholder}` should not yet be registered"
+        );
+    }
 }

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -83,7 +83,7 @@ const emptyCreate: CreateProvider = {
   api_key: "",
 };
 const PAGE_SIZE = 7;
-const DEFAULT_PRESET_ID = "custom";
+const DEFAULT_PRESET_ID = "nyro";
 const protocolOptions = [
   { label: "OpenAI", value: "openai" },
   { label: "OpenAI Responses", value: "openai_responses" },


### PR DESCRIPTION
Migrates the remaining `assets/providers.json` entries into the VendorExtension layer introduced in PR2A and reserves the directory layout for cloud-platform vendors that land in later PRs.

Phase 1 — registered vendors (delegate auth/url to family defaults):
  anthropic, google, nyro (was "custom"), xai, deepseek, nvidia,
  openrouter, moonshotai, minimax, zhipuai (was "zhipu"), zai.
  Each module colocates its `const METADATA` with code, mirroring
  `providers.json` field-for-field (verified by parity tests).

Phase 2 — placeholder modules, NOT registered with `inventory`:
  anthropic/claude_code, google/gemini_cli, azurundry,
  aws_bedrock (+ sigv4, wrapper), google_vertex (+ auth, url).

Vendor renames (custom→nyro, zhipu→zhipuai):
  - Module/struct/vendor_id all updated.
  - providers.json `id` fields rewritten.
  - Idempotent backfill in db::migrate (SQLite) and PostgresBootstrap rewriting `providers.vendor` and `preset_key` from the legacy values to the new canonical ones.
  - normalize_*vendor sentinels (4 sites) updated to skip "nyro".
  - WebUI `DEFAULT_PRESET_ID` switched to "nyro".

Misc:
  - `ChannelDef.base_urls` gains `skip_serializing_if = is_empty` so empty slices serialize as omitted (matches providers.json `null` for the Custom preset).
  - tests/vendor_registry.rs grows to 12 cases: full registration coverage, per-field equivalence vs. providers.json, and an explicit assertion that phase-2 placeholders are absent.

Verification: protocol_registry 7/7, vendor_registry 12/12, full nyro-core test suite green; zero new clippy warnings on touched files.