### PR TITLE
refactor(webui,e2e): PR6 adopt canonical ProtocolId in UI display and e2e config (6/6) 

### DIFF
--- a/tests/e2e/proxy/conftest.py
+++ b/tests/e2e/proxy/conftest.py
@@ -46,13 +46,16 @@ PROTOCOLS: tuple[str, ...] = (
     "google-content",
 )
 
-# Map nyro-tools' kebab-case protocol → key used inside nyro server's
-# YAML `endpoints:` map (snake_case, historical names).
+# Map nyro-tools' kebab-case protocol → canonical ProtocolId string used
+# inside nyro server's YAML `endpoints:` map. The server's write-path
+# normalization (PR4) round-trips legacy short names through aliases,
+# but we feed canonical form so e2e exercises the post-normalization
+# path directly.
 NYRO_PROTOCOL_KEY: dict[str, str] = {
-    "openai-chat": "openai",
-    "openai-responses": "openai_responses",
-    "anthropic-messages": "anthropic",
-    "google-content": "gemini",
+    "openai-chat": "openai/chat/v1",
+    "openai-responses": "openai/responses/v1",
+    "anthropic-messages": "anthropic/messages/2023-06-01",
+    "google-content": "google/generate/v1beta",
 }
 
 # Path suffix appended to the replay base URL inside `endpoints[*].base_url`.

--- a/webui/src/components/log-detail-dialog.tsx
+++ b/webui/src/components/log-detail-dialog.tsx
@@ -6,6 +6,7 @@ import { backend } from "@/lib/backend";
 import { useLocale } from "@/lib/i18n";
 import type { RequestLog } from "@/lib/types";
 import { formatDuration, formatLogTime, formatTokenCount, tryPrettyJson } from "@/lib/format";
+import { prettyName } from "@/lib/protocol-id";
 import { cn } from "@/lib/utils";
 import {
   Dialog,
@@ -100,9 +101,7 @@ export function LogDetailDialog({ logId, summary, open, onOpenChange }: LogDetai
             </span>
           ) : null}
           {log?.ingress_protocol || log?.egress_protocol ? (
-            <span className="text-slate-400">
-              {log?.ingress_protocol ?? "–"} → {log?.egress_protocol ?? "–"}
-            </span>
+            <ProtocolLine ingress={log?.ingress_protocol} egress={log?.egress_protocol} />
           ) : null}
         </div>
 
@@ -195,5 +194,33 @@ function PayloadBlock({ title, content, isZh }: PayloadBlockProps) {
         {hasContent ? pretty : <span className="text-slate-400">{isZh ? "（无内容）" : "(empty)"}</span>}
       </pre>
     </div>
+  );
+}
+
+function ProtocolLine({
+  ingress,
+  egress,
+}: {
+  ingress: string | null | undefined;
+  egress: string | null | undefined;
+}) {
+  const inPretty = prettyName(ingress);
+  const outPretty = prettyName(egress);
+  const renderSide = (raw: string | null | undefined, p: ReturnType<typeof prettyName>) => {
+    if (!raw) return <span className="text-slate-400">–</span>;
+    if (!p) return <span className="text-slate-500">{raw}</span>;
+    return (
+      <span className="inline-flex flex-col leading-tight">
+        <span className="font-medium text-slate-600">{p.family}</span>
+        <span className="text-[10px] text-slate-400">{p.detail}</span>
+      </span>
+    );
+  };
+  return (
+    <span className="inline-flex items-center gap-1.5 text-slate-500">
+      {renderSide(ingress, inPretty)}
+      <span className="text-slate-300">→</span>
+      {renderSide(egress, outPretty)}
+    </span>
   );
 }

