### PR TITLE
fix(stream) + feat(api): emit Usage before Done; expose model capabilities in /v1/models

### DIFF
--- a/crates/nyro-core/src/protocol/codec/openai/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/stream.rs
@@ -258,15 +258,15 @@ impl OpenAIStreamParser {
             }
         }
 
+        let u = extract_usage(chunk);
+        if u.input_tokens > 0 || u.output_tokens > 0 {
+            deltas.push(StreamDelta::Usage(u));
+        }
+
         if let Some(reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
             deltas.push(StreamDelta::Done {
                 stop_reason: reason.to_string(),
             });
-        }
-
-        let u = extract_usage(chunk);
-        if u.input_tokens > 0 || u.output_tokens > 0 {
-            deltas.push(StreamDelta::Usage(u));
         }
     }
 
@@ -650,5 +650,64 @@ mod tests {
         let has_reasoning = deltas.iter().any(|d| matches!(d, StreamDelta::ReasoningDelta(_)));
         assert!(has_text, "expected TextDelta('hello'), got: {deltas:?}");
         assert!(!has_reasoning, "should not have ReasoningDelta when no think tags, got: {deltas:?}");
+    }
+
+    #[test]
+    fn test_stream_usage_in_final_chunk() {
+        // When the upstream sends finish_reason + usage in the same SSE chunk,
+        // the parser must emit Usage before Done so that format_deltas sees
+        // the real token counts when building the final SSE event.
+        //
+        // BUG: parse_openai_chunk pushes Done before Usage, so format_deltas
+        // emits usage={0,0,0} in the chunk before [DONE], and the client
+        // (OpenAI SDK) stops at that first [DONE].
+        let mut parser = OpenAIStreamParser::new();
+        let mut formatter = OpenAIStreamFormatter::new();
+
+        // chunk 1: role marker
+        let d = parser
+            .parse_chunk(&data_sse(
+                r#"{"id":"chatcmpl-u","model":"t","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#,
+            ))
+            .unwrap();
+        formatter.format_deltas(&d);
+
+        // chunk 2: content
+        let d = parser
+            .parse_chunk(&data_sse(
+                r#"{"id":"chatcmpl-u","model":"t","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}"#,
+            ))
+            .unwrap();
+        formatter.format_deltas(&d);
+
+        // chunk 3: finish + usage (THE BUG — Done emitted before Usage)
+        let d = parser
+            .parse_chunk(&data_sse(
+                r#"{"id":"chatcmpl-u","model":"t","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"#,
+            ))
+            .unwrap();
+        let events = formatter.format_deltas(&d);
+
+        // find the last non-DONE event (it should carry the real usage)
+        let content_events: Vec<&SseEvent> =
+            events.iter().filter(|e| e.data != "[DONE]").collect();
+        assert!(!content_events.is_empty(), "expected a non-DONE SSE event");
+
+        let last = content_events.last().unwrap();
+        let val: serde_json::Value = serde_json::from_str(&last.data).unwrap();
+        let usage = &val["usage"];
+
+        assert_eq!(
+            usage["prompt_tokens"].as_u64(),
+            Some(10),
+            "BUG: usage.prompt_tokens is {:?} -- Done was formatted before Usage was applied",
+            usage["prompt_tokens"].as_u64(),
+        );
+        assert_eq!(
+            usage["completion_tokens"].as_u64(),
+            Some(5),
+            "usage.completion_tokens should be 5, got {:?}",
+            usage["completion_tokens"].as_u64(),
+        );
     }
 }

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::convert::Infallible;
 use std::time::Instant;
 
@@ -18,7 +18,8 @@ use tokio::time::{Duration, timeout};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::db::models::{
-    Provider, Route, RouteCacheConfig, RouteExactCacheConfig, RouteSemanticCacheConfig, RouteTarget,
+    ModelCapabilities, Provider, Route, RouteCacheConfig, RouteExactCacheConfig, RouteSemanticCacheConfig,
+    RouteTarget,
 };
 use crate::cache::entry::CacheEntry;
 use crate::cache::key::{build_cache_key, build_semantic_partition};
@@ -479,26 +480,57 @@ pub async fn models_list(State(gw): State<Gateway>, headers: HeaderMap) -> Respo
     }
 
     let cache = gw.route_cache.read().await;
-    let models = cache
+    let active_routes: Vec<_> = cache
         .routes
         .iter()
         .filter(|route| !route.access_control || accessible_route_ids.contains(&route.id))
-        .map(|route| route.virtual_model.trim())
-        .filter(|model| !model.is_empty())
-        .map(ToString::to_string)
-        .collect::<BTreeSet<_>>();
+        .collect();
+
+    // Collect unique (provider_id, target_model) pairs for capability lookup
+    let mut target_set: Vec<(String, String)> = Vec::new();
+    for route in &active_routes {
+        let pair = (route.target_provider.clone(), route.target_model.clone());
+        if !target_set.contains(&pair) {
+            target_set.push(pair);
+        }
+    }
+
+    // Pre-fetch capabilities for all model targets
+    let admin = gw.admin();
+    let mut cap_map: HashMap<String, Option<ModelCapabilities>> = HashMap::new();
+    for (provider_id, target_model) in &target_set {
+        let caps = admin.get_model_capabilities(provider_id, target_model).await.ok();
+        cap_map.insert(target_model.clone(), caps);
+    }
+
+    // Build model list with most capabilities from the route that matches
+    let models: BTreeSet<String> = active_routes.iter().map(|r| r.virtual_model.trim().to_string()).filter(|m| !m.is_empty()).collect();
 
     let data = models
         .into_iter()
         .map(|model| {
-            serde_json::json!({
+            let mut obj = serde_json::json!({
                 "id": model,
                 "object": "model",
                 "created": 0,
                 "owned_by": "Nyro"
-            })
+            });
+
+            // Find the route for this virtual model and attach capabilities
+            if let Some(route) = active_routes.iter().find(|r| r.virtual_model.trim() == model) {
+                if let Some(Some(caps)) = cap_map.get(&route.target_model) {
+                    obj["max_context_length"] = serde_json::json!(caps.context_window);
+                    if let Some(max_out) = caps.output_max_tokens {
+                        obj["max_output_tokens"] = serde_json::json!(max_out);
+                    }
+                }
+            }
+
+            obj
         })
         .collect::<Vec<_>>();
+
+    drop(cache);
 
     Json(serde_json::json!({
         "object": "list",


### PR DESCRIPTION
Two independent fixes:

### 1. Stream: emit Usage delta before Done

`parse_openai_chunk` currently pushes `Done` before `Usage`. This means `format_deltas` emits `usage={0,0,0}` in the chunk before `[DONE]`, and the OpenAI SDK stops at that first `[DONE]` — the real token counts in the subsequent `Usage` chunk are never seen by the client.

**Fix:** reorder so `Usage` delta precedes `Done`. Includes a regression test.

### 2. API: expose model capabilities in /v1/models

The `/v1/models` endpoint currently returns bare `{id, object, created, owned_by}`. This adds `max_context_length` and `max_output_tokens` by pre-fetching `ModelCapabilities` from the admin for each route's target model.

```json
{
  "id": "deepseek-v3",
  "object": "model",
  "owned_by": "Nyro",
  "max_context_length": 131072,
  "max_output_tokens": 8192
}
```

---

**Files:** `stream.rs` (+64, -5, 1 test), `handler.rs` (+41, -9)
**Tests:** `cargo test --workspace --exclude nyro-desktop --exclude nyro-server` — 153 passed, 0 failed