### PR TITLE
refactor(protocol): PR4 close legacy Protocol enum + DB normalization (4/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,7 @@ dependencies = [
  "sha2",
  "sqlite-vec",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/nyro-core/Cargo.toml
+++ b/crates/nyro-core/Cargo.toml
@@ -38,3 +38,6 @@ rand = "0.8"
 sha2 = "0.10"
 dashmap = "6"
 inventory = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -16,7 +16,8 @@ use crate::auth::types::{
     RefreshAuthContext, RuntimeBinding, StartAuthContext, StoredCredential, UpdateAuthSession,
 };
 use crate::db::models::*;
-use crate::protocol::{Protocol, ProviderProtocols};
+use crate::protocol::ProviderProtocols;
+use crate::protocol::ids::OPENAI_CHAT_V1;
 use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
 use crate::protocol::vendor::{VendorCtx, VendorRegistry};
 use crate::proxy::client::ProxyClient;
@@ -569,8 +570,8 @@ impl AdminService {
                 vendor,
                 protocol: input.protocol,
                 base_url: input.base_url,
-                default_protocol: input.default_protocol,
-                protocol_endpoints: input.protocol_endpoints,
+                default_protocol: normalize_default_protocol_field(input.default_protocol),
+                protocol_endpoints: normalize_protocol_endpoints_field(input.protocol_endpoints),
                 preset_key: input.preset_key,
                 channel: input.channel,
                 models_source: input.models_source,
@@ -631,8 +632,8 @@ impl AdminService {
                     vendor,
                     protocol: Some(protocol),
                     base_url: Some(base_url),
-                    default_protocol: input.default_protocol,
-                    protocol_endpoints: input.protocol_endpoints,
+                    default_protocol: normalize_default_protocol_field(input.default_protocol),
+                    protocol_endpoints: normalize_protocol_endpoints_field(input.protocol_endpoints),
                     preset_key,
                     channel,
                     models_source,
@@ -2509,6 +2510,36 @@ fn normalize_vendor(vendor: Option<&str>) -> Option<String> {
         .map(|v| v.to_lowercase())
 }
 
+/// Rewrite a `default_protocol` field into canonical
+/// [`ProtocolId`](crate::protocol::ids::ProtocolId) form before
+/// persistence. `None` and empty strings pass through unchanged so we
+/// don't surprise callers that explicitly want to clear the field.
+fn normalize_default_protocol_field(value: Option<String>) -> Option<String> {
+    let s = value?;
+    if s.trim().is_empty() {
+        return Some(s);
+    }
+    Some(crate::protocol::normalize::normalize_protocol_string(
+        &s,
+        crate::protocol::registry::ProtocolRegistry::global(),
+    ))
+}
+
+/// Rewrite a `protocol_endpoints` JSON blob (with possibly legacy /
+/// alias keys) into canonical [`ProtocolId`](crate::protocol::ids::ProtocolId)
+/// keys before persistence. `None` and empty / `{}` strings pass through.
+fn normalize_protocol_endpoints_field(value: Option<String>) -> Option<String> {
+    let s = value?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed == "{}" {
+        return Some(s);
+    }
+    Some(crate::protocol::normalize::normalize_protocol_endpoints_json(
+        &s,
+        crate::protocol::registry::ProtocolRegistry::global(),
+    ))
+}
+
 fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
     if let Some(endpoint) = provider.effective_models_source() {
         let trimmed = endpoint.trim();
@@ -2544,10 +2575,10 @@ fn provider_supports_openai_endpoint(provider: &Provider) -> bool {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(Protocol::OpenAI) {
+    if !protocols.supports(OPENAI_CHAT_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(Protocol::OpenAI);
+    let resolved = protocols.resolve_egress(OPENAI_CHAT_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         return None;
@@ -2585,19 +2616,39 @@ fn resolve_provider_credential(provider: &Provider) -> anyhow::Result<String> {
 }
 
 fn sync_runtime_protocol_endpoints(provider: &Provider, base_url: &str) -> anyhow::Result<String> {
-    let mut endpoints = provider.parsed_protocol_endpoints();
-    let runtime_base_url = base_url.trim();
+    use crate::protocol::registry::ProtocolRegistry;
+    let reg = ProtocolRegistry::global();
 
+    // Re-key the existing endpoints map to canonical ProtocolId form so any
+    // legacy / alias keys round-trip into a normalized shape on every sync.
+    let raw = provider.parsed_protocol_endpoints();
+    let mut endpoints: std::collections::HashMap<String, ProtocolEndpointEntry> =
+        std::collections::HashMap::with_capacity(raw.len());
+    for (key, val) in raw {
+        let canonical = reg
+            .resolve_alias(&key)
+            .map(|id| id.to_string())
+            .unwrap_or(key);
+        endpoints.entry(canonical).or_insert(val);
+    }
+
+    let runtime_base_url = base_url.trim();
     if runtime_base_url.is_empty() {
         return Ok(serde_json::to_string(&endpoints)?);
     }
 
-    let default_protocol = provider.effective_default_protocol().trim().to_string();
-    let legacy_protocol = provider.protocol.trim().to_string();
+    let default_protocol = reg
+        .resolve_alias(provider.effective_default_protocol().trim())
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| provider.effective_default_protocol().trim().to_string());
+    let legacy_protocol = reg
+        .resolve_alias(provider.protocol.trim())
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| provider.protocol.trim().to_string());
 
     // If default_protocol differs from the legacy protocol field, the provider
-    // has been upgraded (e.g. openai → openai_responses via OAuth bind).
-    // Remove the stale legacy entry so only the current protocol remains.
+    // has been upgraded (e.g. chat → responses via OAuth bind). Remove the
+    // stale legacy entry so only the current protocol remains.
     if !default_protocol.is_empty()
         && !legacy_protocol.is_empty()
         && default_protocol != legacy_protocol

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -8,6 +8,11 @@ use sqlx::Row;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
+use crate::protocol::normalize::{
+    normalize_protocol_endpoints_json, normalize_protocol_string,
+};
+use crate::protocol::registry::ProtocolRegistry;
+
 static SQLITE_VEC_INIT: Once = Once::new();
 const VECTOR_DIMENSIONS_SETTING_KEY: &str = "vector_embedding_dimensions";
 
@@ -88,8 +93,63 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     ensure_semantic_cache_vectors_table(pool, vector_dimensions).await?;
     backfill_provider_vendor(pool).await?;
     migrate_vendor_renames(pool).await?;
+    normalize_provider_protocols(pool).await?;
     backfill_route_fields(pool).await?;
     backfill_route_targets(pool).await?;
+    Ok(())
+}
+
+/// Rewrites legacy / alias protocol identifiers in `providers` rows into
+/// canonical [`ProtocolId`](crate::protocol::ids::ProtocolId) strings.
+///
+/// Two columns are touched:
+///
+/// - `providers.default_protocol` — single value, e.g. `"openai"` →
+///   `"openai/chat/v1"`.
+/// - `providers.protocol_endpoints` — JSON object, e.g.
+///   `{ "openai": {...}, "openai_responses": {...} }` →
+///   `{ "openai/chat/v1": {...}, "openai/responses/v1": {...} }`.
+///
+/// Idempotent: re-running on already-normalized rows is a no-op (the
+/// row signature is unchanged so no UPDATE is issued). Unknown keys are
+/// preserved verbatim with a `tracing::warn` so a foreign yaml import
+/// can still be inspected manually.
+async fn normalize_provider_protocols(pool: &SqlitePool) -> anyhow::Result<()> {
+    let reg = ProtocolRegistry::global();
+    let rows = sqlx::query("SELECT id, default_protocol, protocol_endpoints FROM providers")
+        .fetch_all(pool)
+        .await?;
+
+    for row in rows {
+        let id: String = row.try_get("id")?;
+        let raw_default: String = row.try_get("default_protocol").unwrap_or_default();
+        let raw_endpoints: String = row.try_get("protocol_endpoints").unwrap_or_default();
+
+        let new_default = normalize_protocol_string(&raw_default, reg);
+        let new_endpoints = normalize_protocol_endpoints_json(&raw_endpoints, reg);
+
+        let default_changed = new_default != raw_default;
+        let endpoints_changed = new_endpoints != raw_endpoints;
+        if !default_changed && !endpoints_changed {
+            continue;
+        }
+
+        tracing::info!(
+            provider_id = %id,
+            default_changed,
+            endpoints_changed,
+            "normalizing provider protocol identifiers to canonical ProtocolId form"
+        );
+
+        sqlx::query(
+            "UPDATE providers SET default_protocol = ?1, protocol_endpoints = ?2 WHERE id = ?3",
+        )
+        .bind(&new_default)
+        .bind(&new_endpoints)
+        .bind(&id)
+        .execute(pool)
+        .await?;
+    }
     Ok(())
 }
 

--- a/crates/nyro-core/src/protocol/anthropic/decoder.rs
+++ b/crates/nyro-core/src/protocol/anthropic/decoder.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use serde_json::Value;
 
+use crate::protocol::IngressDecoder;
+use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
 use crate::protocol::types::*;
-use crate::protocol::{IngressDecoder, Protocol};
 
 use super::types::*;
 
@@ -58,7 +59,7 @@ impl IngressDecoder for AnthropicDecoder {
             top_p: req.top_p,
             tools,
             tool_choice: req.tool_choice,
-            source_protocol: Protocol::Anthropic,
+            source_protocol: ANTHROPIC_MESSAGES_2023_06_01,
             extra: Default::default(),
         })
     }

--- a/crates/nyro-core/src/protocol/family/openai/embeddings.rs
+++ b/crates/nyro-core/src/protocol/family/openai/embeddings.rs
@@ -30,7 +30,7 @@ use crate::protocol::ids::{OPENAI_EMBEDDINGS_V1, ProtocolCapabilities, ProtocolI
 use crate::protocol::registry::ProtocolRegistration;
 use crate::protocol::traits::*;
 use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta, TokenUsage};
-use crate::protocol::{Protocol, SseEvent};
+use crate::protocol::SseEvent;
 
 pub const EMBEDDINGS_BODY_KEY: &str = "__embeddings_passthrough_body__";
 
@@ -104,7 +104,7 @@ impl IngressDecoder for EmbeddingsPassthroughDecoder {
             top_p: None,
             tools: None,
             tool_choice: None,
-            source_protocol: Protocol::OpenAI,
+            source_protocol: OPENAI_EMBEDDINGS_V1,
             extra,
         })
     }

--- a/crates/nyro-core/src/protocol/gemini/decoder.rs
+++ b/crates/nyro-core/src/protocol/gemini/decoder.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use serde_json::Value;
 
+use crate::protocol::IngressDecoder;
+use crate::protocol::ids::GOOGLE_GENERATE_V1BETA;
 use crate::protocol::types::*;
-use crate::protocol::{IngressDecoder, Protocol};
 
 use super::types::*;
 
@@ -67,7 +68,7 @@ impl GeminiDecoder {
             top_p,
             tools,
             tool_choice: None,
-            source_protocol: Protocol::Gemini,
+            source_protocol: GOOGLE_GENERATE_V1BETA,
             extra: Default::default(),
         })
     }

--- a/crates/nyro-core/src/protocol/ids.rs
+++ b/crates/nyro-core/src/protocol/ids.rs
@@ -64,6 +64,16 @@ impl ProtocolId {
     ) -> Self {
         Self { family, dialect, version }
     }
+
+    /// Look up the registered handler for this id.
+    ///
+    /// Panics only if no `inventory::submit!` registration exists — a
+    /// build-time invariant covered by `tests/protocol_registry.rs`.
+    pub fn handler(self) -> &'static std::sync::Arc<dyn super::traits::ProtocolHandler> {
+        super::registry::ProtocolRegistry::global()
+            .get(&self)
+            .unwrap_or_else(|| panic!("ProtocolHandler for {self} not registered"))
+    }
 }
 
 impl fmt::Display for ProtocolId {

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -1,6 +1,6 @@
 //! Protocol layer.
 //!
-//! # Two-layer identity (PR1+)
+//! # Two-layer identity
 //!
 //! Canonical form: `{family}/{dialect}/{wire_version}`.
 //!
@@ -8,21 +8,20 @@
 //! - `dialect`: wire-format verb/noun (`chat`, `responses`, `messages`, `generate`).
 //! - `wire_version`: schema version as the vendor labels it (`v1`, `2023-06-01`, `v1beta`).
 //!
-//! See [`ids`], [`traits`], [`registry`], and [`family`] for the new model.
-//! The legacy [`Protocol`] enum, factory functions, and [`ProviderProtocols`]
-//! below remain in place during PR1; PR3/PR4 migrate the call sites and
-//! delete them.
+//! See [`ids`], [`traits`], [`registry`], and [`family`] for the model.
 //!
-//! ## Default alias table (resolved at runtime in [`registry::ProtocolRegistry::resolve_alias`])
+//! ## Alias table (resolved at runtime in [`registry::ProtocolRegistry::resolve_alias`])
 //!
 //! Primary short names: `openai-chat`, `openai-responses`, `anthropic-messages`,
 //! `google-generate` (kebab-case `{family}-{dialect}` form).
 //!
-//! Friendly aliases: `responses` → OpenAI Responses, `claude` → Anthropic Messages.
+//! Friendly aliases: `responses` → OpenAI Responses, `claude` → Anthropic Messages,
+//! `embeddings` → OpenAI Embeddings.
 //!
-//! Legacy values from the old `Protocol` enum: `openai`, `openai_responses`,
-//! `anthropic`, `gemini` — still resolvable for back-compat with old DB rows
-//! and yaml configs until PR4 normalizes the write paths.
+//! Legacy strings from the pre-PR4 `Protocol` enum (`openai`, `openai_responses`,
+//! `anthropic`, `gemini`) remain resolvable for back-compat: the DB startup
+//! migration rewrites stored values to canonical [`ids::ProtocolId`] strings, but
+//! older yaml configs / older DB snapshots may still carry the legacy spellings.
 
 pub mod types;
 pub mod openai;
@@ -35,84 +34,14 @@ pub mod traits;
 pub mod registry;
 pub mod family;
 pub mod vendor;
+pub mod normalize;
 
 use std::collections::HashMap;
 
 use reqwest::header::HeaderMap;
 
 use crate::db::models::{Provider, ProtocolEndpointEntry};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Protocol {
-    OpenAI,
-    Anthropic,
-    Gemini,
-    /// OpenAI Responses API (`POST /v1/responses`).
-    /// Routes as "openai" but uses Responses-specific formatters.
-    #[serde(rename = "openai_responses")]
-    ResponsesAPI,
-}
-
-impl Protocol {
-    /// The base protocol string used for route matching.
-    /// `ResponsesAPI` shares routes with `OpenAI`.
-    pub fn route_protocol(&self) -> &'static str {
-        match self {
-            Protocol::OpenAI | Protocol::ResponsesAPI => "openai",
-            Protocol::Anthropic => "anthropic",
-            Protocol::Gemini => "gemini",
-        }
-    }
-
-    /// Bridge from the legacy enum to the new `ProtocolId`.
-    ///
-    /// PR3 plumbing only — once PR4 deletes the enum, every call site
-    /// will already use `ProtocolId` natively and this disappears.
-    pub fn to_protocol_id(self) -> ids::ProtocolId {
-        match self {
-            Protocol::OpenAI => ids::OPENAI_CHAT_V1,
-            Protocol::ResponsesAPI => ids::OPENAI_RESPONSES_V1,
-            Protocol::Anthropic => ids::ANTHROPIC_MESSAGES_2023_06_01,
-            Protocol::Gemini => ids::GOOGLE_GENERATE_V1BETA,
-        }
-    }
-
-    /// Resolve this protocol's registered handler. Panics only if the
-    /// `inventory::submit!` registration is missing — a build-time
-    /// invariant covered by `tests/protocol_registry.rs`.
-    pub fn handler(self) -> &'static std::sync::Arc<dyn traits::ProtocolHandler> {
-        let id = self.to_protocol_id();
-        registry::ProtocolRegistry::global()
-            .get(&id)
-            .unwrap_or_else(|| panic!("ProtocolHandler for {id} not registered"))
-    }
-}
-
-impl std::fmt::Display for Protocol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Protocol::OpenAI => write!(f, "openai"),
-            Protocol::Anthropic => write!(f, "anthropic"),
-            Protocol::Gemini => write!(f, "gemini"),
-            Protocol::ResponsesAPI => write!(f, "openai_responses"),
-        }
-    }
-}
-
-impl std::str::FromStr for Protocol {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "openai" => Ok(Protocol::OpenAI),
-            "anthropic" => Ok(Protocol::Anthropic),
-            "gemini" => Ok(Protocol::Gemini),
-            "openai_responses" => Ok(Protocol::ResponsesAPI),
-            _ => anyhow::bail!("unknown protocol: {s}"),
-        }
-    }
-}
+use crate::protocol::ids::ProtocolId;
 
 // ── Client → Gateway ──
 