--- a/webui/src/lib/protocol-id.ts
+++ b/webui/src/lib/protocol-id.ts
@@ -1,0 +1,85 @@
+/**
+ * Protocol identifier utilities.
+ *
+ * Mirrors the backend `ProtocolId` (`family/dialect/version`) shape and
+ * its alias resolution table. The frontend stays loose-typed (`string`
+ * on the wire) but routes every comparison and display through these
+ * helpers so legacy short names (`openai`, `anthropic`, `gemini`,
+ * `openai_responses`) and canonical IDs (`openai/chat/v1`,
+ * `anthropic/messages/2023-06-01`, ...) interoperate seamlessly.
+ *
+ * Keep the alias table in sync with the Rust side at
+ * `crates/nyro-core/src/protocol/registry.rs::default_aliases`.
+ */
+
+export interface ProtocolId {
+  family: string;
+  dialect: string;
+  version: string;
+}
+
+const ALIAS_TABLE: Record<string, ProtocolId> = {
+  // Canonical pass-through (idempotent on already-canonical strings).
+  "openai/chat/v1": { family: "openai", dialect: "chat", version: "v1" },
+  "openai/responses/v1": { family: "openai", dialect: "responses", version: "v1" },
+  "openai/embeddings/v1": { family: "openai", dialect: "embeddings", version: "v1" },
+  "anthropic/messages/2023-06-01": {
+    family: "anthropic",
+    dialect: "messages",
+    version: "2023-06-01",
+  },
+  "google/generate/v1beta": { family: "google", dialect: "generate", version: "v1beta" },
+
+  // Short-name aliases used in WebUI dropdowns and YAML configs.
+  "openai-chat": { family: "openai", dialect: "chat", version: "v1" },
+  "openai-responses": { family: "openai", dialect: "responses", version: "v1" },
+  "openai-embeddings": { family: "openai", dialect: "embeddings", version: "v1" },
+  "anthropic-messages": {
+    family: "anthropic",
+    dialect: "messages",
+    version: "2023-06-01",
+  },
+  "google-generate": { family: "google", dialect: "generate", version: "v1beta" },
+
+  // Legacy short names persisted in older databases / preset JSON.
+  openai: { family: "openai", dialect: "chat", version: "v1" },
+  openai_responses: { family: "openai", dialect: "responses", version: "v1" },
+  embeddings: { family: "openai", dialect: "embeddings", version: "v1" },
+  anthropic: { family: "anthropic", dialect: "messages", version: "2023-06-01" },
+  claude: { family: "anthropic", dialect: "messages", version: "2023-06-01" },
+  gemini: { family: "google", dialect: "generate", version: "v1beta" },
+};
+
+/** Resolve a raw protocol string into a structured `ProtocolId`, or
+ *  `null` if it doesn't match any known alias / canonical form. */
+export function parseProtocolId(raw: string | null | undefined): ProtocolId | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const direct = ALIAS_TABLE[trimmed];
+  if (direct) return direct;
+  // Canonical fallback for unknown but well-formed `family/dialect/version`.
+  const parts = trimmed.split("/");
+  if (parts.length === 3 && parts.every((p) => p.length > 0)) {
+    return { family: parts[0], dialect: parts[1], version: parts[2] };
+  }
+  return null;
+}
+
+/** Format a `ProtocolId` back to its canonical wire form. */
+export function formatProtocolId(id: ProtocolId): string {
+  return `${id.family}/${id.dialect}/${id.version}`;
+}
+
+/** Display label split by the two layers we surface in the UI:
+ *  the family (vendor) and a dialect+version subtitle. Returns `null`
+ *  when the input can't be parsed so callers can fall back to the
+ *  raw string verbatim. */
+export function prettyName(raw: string | null | undefined): {
+  family: string;
+  detail: string;
+} | null {
+  const id = parseProtocolId(raw);
+  if (!id) return null;
+  return { family: id.family, detail: `${id.dialect} · ${id.version}` };
+}

--- a/webui/src/pages/logs.tsx
+++ b/webui/src/pages/logs.tsx
@@ -6,6 +6,7 @@ import { backend } from "@/lib/backend";
 import type { LogPage, LogQuery, Provider, RequestLog } from "@/lib/types";
 import { getRouteType } from "@/lib/types";
 import { formatDuration, formatLogTime, formatTokenCount } from "@/lib/format";
+import { prettyName } from "@/lib/protocol-id";
 import { cn } from "@/lib/utils";
 import { useLocale } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
@@ -195,9 +196,10 @@ export default function LogsPage() {
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex items-center gap-1.5 text-xs text-slate-500">
-                          <span>
-                            {(log.ingress_protocol ?? "–")} → {(log.egress_protocol ?? "–")}
-                          </span>
+                          <ProtocolLane
+                            ingress={log.ingress_protocol}
+                            egress={log.egress_protocol}
+                          />
                           {routeType === "embedding" ? (
                             <Badge variant="outline" className="text-[10px]">EMB</Badge>
                           ) : null}
@@ -283,5 +285,34 @@ export default function LogsPage() {
         }}
       />
     </div>
