### PR TITLE
fix(ui): add dark mode override for text-slate-800

### DIFF
--- a/webui/src/index.css
+++ b/webui/src/index.css
@@ -1108,7 +1108,8 @@ html[data-theme="dark"] .border-slate-200 {
   border-color: rgba(255, 255, 255, 0.1) !important;
 }
 
-html[data-theme="dark"] .text-slate-900 {
+html[data-theme="dark"] .text-slate-900,
+html[data-theme="dark"] .text-slate-800 {
   color: #fafafa !important;
 }
 


### PR DESCRIPTION
## Problem

In dark mode, card section headers on the Dashboard, Providers, Stats, and Logs pages were rendering as dark navy (`#1e293b`) on dark glass backgrounds — making them nearly invisible.

**Root cause:** The dark mode CSS in `index.css` had `data-theme="dark"` overrides for `text-slate-900` (→ white), `700`/600/500/400 (→ light grey) — but `text-slate-800` was missing from the override list.

## Fix

```diff
-html[data-theme="dark"] .text-slate-900 {
+html[data-theme="dark"] .text-slate-900,
+html[data-theme="dark"] .text-slate-800 {
   color: #fafafa !important;
 }
```

## Impact

Single CSS rule fixes **14 elements** across 4 pages:
- Dashboard: 4 card headers ("Requests (24h)", "Latency (24h)", "Top Models", "Provider Overview")
- Providers: 6 elements
- Stats: 3 card headers
- Logs: 1 element

## Files

`webui/src/index.css` (+2, −1)

## Before 
<img width="1265" height="793" alt="Screenshot 2026-04-30 at 10 01 41" src="https://github.com/user-attachments/assets/60693875-4829-4d75-806a-b11d128511c8" />


## After
<img width="1273" height="797" alt="Screenshot 2026-04-30 at 10 10 32" src="https://github.com/user-attachments/assets/687449fc-00c0-45ad-bea3-860d68b7964e" />