@@ -187,145 +116,68 @@ impl SseEvent {
     }
 }
 
-// ── Factory functions ──
-
-pub fn get_decoder(protocol: Protocol) -> Box<dyn IngressDecoder + Send> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::decoder::OpenAIDecoder),
-        Protocol::Anthropic => Box::new(anthropic::decoder::AnthropicDecoder),
-        Protocol::Gemini => Box::new(gemini::decoder::GeminiDecoder),
-        Protocol::ResponsesAPI => Box::new(openai::responses::decoder::ResponsesDecoder),
-    }
-}
-
-pub fn get_encoder(protocol: Protocol) -> Box<dyn EgressEncoder + Send> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::encoder::OpenAIEncoder),
-        Protocol::ResponsesAPI => Box::new(openai::responses::encoder::ResponsesEncoder),
-        Protocol::Anthropic => Box::new(anthropic::encoder::AnthropicEncoder),
-        Protocol::Gemini => Box::new(gemini::encoder::GeminiEncoder),
-    }
-}
-
-pub fn get_response_parser(protocol: Protocol) -> Box<dyn ResponseParser> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::stream::OpenAIResponseParser),
-        Protocol::ResponsesAPI => Box::new(openai::responses::parser::ResponsesResponseParser),
-        Protocol::Anthropic => Box::new(anthropic::stream::AnthropicResponseParser),
-        Protocol::Gemini => Box::new(gemini::stream::GeminiResponseParser),
-    }
-}
-
-pub fn get_response_formatter(protocol: Protocol) -> Box<dyn ResponseFormatter> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::stream::OpenAIResponseFormatter),
-        Protocol::Anthropic => Box::new(anthropic::stream::AnthropicResponseFormatter),
-        Protocol::Gemini => Box::new(gemini::stream::GeminiResponseFormatter),
-        Protocol::ResponsesAPI => {
-            Box::new(openai::responses::formatter::ResponsesResponseFormatter)
-        }
-    }
-}
-
-pub fn get_stream_parser(protocol: Protocol) -> Box<dyn StreamParser> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::stream::OpenAIStreamParser::new()),
-        Protocol::ResponsesAPI => {
-            Box::new(openai::responses::parser::ResponsesStreamParser::new())
-        }
-        Protocol::Anthropic => Box::new(anthropic::stream::AnthropicStreamParser::new()),
-        Protocol::Gemini => Box::new(gemini::stream::GeminiStreamParser::new()),
-    }
-}
-
-pub fn get_stream_formatter(protocol: Protocol) -> Box<dyn StreamFormatter> {
-    match protocol {
-        Protocol::OpenAI => Box::new(openai::stream::OpenAIStreamFormatter::new()),
-        Protocol::Anthropic => Box::new(anthropic::stream::AnthropicStreamFormatter::new()),
-        Protocol::Gemini => Box::new(gemini::stream::GeminiStreamFormatter::new()),
-        Protocol::ResponsesAPI => {
-            Box::new(openai::responses::stream::ResponsesStreamFormatter::new())
-        }
-    }
-}
-
 // ── Provider multi-protocol negotiation ──
 
 #[derive(Debug, Clone)]
 pub struct ProviderProtocols {
-    pub default: Protocol,
-    pub endpoints: HashMap<Protocol, ProtocolEndpointEntry>,
+    pub default: ProtocolId,
+    pub endpoints: HashMap<ProtocolId, ProtocolEndpointEntry>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ResolvedEgress {
-    pub protocol: Protocol,
+    pub protocol: ProtocolId,
     pub base_url: String,
     pub needs_conversion: bool,
 }
 
 impl ProviderProtocols {
-    /// Best-effort string → `Protocol` resolver. Accepts:
+    /// Best-effort string → [`ProtocolId`] resolver.
     ///
-    /// - legacy strings (`openai` / `openai_responses` / `anthropic` / `gemini`),
-    /// - the new alias table (`openai-chat`, `responses`, `claude`, …),
-    /// - canonical [`ids::ProtocolId`] strings (`openai/chat/v1`, …).
+    /// Accepts legacy strings (`openai` / `openai_responses` / `anthropic` /
+    /// `gemini`), short aliases (`openai-chat`, `responses`, `claude`, …),
+    /// and canonical `family/dialect/version` strings — all routed through
+    /// [`registry::ProtocolRegistry::resolve_alias`].
     ///
-    /// Used to read `provider.protocol_endpoints` JSON during runtime — DB
-    /// rows may carry any of the three forms during the PR3/PR4 transition.
-    fn parse_protocol_key(s: &str) -> Option<Protocol> {
-        if let Ok(p) = s.parse::<Protocol>() {
-            return Some(p);
-        }
-        let id = registry::ProtocolRegistry::global().resolve_alias(s)?;
-        if id == ids::OPENAI_CHAT_V1 {
-            Some(Protocol::OpenAI)
-        } else if id == ids::OPENAI_RESPONSES_V1 {
-            Some(Protocol::ResponsesAPI)
-        } else if id == ids::ANTHROPIC_MESSAGES_2023_06_01 {
-            Some(Protocol::Anthropic)
-        } else if id == ids::GOOGLE_GENERATE_V1BETA {
-            Some(Protocol::Gemini)
-        } else {
-            // Embeddings and other dialects are not part of the legacy
-            // `Protocol` enum surface; they bypass `ProviderProtocols`.
-            None
-        }
+    /// Returns `None` for unknown keys so we silently drop garbage from old
+    /// DB rows instead of panicking.
+    pub fn parse_protocol_key(s: &str) -> Option<ProtocolId> {
+        registry::ProtocolRegistry::global().resolve_alias(s)
     }
 
     pub fn from_provider(provider: &Provider) -> Self {
         let raw_map = provider.parsed_protocol_endpoints();
-        let mut endpoints: HashMap<Protocol, ProtocolEndpointEntry> = HashMap::new();
+        let mut endpoints: HashMap<ProtocolId, ProtocolEndpointEntry> = HashMap::new();
         for (key, entry) in &raw_map {
-            if let Some(p) = Self::parse_protocol_key(key)
-                && !endpoints.contains_key(&p)
+            if let Some(id) = Self::parse_protocol_key(key)
+                && !endpoints.contains_key(&id)
             {
-                endpoints.insert(p, entry.clone());
+                endpoints.insert(id, entry.clone());
             }
         }
 
         let declared_default = Self::parse_protocol_key(&provider.effective_default_protocol());
         let default = declared_default
-            .filter(|p| endpoints.contains_key(p))
+            .filter(|id| endpoints.contains_key(id))
             .or_else(|| endpoints.keys().next().copied())
             .or(declared_default)
-            .unwrap_or(Protocol::OpenAI);
+            .unwrap_or(ids::OPENAI_CHAT_V1);
 
         Self { default, endpoints }
     }
 
-    pub fn supports(&self, protocol: Protocol) -> bool {
+    pub fn supports(&self, protocol: ProtocolId) -> bool {
         self.endpoints.contains_key(&protocol)
     }
 
     /// Three-tier egress resolution:
     ///
-    /// 1. **Exact `ProtocolId` match** — same wire format on both sides.
-    /// 2. **Same-family fallback** — e.g. ingress `openai-responses` against
-    ///    a provider that only declares `openai-chat`; we still talk OpenAI,
+    /// 1. **Exact [`ProtocolId`] match** — same wire format on both sides.
+    /// 2. **Same-family fallback** — e.g. ingress `openai/responses/v1` against
+    ///    a provider that only declares `openai/chat/v1`; we still talk OpenAI,
     ///    but the codec layer must translate.
     /// 3. **Global default** — last resort, also conversion needed.
-    pub fn resolve_egress(&self, ingress: Protocol) -> ResolvedEgress {
+    pub fn resolve_egress(&self, ingress: ProtocolId) -> ResolvedEgress {
         if let Some(ep) = self.endpoints.get(&ingress) {
             return ResolvedEgress {
                 protocol: ingress,
@@ -334,14 +186,13 @@ impl ProviderProtocols {
             };
         }
 
-        let target_family = ingress.to_protocol_id().family;
-        if let Some((p, ep)) = self
+        if let Some((id, ep)) = self
             .endpoints
             .iter()
-            .find(|(p, _)| p.to_protocol_id().family == target_family)
+            .find(|(id, _)| id.family == ingress.family)
         {
             return ResolvedEgress {
-                protocol: *p,
+                protocol: *id,
                 base_url: ep.base_url.clone(),
                 needs_conversion: true,
             };

--- a/crates/nyro-core/src/protocol/normalize.rs
+++ b/crates/nyro-core/src/protocol/normalize.rs
@@ -1,0 +1,155 @@
+//! Protocol-identifier normalization helpers.
+//!
+//! Used both by the DB startup migration (`db::mod::normalize_provider_protocols`
+//! / `storage::postgres::normalize_provider_protocols`) and the write-path
+//! gating (yaml import + admin CRUD + preset install + sync_runtime).
+//!
+//! Every persisted protocol identifier flows through these helpers so that
+//! the storage layer always carries the canonical
+//! `family/dialect/version` form. Unrecognized values are preserved
+//! verbatim with a `tracing::warn!`, leaving room for foreign or future
+//! identifiers to be inspected manually instead of silently dropped.
+
+use crate::protocol::registry::ProtocolRegistry;
+
+/// Normalize a single protocol identifier string.
+///
+/// Returns the canonical [`crate::protocol::ids::ProtocolId`] `to_string()`
+/// form, or the trimmed input verbatim if no alias matches.
+pub fn normalize_protocol_string(raw: &str, reg: &ProtocolRegistry) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match reg.resolve_alias(trimmed) {
+        Some(id) => id.to_string(),
+        None => {
+            tracing::warn!(
+                value = trimmed,
+                "leaving unrecognized protocol identifier unchanged"
+            );
+            trimmed.to_string()
+        }
+    }
+}
+
+/// Rewrite every key of a `protocol_endpoints`-shaped JSON object into
+/// canonical [`crate::protocol::ids::ProtocolId`] form. Returns the input
+/// verbatim if it is not a JSON object (so empty `"{}"` stays `"{}"`).
+///
+/// Collisions (legacy `openai` and canonical `openai/chat/v1` both
+/// present in the same row) are resolved with first-writer-wins on the
+/// canonical key — we never overwrite an already-normalized entry.
+pub fn normalize_protocol_endpoints_json(raw: &str, reg: &ProtocolRegistry) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "{}" {
+        return raw.to_string();
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        tracing::warn!(value = trimmed, "skipping protocol_endpoints normalization: invalid JSON");
+        return raw.to_string();
+    };
+    let Some(obj) = value.as_object() else {
+        return raw.to_string();
+    };
+
+    let mut next = serde_json::Map::with_capacity(obj.len());
+    for (key, val) in obj {
+        let canonical = match reg.resolve_alias(key) {
+            Some(id) => id.to_string(),
+            None => {
+                tracing::warn!(
+                    key = %key,
+                    "leaving unrecognized protocol_endpoints key unchanged"
+                );
+                key.clone()
+            }
+        };
+        next.entry(canonical).or_insert_with(|| val.clone());
+    }
+
+    serde_json::Value::Object(next).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::ids::{
+        ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+    };
+
+    #[test]
+    fn normalizes_legacy_protocol_strings() {
+        let reg = ProtocolRegistry::global();
+        assert_eq!(normalize_protocol_string("openai", reg), OPENAI_CHAT_V1.to_string());
+        assert_eq!(
+            normalize_protocol_string("openai_responses", reg),
+            OPENAI_RESPONSES_V1.to_string()
+        );
+        assert_eq!(
+            normalize_protocol_string("anthropic", reg),
+            ANTHROPIC_MESSAGES_2023_06_01.to_string()
+        );
+        assert_eq!(
+            normalize_protocol_string("gemini", reg),
+            GOOGLE_GENERATE_V1BETA.to_string()
+        );
+    }
+
+    #[test]
+    fn idempotent_on_canonical_strings() {
+        let reg = ProtocolRegistry::global();
+        for s in [
+            OPENAI_CHAT_V1.to_string(),
+            OPENAI_RESPONSES_V1.to_string(),
+            ANTHROPIC_MESSAGES_2023_06_01.to_string(),
+            GOOGLE_GENERATE_V1BETA.to_string(),
+        ] {
+            assert_eq!(normalize_protocol_string(&s, reg), s);
+        }
+    }
+
+    #[test]
+    fn preserves_unknown_strings() {
+        let reg = ProtocolRegistry::global();
+        assert_eq!(
+            normalize_protocol_string("foo/bar/baz", reg),
+            "foo/bar/baz".to_string()
+        );
+    }
+
+    #[test]
+    fn normalizes_endpoints_json_keys() {
+        let reg = ProtocolRegistry::global();
+        let raw = r#"{"openai":{"base_url":"a"},"openai_responses":{"base_url":"b"}}"#;
+        let normalized = normalize_protocol_endpoints_json(raw, reg);
+        let v: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key(&OPENAI_CHAT_V1.to_string()));
+        assert!(obj.contains_key(&OPENAI_RESPONSES_V1.to_string()));
+        assert!(!obj.contains_key("openai"));
+    }
+
+    #[test]
+    fn empty_endpoints_pass_through() {
+        let reg = ProtocolRegistry::global();
+        assert_eq!(normalize_protocol_endpoints_json("{}", reg), "{}");
+        assert_eq!(normalize_protocol_endpoints_json("", reg), "");
+    }
+
+    #[test]
+    fn endpoints_collision_keeps_canonical_first() {
+        let reg = ProtocolRegistry::global();
+        // Both legacy and canonical present: order in input is `openai`
+        // before `openai/chat/v1`, but both normalize to the same key
+        // `openai/chat/v1`. The canonical entry must win — first-writer-
+        // wins is what we get because both map to the same key and the
+        // first insert holds.
+        let raw = r#"{"openai":{"base_url":"legacy"},"openai/chat/v1":{"base_url":"canonical"}}"#;
+        let normalized = normalize_protocol_endpoints_json(raw, reg);
+        let v: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+        let entry = v.get(OPENAI_CHAT_V1.to_string().as_str()).unwrap();
+        // First writer wins → "legacy" comes first in the input map.
+        assert_eq!(entry["base_url"], "legacy");
+    }
+}

--- a/crates/nyro-core/src/protocol/openai/decoder.rs
+++ b/crates/nyro-core/src/protocol/openai/decoder.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use serde_json::Value;
 
+use crate::protocol::IngressDecoder;
+use crate::protocol::ids::OPENAI_CHAT_V1;
 use crate::protocol::types::*;
-use crate::protocol::{IngressDecoder, Protocol};
 
 use super::types::*;
 
@@ -41,7 +42,7 @@ impl IngressDecoder for OpenAIDecoder {
             top_p: req.top_p,
             tools,
             tool_choice: req.tool_choice,
-            source_protocol: Protocol::OpenAI,
+            source_protocol: OPENAI_CHAT_V1,
             extra: req.extra,
         })
     }

--- a/crates/nyro-core/src/protocol/openai/responses/decoder.rs
+++ b/crates/nyro-core/src/protocol/openai/responses/decoder.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use anyhow::Result;
 use serde_json::Value;
 
+use crate::protocol::IngressDecoder;
+use crate::protocol::ids::OPENAI_RESPONSES_V1;
 use crate::protocol::types::*;
-use crate::protocol::{IngressDecoder, Protocol};
 
 pub struct ResponsesDecoder;
 
@@ -96,7 +97,7 @@ impl IngressDecoder for ResponsesDecoder {
             top_p,
             tools,
             tool_choice,
-            source_protocol: Protocol::ResponsesAPI,
+            source_protocol: OPENAI_RESPONSES_V1,
             extra,
         })
     }

--- a/crates/nyro-core/src/protocol/semantic/tool_correlation.rs
+++ b/crates/nyro-core/src/protocol/semantic/tool_correlation.rs
@@ -133,8 +133,8 @@ fn extract_tool_result_hint(content: &MessageContent) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::ids::OPENAI_CHAT_V1;
     use crate::protocol::types::MessageContent;
-    use crate::protocol::Protocol;
 
     fn make_req(messages: Vec<InternalMessage>) -> InternalRequest {
         InternalRequest {
@@ -146,7 +146,7 @@ mod tests {
             top_p: None,
             tools: None,
             tool_choice: None,
-            source_protocol: Protocol::OpenAI,
+            source_protocol: OPENAI_CHAT_V1,
             extra: Default::default(),
         }
     }

--- a/crates/nyro-core/src/protocol/types.rs
+++ b/crates/nyro-core/src/protocol/types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::Protocol;
+use super::ids::ProtocolId;
 
 // ── Ingress: client request → internal ──
 
@@ -17,7 +17,7 @@ pub struct InternalRequest {
     pub top_p: Option<f64>,
     pub tools: Option<Vec<ToolDef>>,
     pub tool_choice: Option<Value>,
-    pub source_protocol: Protocol,
+    pub source_protocol: ProtocolId,
     pub extra: HashMap<String, Value>,
 }
 

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -24,11 +24,14 @@ use crate::cache::entry::CacheEntry;
 use crate::cache::key::{build_cache_key, build_semantic_partition};
 use crate::logging::LogEntry;
 use crate::protocol::gemini::decoder::GeminiDecoder;
-use crate::protocol::ids::{OPENAI_EMBEDDINGS_V1, ProtocolCapabilities};
+use crate::protocol::ids::{
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_EMBEDDINGS_V1,
+    OPENAI_RESPONSES_V1, ProtocolCapabilities, ProtocolId,
+};
 use crate::protocol::registry::ProtocolRegistry;
 use crate::protocol::types::*;
 use crate::protocol::vendor::{VendorCtx, VendorRegistry};
-use crate::protocol::{Protocol, ProviderProtocols};
+use crate::protocol::ProviderProtocols;
 use crate::proxy::client::ProxyClient;
 use crate::router::TargetSelector;
 use crate::storage::traits::{ApiKeyAccessRecord, UsageWindow};
@@ -41,7 +44,7 @@ pub async fn openai_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::OpenAI, "/v1/chat/completions").await
+    universal_proxy(gw, headers, body, OPENAI_CHAT_V1, "/v1/chat/completions").await
 }
 
 // ── OpenAI Responses API ingress: POST /v1/responses ──