+  );
+}
+
+function ProtocolCell({ value }: { value: string | null | undefined }) {
+  const pretty = prettyName(value);
+  if (!pretty) {
+    return <span className="text-slate-400">–</span>;
+  }
+  return (
+    <span className="flex flex-col leading-tight">
+      <span className="font-medium text-slate-700">{pretty.family}</span>
+      <span className="text-[10px] text-slate-400">{pretty.detail}</span>
+    </span>
+  );
+}
+
+function ProtocolLane({
+  ingress,
+  egress,
+}: {
+  ingress: string | null | undefined;
+  egress: string | null | undefined;
+}) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <ProtocolCell value={ingress} />
+      <span className="text-slate-300">→</span>
+      <ProtocolCell value={egress} />
+    </span>
   );
 }

--- a/webui/src/pages/routes.tsx
+++ b/webui/src/pages/routes.tsx
@@ -17,6 +17,7 @@ import type {
   UpsertRouteTarget,
 } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
+import { parseProtocolId } from "@/lib/protocol-id";
 import { ProviderIcon } from "@/components/ui/provider-icon";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -85,12 +86,19 @@ function hasProviderModelsEndpoint(provider?: Provider) {
 
 function providerSupportsOpenAiEndpoint(provider?: Provider) {
   if (!provider) return false;
+  // Accept any protocol identifier whose family resolves to OpenAI —
+  // covers legacy `openai` short name, canonical `openai/chat/v1`, and
+  // future OpenAI dialects (`openai/responses/v1`, `openai/embeddings/v1`).
+  const isOpenAiKey = (raw: string): boolean => {
+    const id = parseProtocolId(raw);
+    return id?.family === "openai";
+  };
   const raw = provider.protocol_endpoints?.trim();
   if (raw) {
     try {
       const parsed = JSON.parse(raw) as Record<string, { base_url?: string }>;
       for (const [key, value] of Object.entries(parsed)) {
-        if (key.trim().toLowerCase() === "openai" && Boolean(value?.base_url?.trim())) {
+        if (isOpenAiKey(key) && Boolean(value?.base_url?.trim())) {
           return true;
         }
       }
@@ -98,7 +106,7 @@ function providerSupportsOpenAiEndpoint(provider?: Provider) {
       // ignore invalid json and fallback to legacy protocol/base_url fields
     }
   }
-  return provider.protocol.trim().toLowerCase() === "openai" && Boolean(provider.base_url.trim());
+  return isOpenAiKey(provider.protocol) && Boolean(provider.base_url.trim());
 }
 
 function normalizeTargetsForRouteType(


### PR DESCRIPTION
- Add `webui/src/lib/protocol-id.ts` with `parseProtocolId` / `formatProtocolId` / `prettyName`, mirroring the backend alias table (`crates/nyro-core/src/protocol/registry.rs`). Accepts both legacy short names (`openai`, `anthropic`, `gemini`, `openai_responses`) and canonical `family/dialect/version` forms.
- Logs list (`logs.tsx`) and detail dialog (`log-detail-dialog.tsx`) now split each protocol into a family line + `dialect · version` subtitle, gracefully falling back to the raw string for unknown ids.
- `routes.tsx::providerSupportsOpenAiEndpoint` resolves keys through `parseProtocolId(..).family === "openai"` so it matches both `openai` and `openai/chat/v1` (and future OpenAI dialects).
- E2E `tests/e2e/proxy/conftest.py::NYRO_PROTOCOL_KEY` now feeds canonical ProtocolIds directly into the synthesized YAML, exercising the PR4 write-path normalization end-to-end.

`ProviderProtocol` union and `providers.tsx` dropdown intentionally keep legacy short names — they faithfully describe the wire shape returned by `VendorRegistry::list_metadata_legacy_json` (PR5) and the form submission is canonicalized by the backend's
`normalize_protocol_*_field` helpers (PR4).

Verified: `pnpm -C webui build`, `cargo test --workspace`, `cargo clippy --workspace --all-targets` all clean.