@@ -51,7 +54,7 @@ pub async fn responses_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::ResponsesAPI, "/v1/responses").await
+    universal_proxy(gw, headers, body, OPENAI_RESPONSES_V1, "/v1/responses").await
 }
 
 // ── OpenAI embeddings ingress: POST /v1/embeddings ──
@@ -384,7 +387,7 @@ pub async fn anthropic_proxy(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    universal_proxy(gw, headers, body, Protocol::Anthropic, "/v1/messages").await
+    universal_proxy(gw, headers, body, ANTHROPIC_MESSAGES_2023_06_01, "/v1/messages").await
 }
 
 // ── Gemini ingress: POST /v1beta/models/:model_action ──
@@ -443,7 +446,7 @@ pub async fn gemini_proxy(
         gw,
         headers,
         internal,
-        Protocol::Gemini,
+        GOOGLE_GENERATE_V1BETA,
         "POST",
         &path,
         request_headers,
@@ -510,7 +513,7 @@ async fn universal_proxy(
     gw: Gateway,
     headers: HeaderMap,
     body: Value,
-    ingress: Protocol,
+    ingress: ProtocolId,
     path: &'static str,
 ) -> Response {
     let request_headers = headers_to_json(&headers);
@@ -566,7 +569,7 @@ async fn proxy_pipeline(
     gw: Gateway,
     headers: HeaderMap,
     internal: InternalRequest,
-    ingress: Protocol,
+    ingress: ProtocolId,
     method: &str,
     path: &str,
     request_headers_str: Option<String>,
@@ -1001,10 +1004,10 @@ async fn proxy_pipeline(
             resolved.base_url
         };
 
-        // [PR3] Resolve protocol handler + vendor extension. Both are
+        // Resolve protocol handler + vendor extension. Both are
         // process-global registrations; lookup is O(1) for handlers and
         // small linear scans for extensions.
-        let egress_id = egress.to_protocol_id();
+        let egress_id = egress;
         let egress_handler = match ProtocolRegistry::global().get(&egress_id) {
             Some(h) => h.clone(),
             None => {
@@ -1237,8 +1240,8 @@ async fn handle_non_stream(
     url: &str,
     headers: reqwest::header::HeaderMap,
     provider: &Provider,
-    egress: Protocol,
-    ingress: Protocol,
+    egress: ProtocolId,
+    ingress: ProtocolId,
     body: Value,
     ingress_str: &str,
     egress_str: &str,
@@ -1397,8 +1400,8 @@ async fn handle_non_stream_via_upstream_stream(
     url: &str,
     headers: reqwest::header::HeaderMap,
     provider: &Provider,
-    egress: Protocol,
-    ingress: Protocol,
+    egress: ProtocolId,
+    ingress: ProtocolId,
     body: Value,
     ingress_str: &str,
     egress_str: &str,
@@ -1559,8 +1562,8 @@ async fn handle_stream(
     url: &str,
     headers: reqwest::header::HeaderMap,
     provider: &Provider,
-    egress: Protocol,
-    ingress: Protocol,
+    egress: ProtocolId,
+    ingress: ProtocolId,
     body: Value,
     ingress_str: &str,
     egress_str: &str,
@@ -2177,10 +2180,10 @@ fn parse_embedding_vector(payload: &Value) -> Option<Vec<f32>> {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(Protocol::OpenAI) {
+    if !protocols.supports(OPENAI_CHAT_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(Protocol::OpenAI);
+    let resolved = protocols.resolve_egress(OPENAI_CHAT_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         return None;
@@ -2311,7 +2314,7 @@ fn set_cache_headers(
 }
 
 fn cached_entry_to_response(
-    ingress: Protocol,
+    ingress: ProtocolId,
     entry: &CacheEntry,
     is_stream: bool,
     cache_key: Option<&str>,
@@ -2343,7 +2346,7 @@ fn cached_entry_to_response(
 }
 
 fn replay_cached_stream(
-    ingress: Protocol,
+    ingress: ProtocolId,
     internal: &InternalResponse,
     cache_key: Option<&str>,
     cache_status: &str,

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -1351,6 +1351,9 @@ END $$;"#,
             .execute(self.adapter.pool())
             .await?;
         }
+        // PR4: rewrite provider protocol identifiers into canonical
+        // `family/dialect/version` form. Idempotent.
+        normalize_provider_protocols_pg(self.adapter.pool()).await?;
         Ok(())
     }
 
@@ -1363,6 +1366,57 @@ END $$;"#,
             writable: health.can_connect,
         })
     }
+}
+
+/// Postgres counterpart of `crate::db::normalize_provider_protocols` —
+/// rewrites legacy / alias protocol identifiers in `providers` rows to
+/// canonical [`ProtocolId`](crate::protocol::ids::ProtocolId) strings.
+///
+/// Touches `providers.default_protocol` (single value) and
+/// `providers.protocol_endpoints` (JSON object keys). Idempotent: a row
+/// with already-canonical values is skipped without an UPDATE.
+async fn normalize_provider_protocols_pg(pool: &Pool<Postgres>) -> anyhow::Result<()> {
+    use crate::protocol::normalize::{
+        normalize_protocol_endpoints_json, normalize_protocol_string,
+    };
+    use crate::protocol::registry::ProtocolRegistry;
+
+    let reg = ProtocolRegistry::global();
+    let rows: Vec<(String, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT id, default_protocol, protocol_endpoints FROM providers",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for (id, raw_default, raw_endpoints) in rows {
+        let raw_default = raw_default.unwrap_or_default();
+        let raw_endpoints = raw_endpoints.unwrap_or_default();
+        let new_default = normalize_protocol_string(&raw_default, reg);
+        let new_endpoints = normalize_protocol_endpoints_json(&raw_endpoints, reg);
+
+        let default_changed = new_default != raw_default;
+        let endpoints_changed = new_endpoints != raw_endpoints;
+        if !default_changed && !endpoints_changed {
+            continue;
+        }
+
+        tracing::info!(
+            provider_id = %id,
+            default_changed,
+            endpoints_changed,
+            "normalizing provider protocol identifiers to canonical ProtocolId form (postgres)"
+        );
+
+        sqlx::query(
+            "UPDATE providers SET default_protocol = $1, protocol_endpoints = $2 WHERE id = $3",
+        )
+        .bind(&new_default)
+        .bind(&new_endpoints)
+        .bind(&id)
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
 }
 
 async fn ensure_semantic_cache_vectors_table(

--- a/crates/nyro-core/tests/db_migration_normalizes_protocols.rs
+++ b/crates/nyro-core/tests/db_migration_normalizes_protocols.rs
@@ -1,0 +1,127 @@
+//! Acceptance: the SQLite startup migration rewrites legacy / alias
+//! protocol identifiers in `providers` rows into canonical
+//! [`ProtocolId`](nyro_core::protocol::ids::ProtocolId) form.
+//!
+//! Two guarantees:
+//!
+//! 1. **First migration normalizes** — a row stored by an older build
+//!    (`default_protocol = "openai"`, endpoint keys `"openai"` /
+//!    `"openai_responses"` / `"anthropic"` / `"gemini"`) gets rewritten
+//!    to the canonical form.
+//! 2. **Second migration is a no-op** — re-running `migrate` on an
+//!    already-normalized DB does not change any rows. We assert this
+//!    by snapshotting the row state before and after.
+
+use nyro_core::db::{init_pool, migrate};
+use nyro_core::protocol::ids::{
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+};
+use sqlx::Row;
+
+#[tokio::test]
+async fn migration_normalizes_legacy_protocol_keys_then_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(dir.path()).await.unwrap();
+
+    // First migration → creates schema.
+    migrate(&pool, 8).await.unwrap();
+
+    // Seed a provider with legacy strings, mimicking a row written by
+    // an older build before the canonical-id rollout.
+    sqlx::query(
+        "INSERT INTO providers (id, name, protocol, base_url, api_key, default_protocol, protocol_endpoints) \
+         VALUES ('p1', 'p1', 'openai', 'https://a.example/v1', 'k', 'openai', \
+         '{\"openai\":{\"base_url\":\"https://a.example/v1\"},\"openai_responses\":{\"base_url\":\"https://b.example/v1\"},\"anthropic\":{\"base_url\":\"https://c.example/v1\"},\"gemini\":{\"base_url\":\"https://d.example/v1\"}}')"
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Second migration → must rewrite the legacy row.
+    migrate(&pool, 8).await.unwrap();
+
+    let row = sqlx::query("SELECT default_protocol, protocol_endpoints FROM providers WHERE id = 'p1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let default_protocol: String = row.try_get("default_protocol").unwrap();
+    let endpoints_raw: String = row.try_get("protocol_endpoints").unwrap();
+    let endpoints: serde_json::Value = serde_json::from_str(&endpoints_raw).unwrap();
+    let obj = endpoints.as_object().unwrap();
+
+    assert_eq!(default_protocol, OPENAI_CHAT_V1.to_string());
+    assert!(obj.contains_key(&OPENAI_CHAT_V1.to_string()));
+    assert!(obj.contains_key(&OPENAI_RESPONSES_V1.to_string()));
+    assert!(obj.contains_key(&ANTHROPIC_MESSAGES_2023_06_01.to_string()));
+    assert!(obj.contains_key(&GOOGLE_GENERATE_V1BETA.to_string()));
+    // Legacy keys must be gone.
+    assert!(!obj.contains_key("openai"));
+    assert!(!obj.contains_key("openai_responses"));
+    assert!(!obj.contains_key("anthropic"));
+    assert!(!obj.contains_key("gemini"));
+
+    // Snapshot the current state, then run migrate() again and verify
+    // nothing changes — the migration must be idempotent.
+    let snapshot_before = sqlx::query("SELECT id, default_protocol, protocol_endpoints FROM providers ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| {
+            (
+                r.get::<String, _>("id"),
+                r.get::<String, _>("default_protocol"),
+                r.get::<String, _>("protocol_endpoints"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    migrate(&pool, 8).await.unwrap();
+
+    let snapshot_after = sqlx::query("SELECT id, default_protocol, protocol_endpoints FROM providers ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| {
+            (
+                r.get::<String, _>("id"),
+                r.get::<String, _>("default_protocol"),
+                r.get::<String, _>("protocol_endpoints"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        snapshot_before, snapshot_after,
+        "second migrate() must be a no-op on already-normalized rows"
+    );
+}
+
+#[tokio::test]
+async fn migration_preserves_unknown_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(dir.path()).await.unwrap();
+    migrate(&pool, 8).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO providers (id, name, protocol, base_url, api_key, default_protocol, protocol_endpoints) \
+         VALUES ('p2', 'p2', 'openai', 'https://a.example/v1', 'k', 'openai', \
+         '{\"openai\":{\"base_url\":\"a\"},\"unknown/dialect/v9\":{\"base_url\":\"x\"}}')"
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    migrate(&pool, 8).await.unwrap();
+
+    let raw: String = sqlx::query_scalar("SELECT protocol_endpoints FROM providers WHERE id = 'p2'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert!(v.get(OPENAI_CHAT_V1.to_string().as_str()).is_some());
+    assert!(
+        v.get("unknown/dialect/v9").is_some(),
+        "unknown keys must round-trip unchanged so foreign data isn't dropped"
+    );
+}

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -18,9 +18,11 @@ use nyro_core::protocol::types::{
     StreamDelta,
     TokenUsage, ToolCall, ToolDef,
 };
+use nyro_core::protocol::ids::{
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+};
 use nyro_core::protocol::{
-    EgressEncoder, IngressDecoder, Protocol, ResponseFormatter, ResponseParser, StreamFormatter,
-    StreamParser,
+    EgressEncoder, IngressDecoder, ResponseFormatter, ResponseParser, StreamFormatter, StreamParser,
 };
 
 #[test]
@@ -198,7 +200,7 @@ fn gemini_tool_result_correlation_success() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::Gemini,
+        source_protocol: GOOGLE_GENERATE_V1BETA,
         extra: Default::default(),
     };
 
@@ -257,7 +259,7 @@ fn gemini_tool_result_id_hint_matches_out_of_order_calls() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::Gemini,
+        source_protocol: GOOGLE_GENERATE_V1BETA,
         extra: Default::default(),
     };
 
@@ -384,7 +386,7 @@ fn openai_encoder_injects_synthetic_tool_call_before_orphan_tool_result() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -441,7 +443,7 @@ fn openai_encoder_injects_adjacent_tool_call_for_non_adjacent_match() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -508,7 +510,7 @@ fn openai_encoder_drops_intermediate_assistant_text_before_tool_result() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -583,7 +585,7 @@ fn openai_encoder_remaps_duplicate_tool_call_ids() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -633,7 +635,7 @@ fn anthropic_encoder_maps_required_tool_choice_to_any() {
             parameters: serde_json::json!({"type":"object","properties":{"command":{"type":"string"}}}),
         }]),
         tool_choice: Some(serde_json::json!("required")),
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -671,7 +673,7 @@ fn anthropic_encoder_maps_function_tool_choice_to_tool_name() {
             "type":"function",
             "function":{"name":"exec_command"}
         })),
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -738,7 +740,7 @@ fn anthropic_encoder_merges_consecutive_roles_and_drops_empty_text() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     };
 
@@ -804,7 +806,7 @@ fn anthropic_encoder_normalizes_tool_use_ids_for_tool_and_result() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: Protocol::Gemini,
+        source_protocol: GOOGLE_GENERATE_V1BETA,
         extra: Default::default(),
     };
 
@@ -900,7 +902,7 @@ fn openai_encoder_remaps_reused_tool_result_id_with_synthetic_adjacent_call() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: Protocol::OpenAI,
+        source_protocol: OPENAI_CHAT_V1,
         extra: Default::default(),
     };
 
@@ -970,7 +972,7 @@ fn openai_encoder_rewrites_multi_tool_call_history_to_adjacent_pairs() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: Protocol::Anthropic,
+        source_protocol: ANTHROPIC_MESSAGES_2023_06_01,
         extra: Default::default(),
     };
 
@@ -1059,7 +1061,7 @@ fn openai_encoder_drops_orphan_assistant_tool_calls_without_results() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: Protocol::Gemini,
+        source_protocol: GOOGLE_GENERATE_V1BETA,
         extra: Default::default(),
     };
 
@@ -1222,7 +1224,7 @@ fn gemini_encoder_sanitizes_unsupported_json_schema_fields() {
             }),
         }]),
         tool_choice: None,
-        source_protocol: Protocol::OpenAI,
+        source_protocol: OPENAI_CHAT_V1,
         extra: Default::default(),
     };
 
@@ -1256,7 +1258,7 @@ fn responses_request(messages: Vec<InternalMessage>, stream: bool) -> InternalRe
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: Protocol::ResponsesAPI,
+        source_protocol: OPENAI_RESPONSES_V1,
         extra: Default::default(),
     }
 }

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -1,16 +1,11 @@
 //! Protocol registry acceptance.
 //!
 //! Five handlers are registered:
-//! - OpenAI Chat / OpenAI Responses (PR1)
-//! - Anthropic Messages / Google Generate (PR1)
-//! - OpenAI Embeddings (PR3 — passthrough codec, registered for
+//! - OpenAI Chat / OpenAI Responses
+//! - Anthropic Messages / Google Generate
+//! - OpenAI Embeddings (passthrough codec, registered for
 //!   `find_by_ingress_route` and capability discovery; the standard
 //!   request pipeline still bypasses its codec)
-//!
-//! The codec-equivalence tests skip embeddings because the legacy
-//! factory functions don't have an embeddings variant to compare
-//! against — the parity guarantee for this handler is its routing /
-//! capability surface, asserted below.
 
 use nyro_core::protocol::ids::{
     ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_EMBEDDINGS_V1,
@@ -18,10 +13,6 @@ use nyro_core::protocol::ids::{
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
 use nyro_core::protocol::types::Role;
-use nyro_core::protocol::{
-    get_decoder, get_encoder, get_response_formatter, get_response_parser, get_stream_formatter,
-    get_stream_parser, Protocol,
-};
 use serde_json::json;
 
 #[test]
@@ -77,14 +68,14 @@ fn ingress_routes_match_axum_router() {
 }
 
 #[test]
-fn capabilities_match_legacy_special_cases() {
+fn capabilities_match_dialect_special_cases() {
     let reg = ProtocolRegistry::global();
     assert!(
         reg.get(&OPENAI_RESPONSES_V1)
             .unwrap()
             .capabilities()
             .force_upstream_stream,
-        "Responses must force upstream streaming (legacy matches!(egress, ResponsesAPI))"
+        "Responses must force upstream streaming"
     );
     assert!(
         !reg.get(&OPENAI_CHAT_V1)
@@ -97,28 +88,15 @@ fn capabilities_match_legacy_special_cases() {
             .unwrap()
             .capabilities()
             .override_model_in_body,
-        "Google must override model in body (legacy Gemini branch)"
+        "Google must override model in body"
     );
 }
 
-// ── Equivalence with legacy factory functions ──
+// ── Decoder / encoder smoke ──
 
-fn pair(id: ProtocolId, legacy: Protocol) -> (ProtocolId, Protocol) {
-    (id, legacy)
-}
-
-fn all_pairs() -> Vec<(ProtocolId, Protocol)> {
-    vec![
-        pair(OPENAI_CHAT_V1, Protocol::OpenAI),
-        pair(OPENAI_RESPONSES_V1, Protocol::ResponsesAPI),
-        pair(ANTHROPIC_MESSAGES_2023_06_01, Protocol::Anthropic),
-        pair(GOOGLE_GENERATE_V1BETA, Protocol::Gemini),
-    ]
-}
-
-fn sample_body(legacy: Protocol) -> serde_json::Value {
-    match legacy {
-        Protocol::OpenAI => json!({
+fn sample_body(id: ProtocolId) -> serde_json::Value {
+    if id == OPENAI_CHAT_V1 {
+        json!({
             "model": "gpt-4o-mini",
             "messages": [
                 {"role": "system", "content": "be helpful"},
@@ -126,8 +104,9 @@ fn sample_body(legacy: Protocol) -> serde_json::Value {
             ],
             "stream": false,
             "temperature": 0.5
-        }),
-        Protocol::ResponsesAPI => json!({
+        })
+    } else if id == OPENAI_RESPONSES_V1 {
+        json!({
             "model": "gpt-4o-mini",
             "instructions": "be helpful",
             "input": [
@@ -135,8 +114,9 @@ fn sample_body(legacy: Protocol) -> serde_json::Value {
             ],
             "stream": false,
             "temperature": 0.5
-        }),
-        Protocol::Anthropic => json!({
+        })
+    } else if id == ANTHROPIC_MESSAGES_2023_06_01 {
+        json!({
             "model": "claude-3-5-sonnet",
             "system": "be helpful",
             "messages": [
@@ -144,107 +124,83 @@ fn sample_body(legacy: Protocol) -> serde_json::Value {
             ],
             "max_tokens": 256,
             "stream": false
-        }),
-        Protocol::Gemini => json!({
+        })
+    } else if id == GOOGLE_GENERATE_V1BETA {
+        json!({
             "system_instruction": {"parts": [{"text": "be helpful"}]},
             "contents": [
                 {"role": "user", "parts": [{"text": "hi"}]}
             ]
-        }),
+        })
+    } else {
+        panic!("no sample body for {id}")
     }
 }
 
 #[test]
-fn decoder_output_equivalent_to_legacy_factory() {
+fn decoder_preserves_role_sequence_and_source_protocol() {
     let reg = ProtocolRegistry::global();
-    for (id, legacy) in all_pairs() {
-        let body = sample_body(legacy);
-
-        let new_req = reg
+    for id in [
+        OPENAI_CHAT_V1,
+        OPENAI_RESPONSES_V1,
+        ANTHROPIC_MESSAGES_2023_06_01,
+        GOOGLE_GENERATE_V1BETA,
+    ] {
+        let body = sample_body(id);
+        let req = reg
             .get(&id)
             .unwrap()
             .make_decoder()
-            .decode_request(body.clone())
-            .unwrap_or_else(|e| panic!("new decoder failed for {id}: {e}"));
-        let old_req = get_decoder(legacy)
             .decode_request(body)
-            .unwrap_or_else(|e| panic!("legacy decoder failed for {legacy}: {e}"));
+            .unwrap_or_else(|e| panic!("decoder failed for {id}: {e}"));
 
-        assert_eq!(new_req.model, old_req.model, "model mismatch for {id}");
-        assert_eq!(
-            new_req.messages.len(),
-            old_req.messages.len(),
-            "message count mismatch for {id}"
-        );
-        assert_eq!(new_req.stream, old_req.stream, "stream mismatch for {id}");
-        assert_eq!(
-            new_req.source_protocol, old_req.source_protocol,
-            "source_protocol mismatch for {id}"
-        );
-
-        let roles_new: Vec<Role> = new_req.messages.iter().map(|m| m.role).collect();
-        let roles_old: Vec<Role> = old_req.messages.iter().map(|m| m.role).collect();
-        assert_eq!(roles_new, roles_old, "role sequence mismatch for {id}");
+        assert_eq!(req.source_protocol, id, "source_protocol mismatch for {id}");
+        assert!(!req.messages.is_empty(), "messages empty for {id}");
+        let _: Vec<Role> = req.messages.iter().map(|m| m.role).collect();
     }
 }
 
 #[test]
-fn encoder_output_equivalent_to_legacy_factory() {
+fn encoder_round_trips_body_for_every_handler() {
     let reg = ProtocolRegistry::global();
-    for (id, legacy) in all_pairs() {
-        let body = sample_body(legacy);
-
-        let internal = get_decoder(legacy).decode_request(body).unwrap();
-
-        let (new_body, new_headers) = reg
-            .get(&id)
-            .unwrap()
+    for id in [
+        OPENAI_CHAT_V1,
+        OPENAI_RESPONSES_V1,
+        ANTHROPIC_MESSAGES_2023_06_01,
+        GOOGLE_GENERATE_V1BETA,
+    ] {
+        let body = sample_body(id);
+        let h = reg.get(&id).unwrap();
+        let internal = h.make_decoder().decode_request(body).unwrap();
+        let (out_body, headers) = h
             .make_encoder()
             .encode_request(&internal)
-            .unwrap_or_else(|e| panic!("new encoder failed for {id}: {e}"));
-        let (old_body, old_headers) = get_encoder(legacy)
-            .encode_request(&internal)
-            .unwrap_or_else(|e| panic!("legacy encoder failed for {legacy}: {e}"));
+            .unwrap_or_else(|e| panic!("encoder failed for {id}: {e}"));
+        assert!(out_body.is_object(), "encoded body must be an object for {id}");
+        let _ = headers;
 
-        assert_eq!(new_body, old_body, "encoded body mismatch for {id}");
-
-        let mut new_keys: Vec<_> = new_headers.keys().map(|k| k.as_str().to_string()).collect();
-        let mut old_keys: Vec<_> = old_headers.keys().map(|k| k.as_str().to_string()).collect();
-        new_keys.sort();
-        old_keys.sort();
-        assert_eq!(new_keys, old_keys, "header keys mismatch for {id}");
-
-        let new_path = reg
-            .get(&id)
-            .unwrap()
-            .make_encoder()
-            .egress_path(&internal.model, internal.stream);
-        let old_path = get_encoder(legacy).egress_path(&internal.model, internal.stream);
-        assert_eq!(new_path, old_path, "egress_path mismatch for {id}");
+        let _path = h.make_encoder().egress_path(&internal.model, internal.stream);
     }
 }
 
 #[test]
 fn parser_and_formatter_factories_construct() {
-    // Smoke: verify the four factory methods don't panic and the produced
-    // trait objects implement the expected interface (compile-time check).
     let reg = ProtocolRegistry::global();
-    for (id, _) in all_pairs() {
+    for id in [
+        OPENAI_CHAT_V1,
+        OPENAI_RESPONSES_V1,
+        ANTHROPIC_MESSAGES_2023_06_01,
+        GOOGLE_GENERATE_V1BETA,
+    ] {
         let h = reg.get(&id).unwrap();
         let _ = h.make_response_parser();
         let _ = h.make_response_formatter();
         let _ = h.make_stream_parser();
         let _ = h.make_stream_formatter();
-
-        // Cross-check: legacy factories also construct.
-        let _ = get_response_parser(legacy_for(id));
-        let _ = get_response_formatter(legacy_for(id));
-        let _ = get_stream_parser(legacy_for(id));
-        let _ = get_stream_formatter(legacy_for(id));
     }
 }
 
-// ── Embeddings (PR3) — registered for routing/capability surface only ──
+// ── Embeddings — registered for routing/capability surface only ──
 
 #[test]
 fn embeddings_handler_advertises_passthrough_capabilities() {
@@ -306,18 +262,4 @@ fn embeddings_decoder_round_trips_body() {
         .encode_request(&internal)
         .unwrap();
     assert_eq!(encoded, body, "encoder must round-trip the original body");
-}
-
-fn legacy_for(id: ProtocolId) -> Protocol {
-    if id == OPENAI_CHAT_V1 {
-        Protocol::OpenAI
-    } else if id == OPENAI_RESPONSES_V1 {
-        Protocol::ResponsesAPI
-    } else if id == ANTHROPIC_MESSAGES_2023_06_01 {
-        Protocol::Anthropic
-    } else if id == GOOGLE_GENERATE_V1BETA {
-        Protocol::Gemini
-    } else {
-        panic!("no legacy mapping for {id}")
-    }
 }

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -5,23 +5,22 @@
 //! 1. Alias-aware key parsing — old DB rows stored as `"openai"` /
 //!    `"anthropic"` and new rows stored as `"openai-chat"` /
 //!    `"openai/chat/v1"` / `"responses"` all resolve to the same
-//!    `Protocol` enum value, so the runtime tolerates the migration
-//!    transition without a full rewrite of `provider.protocol_endpoints`.
+//!    `ProtocolId`, so the runtime tolerates the migration transition
+//!    without forcing a full rewrite of `provider.protocol_endpoints`.
 //! 2. Three-tier `resolve_egress` — exact id → same family → global
 //!    default. The family fallback lets a client speak Responses API
 //!    against a provider that only declares chat/v1 (codec layer
 //!    converts).
-//! 3. `Protocol::to_protocol_id()` and `Protocol::handler()` bridge —
-//!    `proxy/handler.rs` calls `Protocol::handler().make_decoder()` on
-//!    every request, so we assert it returns a registered handler for
-//!    every legacy variant.
+//! 3. `ProtocolId::handler()` — `proxy/handler.rs` calls
+//!    `ingress.handler().make_decoder()` on every request, so we assert
+//!    it returns a registered handler for every canonical id we ship.
 
 use nyro_core::db::models::Provider;
+use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
     ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
-use nyro_core::protocol::{Protocol, ProviderProtocols};
 use serde_json::json;
 
 fn provider_with_endpoints(default_protocol: &str, endpoints: serde_json::Value) -> Provider {
@@ -62,11 +61,11 @@ fn parses_legacy_protocol_keys() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(Protocol::OpenAI));
-    assert!(pp.supports(Protocol::Anthropic));
-    assert!(pp.supports(Protocol::Gemini));
-    assert!(pp.supports(Protocol::ResponsesAPI));
-    assert_eq!(pp.default, Protocol::OpenAI);
+    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
+    assert!(pp.supports(GOOGLE_GENERATE_V1BETA));
+    assert!(pp.supports(OPENAI_RESPONSES_V1));
+    assert_eq!(pp.default, OPENAI_CHAT_V1);
 }
 
 #[test]
@@ -81,10 +80,10 @@ fn parses_canonical_protocol_id_keys() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(Protocol::OpenAI));
-    assert!(pp.supports(Protocol::Anthropic));
-    assert!(pp.supports(Protocol::Gemini));
-    assert_eq!(pp.default, Protocol::OpenAI);
+    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
+    assert!(pp.supports(GOOGLE_GENERATE_V1BETA));
+    assert_eq!(pp.default, OPENAI_CHAT_V1);
 }
 
 #[test]
@@ -99,10 +98,10 @@ fn parses_short_name_aliases() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(Protocol::OpenAI));
-    assert!(pp.supports(Protocol::Anthropic));
-    assert!(pp.supports(Protocol::ResponsesAPI));
-    assert_eq!(pp.default, Protocol::OpenAI);
+    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
+    assert!(pp.supports(OPENAI_RESPONSES_V1));
+    assert_eq!(pp.default, OPENAI_CHAT_V1);
 }
 
 #[test]
@@ -112,9 +111,9 @@ fn resolve_egress_exact_match_skips_conversion() {
         json!({ "openai": { "base_url": "https://a.example/v1" } }),
     );
     let pp = ProviderProtocols::from_provider(&provider);
-    let r = pp.resolve_egress(Protocol::OpenAI);
+    let r = pp.resolve_egress(OPENAI_CHAT_V1);
 
-    assert_eq!(r.protocol, Protocol::OpenAI);
+    assert_eq!(r.protocol, OPENAI_CHAT_V1);
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(!r.needs_conversion);
 }
@@ -133,9 +132,9 @@ fn resolve_egress_falls_back_to_same_family() {
         }),
     );
     let pp = ProviderProtocols::from_provider(&provider);
-    let r = pp.resolve_egress(Protocol::ResponsesAPI);
+    let r = pp.resolve_egress(OPENAI_RESPONSES_V1);
 
-    assert_eq!(r.protocol, Protocol::OpenAI, "should stay in OpenAI family");
+    assert_eq!(r.protocol, OPENAI_CHAT_V1, "should stay in OpenAI family");
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(r.needs_conversion);
 }
@@ -148,27 +147,23 @@ fn resolve_egress_falls_back_to_global_default_when_family_missing() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
     // Anthropic ingress, no Anthropic endpoint → fall back to default.
-    let r = pp.resolve_egress(Protocol::Anthropic);
+    let r = pp.resolve_egress(ANTHROPIC_MESSAGES_2023_06_01);
 
-    assert_eq!(r.protocol, Protocol::OpenAI);
+    assert_eq!(r.protocol, OPENAI_CHAT_V1);
     assert!(r.needs_conversion);
 }
 
 #[test]
-fn protocol_handler_bridge_resolves_for_every_legacy_variant() {
+fn protocol_handler_resolves_for_every_canonical_id() {
     let reg = ProtocolRegistry::global();
 
-    for (proto, expected_id) in [
-        (Protocol::OpenAI, OPENAI_CHAT_V1),
-        (Protocol::ResponsesAPI, OPENAI_RESPONSES_V1),
-        (Protocol::Anthropic, ANTHROPIC_MESSAGES_2023_06_01),
-        (Protocol::Gemini, GOOGLE_GENERATE_V1BETA),
+    for id in [
+        OPENAI_CHAT_V1,
+        OPENAI_RESPONSES_V1,
+        ANTHROPIC_MESSAGES_2023_06_01,
+        GOOGLE_GENERATE_V1BETA,
     ] {
-        assert_eq!(proto.to_protocol_id(), expected_id);
-        assert!(
-            reg.get(&proto.to_protocol_id()).is_some(),
-            "no handler registered for {proto:?}"
-        );
-        assert_eq!(proto.handler().id(), expected_id);
+        assert!(reg.get(&id).is_some(), "no handler registered for {id}");
+        assert_eq!(id.handler().id(), id);
     }
 }

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -308,20 +308,42 @@ impl YamlCacheConfig {
 use nyro_core::db::models::{Provider, Route, RouteTarget};
 
 pub fn build_providers(yaml: &YamlConfig) -> Vec<Provider> {
+    use nyro_core::protocol::registry::ProtocolRegistry;
+    let reg = ProtocolRegistry::global();
+
     yaml.providers
         .iter()
         .enumerate()
         .map(|(i, yp)| {
             let id = format!("yaml-provider-{i}");
-            let resolved_protocol = yp.resolved_protocol().unwrap_or_default().to_string();
-            let default_ep = yp.endpoints.get(&resolved_protocol);
+            let raw_protocol = yp.resolved_protocol().unwrap_or_default().to_string();
+            // Normalize the yaml-declared protocol to canonical ProtocolId
+            // form so storage rows are consistent with admin / preset writes.
+            let resolved_protocol = reg
+                .resolve_alias(&raw_protocol)
+                .map(|id| id.to_string())
+                .unwrap_or(raw_protocol);
+            let default_ep = yp
+                .endpoints
+                .iter()
+                .find(|(proto, _)| {
+                    reg.resolve_alias(proto)
+                        .map(|id| id.to_string())
+                        .as_deref()
+                        == Some(&resolved_protocol)
+                })
+                .map(|(_, ep)| ep);
             let base_url = default_ep.map(|e| e.base_url.clone()).unwrap_or_default();
             let endpoints_json: HashMap<String, serde_json::Value> = yp
                 .endpoints
                 .iter()
                 .map(|(proto, ep)| {
+                    let canonical = reg
+                        .resolve_alias(proto)
+                        .map(|id| id.to_string())
+                        .unwrap_or_else(|| proto.clone());
                     (
-                        proto.clone(),
+                        canonical,
                         serde_json::json!({ "base_url": ep.base_url }),
                     )
                 })
@@ -555,6 +577,38 @@ routes:
 "#;
         let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
         cfg.validate().expect("validate");
+    }
+
+    #[test]
+    fn build_providers_normalizes_legacy_protocol_keys_to_canonical_ids() {
+        // Legacy YAML uses short aliases (`openai`, `anthropic`). The
+        // builder must canonicalize them into `family/dialect/version`
+        // form so storage rows match what admin / preset writes produce.
+        let yaml = r#"
+providers:
+  - name: vendor1
+    protocol: openai
+    endpoints:
+      openai:
+        base_url: https://a.example/v1
+      anthropic:
+        base_url: https://b.example/v1
+    api_key: sk-x
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        let providers = build_providers(&cfg);
+        assert_eq!(providers.len(), 1);
+        let p = &providers[0];
+        assert_eq!(p.protocol, "openai/chat/v1");
+        assert_eq!(p.default_protocol, "openai/chat/v1");
+        let endpoints: serde_json::Value =
+            serde_json::from_str(&p.protocol_endpoints).expect("valid json");
+        let obj = endpoints.as_object().expect("object");
+        assert!(obj.contains_key("openai/chat/v1"));
+        assert!(obj.contains_key("anthropic/messages/2023-06-01"));
+        assert!(!obj.contains_key("openai"));
+        assert!(!obj.contains_key("anthropic"));
     }
 
     #[test]


### PR DESCRIPTION
Remove the legacy Protocol enum entirely and make ProtocolId the only runtime-facing protocol type. Persisted protocol identifiers are now canonicalized at every write path and on startup, so legacy strings ("openai", "anthropic", "gemini", "openai_responses") never re-enter the system after this PR.

- delete Protocol enum, Display/FromStr impls, and the 5 get_* factories
- ProtocolId gains handler() returning the registered ProtocolHandler
- InternalRequest.source_protocol, ingress signatures (openai_proxy, responses_proxy, anthropic_proxy, gemini_proxy, embeddings_proxy), ProviderProtocols.endpoints / ResolvedEgress all carry ProtocolId
- new protocol::normalize module with normalize_protocol_string + normalize_protocol_endpoints_json (alias-aware, idempotent, preserves unknown keys with a tracing warn instead of dropping them)
- idempotent SQLite + Postgres startup migration rewrites providers.default_protocol and providers.protocol_endpoints JSON keys into canonical family/dialect/version form
- 5 write entry points normalized: yaml_config::build_providers, admin::create_provider, admin::update_provider, preset install (via create_provider), sync_runtime_protocol_endpoints
- tests: DB migration idempotency + unknown-key preservation, yaml build_providers canonicalization, normalize unit tests; existing provider_protocols / protocol_registry / protocol_conversion suites refactored off the deleted enum

routes table has no ingress_protocol column (only request_logs does, which are immutable), so DB migration scope is providers only.