### PR TITLE
feat: reimplement Claude Code OAuth on latest architecture

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -739,6 +739,16 @@ impl AdminService {
         let provider = self.get_provider(id).await?;
         let runtime = self.resolve_provider_runtime(&provider).await?;
         let credential = runtime.access_token.clone();
+        if let Some(static_list) = runtime.binding.static_models_override.as_deref() {
+            let models: Vec<String> = static_list
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if !models.is_empty() {
+                return Ok(models);
+            }
+        }
         let endpoint = runtime
             .binding
             .models_source_override
@@ -755,15 +765,15 @@ impl AdminService {
             return Ok(models);
         }
 
-        let mut headers = build_model_headers(
-            &provider.protocol,
-            provider.vendor.as_deref(),
-            &credential,
-        )?;
+        let mut headers = if runtime.binding.disable_default_auth {
+            HeaderMap::new()
+        } else {
+            build_model_headers(&provider.protocol, provider.vendor.as_deref(), &credential)?
+        };
         headers.extend(runtime_binding_headers(&runtime.binding)?);
         let mut request = self.gw.http_client.get(&endpoint).headers(headers).timeout(Duration::from_secs(10));
 
-        if provider.protocol == "gemini" {
+        if provider.protocol == "gemini" && !runtime.binding.disable_default_auth {
             let separator = if endpoint.contains('?') { '&' } else { '?' };
             let mut headers = build_model_headers(
                 &provider.protocol,
@@ -804,6 +814,16 @@ impl AdminService {
         let provider = self.get_provider(id).await?;
         let runtime = self.resolve_provider_runtime(&provider).await?;
         let credential = runtime.access_token.clone();
+        if let Some(static_list) = runtime.binding.static_models_override.as_deref() {
+            let models: Vec<String> = static_list
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if !models.is_empty() {
+                return Ok(models);
+            }
+        }
 
         if let Some(endpoint) = runtime
             .binding
@@ -816,15 +836,15 @@ impl AdminService {
                     return Ok(models);
                 }
 
-            let mut headers = build_model_headers(
-                &provider.protocol,
-                provider.vendor.as_deref(),
-                &credential,
-            )?;
+            let mut headers = if runtime.binding.disable_default_auth {
+                HeaderMap::new()
+            } else {
+                build_model_headers(&provider.protocol, provider.vendor.as_deref(), &credential)?
+            };
             headers.extend(runtime_binding_headers(&runtime.binding)?);
             let mut request = self.gw.http_client.get(&endpoint).headers(headers);
 
-            if provider.protocol == "gemini" {
+            if provider.protocol == "gemini" && !runtime.binding.disable_default_auth {
                 let separator = if endpoint.contains('?') { '&' } else { '?' };
                 let mut headers = build_model_headers(
                     &provider.protocol,
@@ -912,10 +932,11 @@ impl AdminService {
                 Some(ext) => ext.clone(),
                 None => continue,
             };
-            let credential = match resolve_provider_credential(&provider) {
-                Ok(value) => value,
+            let runtime = match self.resolve_provider_runtime(&provider).await {
+                Ok(runtime) => runtime,
                 Err(_) => continue,
             };
+            let credential = runtime.access_token.clone();
             let upstream_url;
             let mut request_headers;
             {
@@ -927,8 +948,13 @@ impl AdminService {
                     credential: None,
                 };
                 upstream_url = extension.build_url(&ctx, &openai_base_url, "/v1/embeddings");
-                request_headers = HeaderMap::new();
-                request_headers.extend(extension.auth_headers(&ctx));
+                request_headers = match runtime_binding_headers(&runtime.binding) {
+                    Ok(headers) => headers,
+                    Err(_) => continue,
+                };
+                if !runtime.binding.disable_default_auth {
+                    request_headers.extend(extension.auth_headers(&ctx));
+                }
             }
             let client = match self.gw.http_client_for_provider(provider.use_proxy).await {
                 Ok(http_client) => ProxyClient::new(http_client),
@@ -997,29 +1023,31 @@ impl AdminService {
         url: &str,
         model: &str,
     ) -> anyhow::Result<ModelCapabilities> {
-        let credential = resolve_provider_credential(provider)?;
+        let runtime = self.resolve_provider_runtime(provider).await?;
+        let credential = runtime.access_token;
+        let mut headers = if runtime.binding.disable_default_auth {
+            HeaderMap::new()
+        } else {
+            build_model_headers(&provider.protocol, provider.vendor.as_deref(), &credential)?
+        };
+        headers.extend(runtime_binding_headers(&runtime.binding)?);
         let mut request = self
             .gw
             .http_client
             .get(url)
-            .headers(build_model_headers(
-                &provider.protocol,
-                provider.vendor.as_deref(),
-                &credential,
-            )?)
+            .headers(headers)
             .timeout(Duration::from_secs(10));
 
-        if provider.protocol == "gemini" {
+        if provider.protocol == "gemini" && !runtime.binding.disable_default_auth {
             let separator = if url.contains('?') { '&' } else { '?' };
+            let mut headers =
+                build_model_headers(&provider.protocol, provider.vendor.as_deref(), &credential)?;
+            headers.extend(runtime_binding_headers(&runtime.binding)?);
             request = self
                 .gw
                 .http_client
                 .get(format!("{url}{separator}key={}", credential))
-                .headers(build_model_headers(
-                    &provider.protocol,
-                    provider.vendor.as_deref(),
-                    &credential,
-                )?)
+                .headers(headers)
                 .timeout(Duration::from_secs(10));
         }
 
@@ -2558,34 +2586,6 @@ fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     Some(trimmed.to_string())
 }
 
-fn resolve_provider_credential(provider: &Provider) -> anyhow::Result<String> {
-    let effective_auth_mode = provider.effective_auth_mode();
-    let auth_mode = effective_auth_mode.trim();
-    let credential = match auth_mode {
-        "apikey" | "" => provider.api_key.trim(),
-        "oauth" => {
-            // OAuth credentials are in the separate credential table.
-            // This sync function cannot access them; callers should use
-            // resolve_provider_runtime() for OAuth providers instead.
-            anyhow::bail!("oauth provider credentials must be resolved via resolve_provider_runtime");
-        }
-        other => anyhow::bail!("unsupported provider auth_mode: {other}"),
-    };
-
-    if credential.is_empty() {
-        let source = "api_key";
-        anyhow::bail!(
-            "provider credential is empty for auth_mode={} ({source})",
-            if auth_mode.is_empty() {
-                "apikey"
-            } else {
-                auth_mode
-            }
-        );
-    }
-
-    Ok(credential.to_string())
-}
 
 fn sync_runtime_protocol_endpoints(provider: &Provider, base_url: &str) -> anyhow::Result<String> {
     use crate::protocol::registry::ProtocolRegistry;

--- a/crates/nyro-core/src/auth/drivers/claude.rs
+++ b/crates/nyro-core/src/auth/drivers/claude.rs
@@ -1,0 +1,483 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use reqwest::header::{ACCEPT, CONTENT_TYPE};
+use serde::Deserialize;
+
+use super::shared::{
+    PkceAuthState, build_authorize_url, encode_scopes, expires_at_after, generate_code_challenge,
+    generate_code_verifier, generate_state, parse_oauth_callback, parse_session_state,
+    required_http_client, validate_callback_state,
+};
+use crate::auth::types::{
+    AuthDriver, AuthDriverMetadata, AuthExchangeInput, AuthScheme, AuthSession, CreateAuthSession,
+    CredentialBundle, ExchangeAuthContext, RefreshAuthContext, RuntimeBinding, StartAuthContext,
+    StoredCredential,
+};
+use crate::db::models::Provider;
+use crate::provider::VendorRegistry;
+use crate::provider::OAuthConfig;
+
+const ANTHROPIC_PRESET_ID: &str = "anthropic";
+const CLAUDE_CODE_CHANNEL_ID: &str = "claude-code";
+const ANTHROPIC_PROTOCOL_ID: &str = "anthropic";
+
+/// User-Agent the official `claude` CLI sends; mirrored on both the
+/// OAuth token endpoint and the inference runtime. **Bump this** when
+/// upgrading Claude Code CLI compatibility — Anthropic has at points
+/// gated the OAuth surface on the CLI version string.
+const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/1.0.98 (external, cli)";
+
+/// Anthropic OAuth-beta header the runtime + token endpoint require.
+/// Bump (or drop) once the OAuth flow GAs.
+const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
+
+#[derive(Debug, Clone, Copy)]
+struct ClaudeCodeConfig {
+    oauth: &'static OAuthConfig,
+    api_base_url: &'static str,
+    static_models: &'static [&'static str],
+}
+
+#[derive(Debug, Default)]
+pub struct ClaudeOAuthDriver;
+
+#[derive(Debug, Deserialize)]
+struct ClaudeTokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+    scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeErrorResponse {
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+impl ClaudeOAuthDriver {
+    fn claude_code_config() -> Result<ClaudeCodeConfig> {
+        let metadata = VendorRegistry::global()
+            .metadata(ANTHROPIC_PRESET_ID)
+            .ok_or_else(|| anyhow!("missing provider preset: {ANTHROPIC_PRESET_ID}"))?;
+        let channel = metadata
+            .channels
+            .iter()
+            .find(|c| c.id == CLAUDE_CODE_CHANNEL_ID)
+            .ok_or_else(|| {
+                anyhow!("missing provider channel: {ANTHROPIC_PRESET_ID}/{CLAUDE_CODE_CHANNEL_ID}")
+            })?;
+        let api_base_url = channel
+            .base_urls
+            .iter()
+            .find(|entry| entry.protocol == ANTHROPIC_PROTOCOL_ID)
+            .map(|entry| entry.base_url)
+            .ok_or_else(|| {
+                anyhow!(
+                    "missing base url for protocol {ANTHROPIC_PROTOCOL_ID} in \
+                     {ANTHROPIC_PRESET_ID}/{CLAUDE_CODE_CHANNEL_ID}"
+                )
+            })?;
+        Ok(ClaudeCodeConfig {
+            oauth: channel.oauth.as_ref().ok_or_else(|| {
+                anyhow!("missing oauth config for {ANTHROPIC_PRESET_ID}/{CLAUDE_CODE_CHANNEL_ID}")
+            })?,
+            api_base_url,
+            static_models: channel.static_models,
+        })
+    }
+
+    fn normalize_token_response(
+        body: &str,
+        fallback_refresh_token: Option<&str>,
+        config: ClaudeCodeConfig,
+    ) -> Result<CredentialBundle> {
+        let token: ClaudeTokenResponse =
+            serde_json::from_str(body).context("parse claude oauth token response")?;
+        let access_token = token
+            .access_token
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| anyhow!("claude oauth token response missing access_token"))?;
+        let expires_in = token.expires_in.unwrap_or(3600).max(1);
+
+        Ok(CredentialBundle {
+            access_token: Some(access_token),
+            refresh_token: token
+                .refresh_token
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| fallback_refresh_token.map(ToString::to_string)),
+            expires_at: Some(expires_at_after(expires_in)),
+            resource_url: Some(config.api_base_url.to_string()),
+            subject_id: None,
+            scopes: encode_scopes(token.scope.as_deref()),
+            raw: serde_json::from_str(body).unwrap_or(serde_json::Value::Null),
+        })
+    }
+
+    fn parse_error(body: &str) -> Option<String> {
+        let parsed: ClaudeErrorResponse = serde_json::from_str(body).ok()?;
+        parsed
+            .error_description
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| parsed.error.filter(|value| !value.trim().is_empty()))
+    }
+
+    /// Headers the official `claude` CLI sends on **both** the OAuth
+    /// token endpoint and the inference runtime. The token endpoint
+    /// rejects requests without `anthropic-beta: oauth-2025-04-20` with
+    /// HTTP 400 `invalid_request_error: "Invalid request format"`, and
+    /// has at points enforced the CLI-shaped UA/Origin/Referer too.
+    /// See `CLAUDE_CLI_USER_AGENT` / `ANTHROPIC_OAUTH_BETA` for the
+    /// values and their maintenance notes.
+    fn claude_cli_headers() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("User-Agent", CLAUDE_CLI_USER_AGENT),
+            ("Referer", "https://claude.ai/"),
+            ("Origin", "https://claude.ai"),
+            ("anthropic-beta", ANTHROPIC_OAUTH_BETA),
+        ]
+    }
+}
+
+#[async_trait]
+impl AuthDriver for ClaudeOAuthDriver {
+    fn metadata(&self) -> AuthDriverMetadata {
+        AuthDriverMetadata {
+            key: "claude-code",
+            label: "Claude Code",
+            scheme: AuthScheme::OAuthAuthCodePkce,
+            supports_new_provider: true,
+            supports_existing_provider: true,
+        }
+    }
+
+    async fn start(&self, ctx: StartAuthContext) -> Result<CreateAuthSession> {
+        let config = Self::claude_code_config()?;
+        let code_verifier = generate_code_verifier();
+        let code_challenge = generate_code_challenge(&code_verifier);
+        let state = generate_state();
+        let redirect_uri = ctx
+            .redirect_uri
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or(config.oauth.redirect_uri);
+        let auth_url = build_authorize_url(
+            config.oauth.authorize_url,
+            &[
+                ("code", "true"),
+                ("client_id", config.oauth.client_id),
+                ("response_type", "code"),
+                ("redirect_uri", redirect_uri),
+                ("scope", config.oauth.scope),
+                ("code_challenge", &code_challenge),
+                ("code_challenge_method", "S256"),
+                ("state", &state),
+            ],
+        )?;
+        let session_state = serde_json::to_string(&PkceAuthState {
+            code_verifier,
+            state,
+            redirect_uri: redirect_uri.to_string(),
+        })?;
+
+        Ok(CreateAuthSession {
+            provider_id: ctx.provider_id,
+            driver_key: self.metadata().key.to_string(),
+            scheme: self.metadata().scheme.as_str().to_string(),
+            status: "pending".to_string(),
+            use_proxy: ctx.use_proxy,
+            user_code: None,
+            verification_uri: Some(config.oauth.auth_base_url.to_string()),
+            verification_uri_complete: Some(auth_url),
+            state_json: Some(session_state),
+            context_json: None,
+            result_json: None,
+            expires_at: Some(expires_at_after(10 * 60)),
+            poll_interval_seconds: Some(2),
+            last_error: None,
+        })
+    }
+
+    async fn exchange(
+        &self,
+        session: &AuthSession,
+        input: AuthExchangeInput,
+        ctx: ExchangeAuthContext,
+    ) -> Result<CredentialBundle> {
+        let config = Self::claude_code_config()?;
+        let state: PkceAuthState = parse_session_state(session)?;
+        let callback = parse_oauth_callback(&input)?;
+        validate_callback_state(&state.state, callback.state.as_deref(), "claude")?;
+        let code = callback
+            .code
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("missing authorization code"))?;
+
+        let client = required_http_client(ctx.http_client)?;
+        // NOTE: Anthropic's token endpoint diverges from RFC 6749 — it
+        // requires `state` to be echoed back in the JSON body, otherwise
+        // it returns 400 "Invalid request format". Keep this field.
+        let token_body = serde_json::json!({
+            "grant_type": "authorization_code",
+            "client_id": config.oauth.client_id,
+            "code": code,
+            "redirect_uri": state.redirect_uri,
+            "code_verifier": state.code_verifier,
+            "state": state.state,
+        });
+
+        let mut request = client
+            .post(config.oauth.token_url)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json");
+        for (key, value) in Self::claude_cli_headers() {
+            request = request.header(key, value);
+        }
+
+        let response = request
+            .json(&token_body)
+            .send()
+            .await
+            .context("exchange claude authorization code")?;
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            let detail = Self::parse_error(&body).unwrap_or(body);
+            bail!("claude oauth token exchange failed: HTTP {status} {detail}");
+        }
+
+        Self::normalize_token_response(&body, None, config)
+    }
+
+    async fn refresh(
+        &self,
+        credential: &StoredCredential,
+        ctx: RefreshAuthContext,
+    ) -> Result<CredentialBundle> {
+        let config = Self::claude_code_config()?;
+        let refresh_token = credential
+            .refresh_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("claude oauth refresh token is missing"))?;
+        let client = required_http_client(ctx.http_client)?;
+
+        let token_body = serde_json::json!({
+            "grant_type": "refresh_token",
+            "client_id": config.oauth.client_id,
+            "refresh_token": refresh_token,
+        });
+
+        let mut request = client
+            .post(config.oauth.token_url)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json");
+        for (key, value) in Self::claude_cli_headers() {
+            request = request.header(key, value);
+        }
+
+        let response = request
+            .json(&token_body)
+            .send()
+            .await
+            .context("refresh claude oauth token")?;
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            let detail = Self::parse_error(&body).unwrap_or(body);
+            bail!("claude oauth token refresh failed: HTTP {status} {detail}");
+        }
+
+        Self::normalize_token_response(&body, Some(refresh_token), config)
+    }
+
+    fn bind_runtime(
+        &self,
+        provider: &Provider,
+        credential: &StoredCredential,
+    ) -> Result<RuntimeBinding> {
+        let config = Self::claude_code_config()?;
+        let access_token = credential
+            .access_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("claude oauth access token is empty in bind_runtime"))?;
+
+        let mut extra_headers = HashMap::new();
+        extra_headers.insert(
+            "authorization".to_string(),
+            format!("Bearer {access_token}"),
+        );
+        extra_headers.insert("anthropic-version".to_string(), "2023-06-01".to_string());
+        // Mirror the CLI-shaped headers token-exchange uses (User-Agent,
+        // Referer, Origin, anthropic-beta) so a future runtime-gating
+        // change at Anthropic does not silently 4xx mid-session. Single
+        // source of truth keeps the version string in
+        // `CLAUDE_CLI_USER_AGENT` / `ANTHROPIC_OAUTH_BETA`.
+        for (key, value) in Self::claude_cli_headers() {
+            extra_headers.insert(key.to_ascii_lowercase(), value.to_string());
+        }
+
+        let base_url_override = credential
+            .resource_url
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| Some(config.api_base_url.to_string()));
+        // The OAuth Bearer fundamentally cannot call Anthropic's
+        // `/v1/models` (that endpoint requires `x-api-key`). Even after
+        // sidestepping that and reading from the models.dev cache, the
+        // full Anthropic catalog is misleading: only a curated subset
+        // is actually reachable through the Claude Code OAuth
+        // subscription. Plumb the channel-level `static_models` through
+        // `static_models_override` so admin discovery returns exactly
+        // what the official `claude` CLI / claude-relay-service treats
+        // as supported.
+        let static_models_override: Option<Vec<String>> = if config.static_models.is_empty() {
+            None
+        } else {
+            Some(
+                config
+                    .static_models
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            )
+        };
+        let capabilities_source_override = provider
+            .capabilities_source
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| Some("ai://models.dev/anthropic".to_string()));
+        let models_source_override = Some("ai://models.dev/anthropic".to_string());
+
+        Ok(RuntimeBinding {
+            base_url_override,
+            extra_headers,
+            model_aliases: HashMap::new(),
+            models_source_override,
+            capabilities_source_override,
+            disable_default_auth: true,
+            static_models_override,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_provider() -> Provider {
+        Provider {
+            id: "test".into(),
+            name: "test".into(),
+            vendor: Some("anthropic".into()),
+            protocol: "anthropic".into(),
+            base_url: String::new(),
+            default_protocol: String::new(),
+            protocol_endpoints: String::new(),
+            preset_key: Some("anthropic".into()),
+            channel: Some("claude-code".into()),
+            models_source: None,
+            capabilities_source: None,
+            static_models: None,
+            api_key: String::new(),
+            auth_mode: "oauth".into(),
+            use_proxy: false,
+            last_test_success: None,
+            last_test_at: None,
+            is_enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn config_loads_from_vendor_registry() {
+        let config = ClaudeOAuthDriver::claude_code_config().unwrap();
+        assert_eq!(config.oauth.auth_base_url, "https://claude.ai");
+        assert!(config.oauth.authorize_url.contains("claude.ai"));
+        assert!(config.oauth.token_url.contains("anthropic.com"));
+        assert_eq!(config.api_base_url, "https://api.anthropic.com");
+    }
+
+    #[test]
+    fn normalize_token_response_uses_claude_runtime_base_url() {
+        let body = r#"{"access_token":"tok_abc","refresh_token":"ref_xyz","expires_in":7200,"scope":"user:inference user:profile"}"#;
+        let config = ClaudeOAuthDriver::claude_code_config().unwrap();
+        let bundle = ClaudeOAuthDriver::normalize_token_response(body, None, config).unwrap();
+        assert_eq!(bundle.access_token.as_deref(), Some("tok_abc"));
+        assert_eq!(bundle.refresh_token.as_deref(), Some("ref_xyz"));
+        assert_eq!(bundle.scopes, vec!["user:inference", "user:profile"]);
+        assert_eq!(
+            bundle.resource_url.as_deref(),
+            Some("https://api.anthropic.com")
+        );
+        assert!(bundle.expires_at.is_some());
+    }
+
+    #[test]
+    fn parse_error_prefers_description() {
+        let body = r#"{"error":"invalid_grant","error_description":"code expired"}"#;
+        assert_eq!(
+            ClaudeOAuthDriver::parse_error(body).as_deref(),
+            Some("code expired")
+        );
+    }
+
+    #[test]
+    fn bind_runtime_sets_bearer_oauth_headers_and_disables_default_auth() {
+        let provider = test_provider();
+        let credential = StoredCredential {
+            access_token: Some("my_token".into()),
+            ..Default::default()
+        };
+        let binding = ClaudeOAuthDriver
+            .bind_runtime(&provider, &credential)
+            .unwrap();
+        assert_eq!(
+            binding.extra_headers.get("authorization").unwrap(),
+            "Bearer my_token"
+        );
+        assert_eq!(
+            binding.extra_headers.get("anthropic-beta").unwrap(),
+            "oauth-2025-04-20"
+        );
+        assert_eq!(
+            binding.extra_headers.get("user-agent").unwrap(),
+            "claude-cli/1.0.98 (external, cli)"
+        );
+        assert!(binding.disable_default_auth);
+        assert_eq!(
+            binding.base_url_override.as_deref(),
+            Some("https://api.anthropic.com")
+        );
+        assert_eq!(
+            binding.models_source_override.as_deref(),
+            Some("ai://models.dev/anthropic"),
+        );
+        let static_models = binding
+            .static_models_override
+            .as_deref()
+            .expect("claude-code channel must ship a curated static model list");
+        for expected in [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+        ] {
+            assert!(
+                static_models.iter().any(|m| m == expected),
+                "expected canonical Claude Code OAuth model {expected:?} in: {static_models:?}",
+            );
+        }
+    }
+}

--- a/crates/nyro-core/src/auth/drivers/mod.rs
+++ b/crates/nyro-core/src/auth/drivers/mod.rs
@@ -1,9 +1,11 @@
+mod claude;
 mod openai;
 mod shared;
 
+pub use claude::ClaudeOAuthDriver;
 pub use openai::OpenAIOAuthDriver;
 pub use shared::{
-    PkceAuthState, build_authorize_url, encode_scopes, expires_at_after,
-    generate_code_challenge, generate_code_verifier, generate_state, parse_oauth_callback,
-    parse_session_state, required_http_client, validate_callback_state,
+    PkceAuthState, build_authorize_url, encode_scopes, expires_at_after, generate_code_challenge,
+    generate_code_verifier, generate_state, parse_oauth_callback, parse_session_state,
+    required_http_client, validate_callback_state,
 };

--- a/crates/nyro-core/src/auth/drivers/openai.rs
+++ b/crates/nyro-core/src/auth/drivers/openai.rs
@@ -328,6 +328,7 @@ impl AuthDriver for OpenAIOAuthDriver {
             models_source_override,
             capabilities_source_override,
             disable_default_auth: false,
+            static_models_override: None,
         })
     }
 }

--- a/crates/nyro-core/src/auth/drivers/shared.rs
+++ b/crates/nyro-core/src/auth/drivers/shared.rs
@@ -78,10 +78,28 @@ pub fn parse_oauth_callback(input: &AuthExchangeInput) -> Result<OAuthCallbackPa
     if let Some(raw_code) = input.code.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
         let parsed = parse_callback_like_value(raw_code);
         if payload.code.is_none() {
-            payload.code = parsed.code.or_else(|| Some(raw_code.split('#').next().unwrap_or(raw_code).to_string()));
+            payload.code = parsed.code.or_else(|| {
+                Some(
+                    raw_code
+                        .split('#')
+                        .next()
+                        .unwrap_or(raw_code)
+                        .trim()
+                        .to_string(),
+                )
+            });
         }
         if payload.state.is_none() {
-            payload.state = parsed.state;
+            // Claude's `code=true` flow shows the user a single `<code>#<state>`
+            // string. When neither full URL nor `code=…&state=…` form is
+            // present, also recover state from the suffix after `#`.
+            payload.state = parsed.state.or_else(|| {
+                raw_code
+                    .split_once('#')
+                    .map(|(_, rest)| rest.trim())
+                    .filter(|rest| !rest.is_empty())
+                    .map(ToString::to_string)
+            });
         }
     }
 
@@ -160,9 +178,76 @@ fn parse_callback_like_value(raw: &str) -> OAuthCallbackPayload {
         }
     }
 
+    // Claude's `code=true` flow displays the auth result as a bare
+    // `<code>#<state>` string; recognize it here so it works whether pasted
+    // into the callback-URL field or the code field.
+    if !raw.contains(' ') && !raw.contains('?') {
+        if let Some((code_part, state_part)) = raw.split_once('#') {
+            let code = code_part.trim();
+            let state = state_part.trim();
+            if !code.is_empty() && !state.is_empty() {
+                return OAuthCallbackPayload {
+                    code: Some(code.to_string()),
+                    state: Some(state.to_string()),
+                };
+            }
+        }
+    }
+
     OAuthCallbackPayload::default()
 }
 
 pub fn required_http_client(client: Option<reqwest::Client>) -> Result<reqwest::Client> {
     client.ok_or_else(|| anyhow!("missing auth http client"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::types::AuthExchangeInput;
+
+    fn code_input(code: &str) -> AuthExchangeInput {
+        AuthExchangeInput {
+            callback_url: None,
+            code: Some(code.to_string()),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    fn callback_input(callback: &str) -> AuthExchangeInput {
+        AuthExchangeInput {
+            callback_url: Some(callback.to_string()),
+            code: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn parse_code_hash_state_form_in_code_field() {
+        let payload = parse_oauth_callback(&code_input("auth_abc123#state_xyz789")).unwrap();
+        assert_eq!(payload.code.as_deref(), Some("auth_abc123"));
+        assert_eq!(payload.state.as_deref(), Some("state_xyz789"));
+    }
+
+    #[test]
+    fn parse_code_hash_state_form_in_callback_field() {
+        let payload = parse_oauth_callback(&callback_input("auth_abc123#state_xyz789")).unwrap();
+        assert_eq!(payload.code.as_deref(), Some("auth_abc123"));
+        assert_eq!(payload.state.as_deref(), Some("state_xyz789"));
+    }
+
+    #[test]
+    fn parse_callback_url_form_still_works() {
+        let payload = parse_oauth_callback(&callback_input(
+            "https://example.com/cb?code=abc&state=xyz",
+        ))
+        .unwrap();
+        assert_eq!(payload.code.as_deref(), Some("abc"));
+        assert_eq!(payload.state.as_deref(), Some("xyz"));
+    }
+
+    #[test]
+    fn validate_state_rejects_missing() {
+        assert!(validate_callback_state("expected", None, "claude").is_err());
+    }
 }

--- a/crates/nyro-core/src/auth/registry.rs
+++ b/crates/nyro-core/src/auth/registry.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use crate::auth::drivers::OpenAIOAuthDriver;
+use crate::auth::drivers::{ClaudeOAuthDriver, OpenAIOAuthDriver};
 use crate::auth::types::{AuthDriver, AuthDriverMetadata};
 
 pub fn normalize_driver_key(value: &str) -> String {
     match value.trim().to_ascii_lowercase().as_str() {
         "openai-oauth" | "openai_oauth" | "openai" | "codex-cli" | "codex" => "codex".to_string(),
+        "claude-code" | "claude_code" | "claude-oauth" | "claude_oauth" | "claude"
+        | "anthropic" => "claude-code".to_string(),
         other => other.to_string(),
     }
 }
@@ -13,12 +15,13 @@ pub fn normalize_driver_key(value: &str) -> String {
 pub fn build_driver(key: &str) -> Option<Arc<dyn AuthDriver>> {
     match normalize_driver_key(key).as_str() {
         "codex" => Some(Arc::new(OpenAIOAuthDriver)),
+        "claude-code" => Some(Arc::new(ClaudeOAuthDriver)),
         _ => None,
     }
 }
 
 pub fn list_driver_metadata() -> Vec<AuthDriverMetadata> {
-    [build_driver("codex")]
+    [build_driver("codex"), build_driver("claude-code")]
         .into_iter()
         .flatten()
         .map(|driver| driver.metadata())

--- a/crates/nyro-core/src/auth/types.rs
+++ b/crates/nyro-core/src/auth/types.rs
@@ -140,6 +140,14 @@ pub struct RuntimeBinding {
     pub models_source_override: Option<String>,
     pub capabilities_source_override: Option<String>,
     pub disable_default_auth: bool,
+    /// When `Some`, the admin model-discovery paths return this exact
+    /// list and skip every URL/HTTP fallback. OAuth drivers (Claude
+    /// Code, future Codex tiers) use this to ship a curated allow-list
+    /// since their upstream `/v1/models` either does not accept the
+    /// minted Bearer or returns models the OAuth subscription cannot
+    /// actually run.
+    #[serde(default)]
+    pub static_models_override: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/nyro-core/src/provider/adapter.rs
+++ b/crates/nyro-core/src/provider/adapter.rs
@@ -33,6 +33,14 @@ pub struct ProviderCtx<'a> {
     pub actual_model: &'a str,
     pub credential: Option<&'a StoredCredential>,
     pub gw: &'a Gateway,
+    /// Set when an OAuth driver has populated `RuntimeBinding.extra_headers`
+    /// with its own auth scheme (Bearer + provider-specific headers) and
+    /// the vendor extension's default `auth_headers` (typically
+    /// `x-api-key` / `Authorization: Bearer <api_key>`) must NOT be
+    /// applied — otherwise the upstream sees both schemes and either
+    /// rejects the request or, worse, interprets an empty `x-api-key`
+    /// from a row whose `api_key` field is blank under OAuth mode.
+    pub disable_default_auth: bool,
 }
 
 impl<'a> ProviderCtx<'a> {

--- a/crates/nyro-core/src/provider/anthropic/claude_code/mod.rs
+++ b/crates/nyro-core/src/provider/anthropic/claude_code/mod.rs
@@ -1,6 +1,40 @@
-//! Placeholder for the Anthropic Claude Code OAuth channel.
+//! Anthropic Claude Code OAuth channel.
 //!
-//! Not registered with `inventory` yet — the OAuth driver, runtime
-//! binding, and metadata will land in a follow-up PR.
+//! Auth-specific headers are injected by `ClaudeOAuthDriver` through
+//! `RuntimeBinding.extra_headers`; this channel extension just gives the
+//! resolver a concrete `(vendor=anthropic, channel=claude-code)` target
+//! and intentionally returns no fallback auth headers so that flipping
+//! `disable_default_auth` cannot leak an empty `x-api-key`.
 
-// TODO: implement OAuth handshake, runtime binding, METADATA entry.
+use reqwest::header::HeaderMap;
+
+use crate::provider::registry::{VendorRegistration, VendorScope};
+use crate::provider::vendor_ext::{VendorCtx, VendorExtension};
+
+pub struct AnthropicClaudeCodeChannel;
+
+impl VendorExtension for AnthropicClaudeCodeChannel {
+    fn scope(&self) -> VendorScope {
+        VendorScope::Channel {
+            vendor_id: "anthropic",
+            channel_id: "claude-code",
+        }
+    }
+
+    // OAuth credentials live in `RuntimeBinding.extra_headers`. Returning
+    // an empty map here is defense-in-depth for the `VendorRegistry`
+    // three-tier `Channel → Vendor → Family` resolution path (used by
+    // admin-side flows), where this channel extension can be the seam
+    // that would otherwise fall back to `AnthropicVendor.auth_headers`'s
+    // `x-api-key`. The proxy `ProviderAdapter` path resolves the adapter
+    // by `vendor_id` and never reaches this `auth_headers` impl — that
+    // path's gate lives in `provider::common::openai::openai_compat_build_request`
+    // (`if ctx.disable_default_auth { HeaderMap::new() }`).
+    fn auth_headers(&self, _ctx: &VendorCtx<'_>) -> HeaderMap {
+        HeaderMap::new()
+    }
+}
+
+inventory::submit! {
+    VendorRegistration { make: || Box::new(AnthropicClaudeCodeChannel) }
+}

--- a/crates/nyro-core/src/provider/anthropic/mod.rs
+++ b/crates/nyro-core/src/provider/anthropic/mod.rs
@@ -14,7 +14,9 @@ use crate::provider::common::openai::{
     openai_compat_build_request, openai_compat_parse_response, openai_compat_stream_parser,
 };
 use crate::provider::inbound::InboundResponse;
-use crate::provider::metadata::{AuthMode, ChannelDef, Label, ProtocolBaseUrl, VendorMetadata};
+use crate::provider::metadata::{
+    AuthMode, ChannelDef, Label, OAuthConfig, ProtocolBaseUrl, VendorMetadata,
+};
 use crate::provider::outbound::OutboundRequest;
 use crate::protocol::ids::ProtocolFamily;
 use crate::provider::registry::{ProviderAdapterRegistration, VendorRegistration, VendorScope};
@@ -26,21 +28,68 @@ const METADATA: VendorMetadata = VendorMetadata {
     label: Label { zh: "Anthropic", en: "Anthropic" },
     icon: "anthropic",
     default_protocol: "anthropic",
-    channels: &[ChannelDef {
-        id: "default",
-        label: Label { zh: "默认", en: "Default" },
-        base_urls: &[ProtocolBaseUrl {
-            protocol: "anthropic",
-            base_url: "https://api.anthropic.com",
-        }],
-        api_key: None,
-        models_source: Some("https://api.anthropic.com/v1/models"),
-        capabilities_source: Some("ai://models.dev/anthropic"),
-        static_models: &[],
-        auth_mode: AuthMode::ApiKey,
-        oauth: None,
-        runtime: None,
-    }],
+    channels: &[
+        ChannelDef {
+            id: "default",
+            label: Label { zh: "默认", en: "Default" },
+            base_urls: &[ProtocolBaseUrl {
+                protocol: "anthropic",
+                base_url: "https://api.anthropic.com",
+            }],
+            api_key: None,
+            models_source: Some("https://api.anthropic.com/v1/models"),
+            capabilities_source: Some("ai://models.dev/anthropic"),
+            static_models: &[],
+            auth_mode: AuthMode::ApiKey,
+            oauth: None,
+            runtime: None,
+        },
+        ChannelDef {
+            id: "claude-code",
+            label: Label { zh: "Claude Code", en: "Claude Code" },
+            base_urls: &[ProtocolBaseUrl {
+                protocol: "anthropic",
+                base_url: "https://api.anthropic.com",
+            }],
+            api_key: None,
+            // OAuth Bearer cannot call Anthropic's `/v1/models` (that
+            // endpoint is x-api-key only). Even when we sidestep that
+            // and pull the full Anthropic catalog from models.dev, only
+            // a curated subset is actually reachable via the Claude
+            // Code OAuth subscription — the rest 403 at request time.
+            //
+            // List below tracks Wei-Shaw/claude-relay-service's
+            // `config/models.js::CLAUDE_MODELS` (the dropdown used for
+            // OAuth account selection + connectivity testing). Driver
+            // `ClaudeOAuthDriver::bind_runtime` plumbs this list into
+            // `RuntimeBinding.static_models_override` so admin model
+            // discovery returns it directly without hitting any
+            // upstream URL.
+            models_source: Some("ai://models.dev/anthropic"),
+            capabilities_source: Some("ai://models.dev/anthropic"),
+            static_models: &[
+                "claude-opus-4-6",
+                "claude-sonnet-4-6",
+                "claude-opus-4-5-20251101",
+                "claude-sonnet-4-5-20250929",
+                "claude-sonnet-4-20250514",
+                "claude-opus-4-1-20250805",
+                "claude-opus-4-20250514",
+                "claude-haiku-4-5-20251001",
+                "claude-3-5-haiku-20241022",
+            ],
+            auth_mode: AuthMode::OAuth,
+            oauth: Some(OAuthConfig {
+                auth_base_url: "https://claude.ai",
+                authorize_url: "https://claude.ai/oauth/authorize",
+                token_url: "https://console.anthropic.com/v1/oauth/token",
+                client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+                redirect_uri: "https://platform.claude.com/oauth/code/callback",
+                scope: "user:inference user:profile",
+            }),
+            runtime: None,
+        },
+    ],
 };
 
 pub struct AnthropicVendor;

--- a/crates/nyro-core/src/provider/common/openai.rs
+++ b/crates/nyro-core/src/provider/common/openai.rs
@@ -166,12 +166,31 @@ where
         .map_err(GatewayError::internal)?;
 
     // 6. auth headers
-    let mut headers = vendor.auth_headers(&vendor_ctx);
+    //
+    // OAuth drivers (codex, claude-code) stash their Bearer + provider-
+    // specific headers in `RuntimeBinding.extra_headers` and ask the
+    // dispatcher to skip the vendor's default `auth_headers` via
+    // `ctx.disable_default_auth`. Skipping unconditionally would break
+    // every API-key path; gating here keeps the OAuth invariant
+    // ("no leaked empty x-api-key") in a single seam shared by every
+    // openai-compat adapter.
+    let mut headers = if ctx.disable_default_auth {
+        reqwest::header::HeaderMap::new()
+    } else {
+        vendor.auth_headers(&vendor_ctx)
+    };
     // Anthropic-protocol upstreams require `x-api-key` instead of
     // `Authorization: Bearer`. Most OpenAI-compatible vendors blindly emit
     // Bearer; rewrite here so any vendor with a declared anthropic endpoint
     // works out of the box.
-    if ctx.protocol.family == crate::protocol::ids::ProtocolFamily::Anthropic
+    //
+    // Skipped under `disable_default_auth`: when an OAuth driver owns auth
+    // (claude-code uses `Bearer <oauth_token>` + `anthropic-beta=
+    // oauth-2025-04-20`), `ctx.api_key` is the OAuth Bearer token, NOT a
+    // real Anthropic API key. Rewriting it here would forward the Bearer
+    // as a fake `x-api-key` and break the OAuth handshake.
+    if !ctx.disable_default_auth
+        && ctx.protocol.family == crate::protocol::ids::ProtocolFamily::Anthropic
         && !headers.contains_key("x-api-key")
     {
         headers.remove(reqwest::header::AUTHORIZATION);
@@ -254,7 +273,35 @@ impl ThinkTagExtractingParser {
 
 #[cfg(test)]
 mod tests {
+    //! Tests cover two seams in this module:
+    //!
+    //! 1. URL building (`openai_build_url` / `base_ends_with_version_segment`)
+    //!    — versioned vs non-versioned bases.
+    //!
+    //! 2. The `disable_default_auth` gate inside
+    //!    `openai_compat_build_request`. Every `ProviderAdapter`
+    //!    (anthropic / openai / google / deepseek / zai / zhipuai /
+    //!    minimax / moonshotai / nvidia / custom) routes through this
+    //!    helper. When `ProviderCtx.disable_default_auth` is set, the
+    //!    vendor's default `auth_headers` AND the Anthropic-egress
+    //!    `Authorization → x-api-key` rewrite MUST be suppressed —
+    //!    otherwise OAuth providers either leak an empty `x-api-key`
+    //!    (the PR #86 bug) or forward an OAuth Bearer as a fake
+    //!    `x-api-key` (the PR #105 interaction). Both directions are
+    //!    pinned so a future refactor that flips a gate fails loudly.
     use super::*;
+    use crate::Gateway;
+    use crate::GatewayConfig;
+    use crate::db::models::Provider;
+    use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1};
+    use crate::protocol::types::{InternalMessage, InternalRequest, MessageContent, Role};
+    use crate::provider::adapter::ProviderCtx;
+    use crate::provider::registry::VendorScope;
+    use crate::provider::vendor_ext::{VendorCtx, VendorExtension};
+    use reqwest::header::HeaderMap as ExtHeaderMap;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use uuid::Uuid;
 
     #[test]
     fn version_segment_recognition() {
@@ -306,10 +353,7 @@ mod tests {
     #[test]
     fn build_url_preserves_v1_for_anthropic_base() {
         assert_eq!(
-            openai_build_url(
-                "https://open.bigmodel.cn/api/anthropic",
-                "/v1/messages"
-            ),
+            openai_build_url("https://open.bigmodel.cn/api/anthropic", "/v1/messages"),
             "https://open.bigmodel.cn/api/anthropic/v1/messages"
         );
         assert_eq!(
@@ -327,6 +371,229 @@ mod tests {
         assert_eq!(
             openai_build_url("https://api.example.com/", "/v1/chat/completions"),
             "https://api.example.com/v1/chat/completions"
+        );
+    }
+
+    /// Stand-in vendor: always tries to inject `x-api-key: <ctx.api_key>`,
+    /// mirroring how `AnthropicVendor::auth_headers` and friends behave.
+    /// The seam under test is "this fallback gets suppressed under
+    /// `disable_default_auth`".
+    struct FakeApiKeyVendor;
+
+    impl VendorExtension for FakeApiKeyVendor {
+        fn scope(&self) -> VendorScope {
+            VendorScope::Vendor {
+                vendor_id: "fake-test",
+            }
+        }
+        fn auth_headers(&self, ctx: &VendorCtx<'_>) -> ExtHeaderMap {
+            let mut h = ExtHeaderMap::new();
+            if !ctx.api_key.is_empty() {
+                h.insert(
+                    "x-api-key",
+                    reqwest::header::HeaderValue::from_str(ctx.api_key).unwrap(),
+                );
+            }
+            h
+        }
+    }
+
+    /// Mirrors most OpenAI-compat vendors (zhipuai/deepseek/custom...):
+    /// emit `Authorization: Bearer <ctx.api_key>`. PR #105's rewrite block
+    /// then converts this to `x-api-key` when egress family is Anthropic.
+    /// We reuse it to test the OAuth interaction (rewrite must NOT fire
+    /// when an OAuth driver owns auth).
+    struct FakeBearerVendor;
+
+    impl VendorExtension for FakeBearerVendor {
+        fn scope(&self) -> VendorScope {
+            VendorScope::Vendor {
+                vendor_id: "fake-bearer",
+            }
+        }
+        fn auth_headers(&self, ctx: &VendorCtx<'_>) -> ExtHeaderMap {
+            let mut h = ExtHeaderMap::new();
+            if !ctx.api_key.is_empty() {
+                h.insert(
+                    reqwest::header::AUTHORIZATION,
+                    reqwest::header::HeaderValue::from_str(&format!("Bearer {}", ctx.api_key))
+                        .unwrap(),
+                );
+            }
+            h
+        }
+    }
+
+    fn provider_with_api_key(api_key: &str) -> Provider {
+        Provider {
+            id: "p".into(),
+            name: "p".into(),
+            vendor: Some("fake-test".into()),
+            protocol: "openai".into(),
+            base_url: "https://upstream.local".into(),
+            default_protocol: "openai".into(),
+            protocol_endpoints: String::new(),
+            preset_key: Some("fake-test".into()),
+            channel: Some("default".into()),
+            models_source: None,
+            capabilities_source: None,
+            static_models: None,
+            api_key: api_key.into(),
+            auth_mode: "apikey".into(),
+            use_proxy: false,
+            last_test_success: None,
+            last_test_at: None,
+            is_enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    fn minimal_chat_request() -> InternalRequest {
+        InternalRequest {
+            messages: vec![InternalMessage {
+                role: Role::User,
+                content: MessageContent::Text("ping".into()),
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            model: "ignored-by-actual-model".into(),
+            stream: false,
+            temperature: None,
+            max_tokens: None,
+            top_p: None,
+            tools: None,
+            tool_choice: None,
+            source_protocol: OPENAI_CHAT_V1,
+            extra: HashMap::new(),
+        }
+    }
+
+    async fn build_test_gateway() -> Gateway {
+        let mut config = GatewayConfig::default();
+        config.data_dir = PathBuf::from(std::env::temp_dir())
+            .join(format!("nyro-disable-default-auth-test-{}", Uuid::new_v4()));
+        let (gw, _log_rx) = Gateway::new(config).await.expect("gateway init");
+        gw
+    }
+
+    #[tokio::test]
+    async fn build_request_suppresses_default_auth_when_oauth_owns_it() {
+        let gw = build_test_gateway().await;
+        let provider = provider_with_api_key("would-leak-if-bypassed");
+        let mut req = minimal_chat_request();
+        let ctx = ProviderCtx {
+            provider: &provider,
+            protocol: OPENAI_CHAT_V1,
+            egress_base_url: "https://upstream.local",
+            api_key: &provider.api_key,
+            actual_model: "gpt-test",
+            credential: None,
+            gw: &gw,
+            disable_default_auth: true,
+        };
+        let out = openai_compat_build_request(&FakeApiKeyVendor, &mut req, &ctx)
+            .await
+            .expect("build_request succeeds");
+        assert!(
+            out.headers.get("x-api-key").is_none(),
+            "OAuth provider must not emit fallback x-api-key, got: {:?}",
+            out.headers.get("x-api-key"),
+        );
+    }
+
+    #[tokio::test]
+    async fn build_request_keeps_default_auth_when_no_oauth() {
+        let gw = build_test_gateway().await;
+        let provider = provider_with_api_key("apikey-abc");
+        let mut req = minimal_chat_request();
+        let ctx = ProviderCtx {
+            provider: &provider,
+            protocol: OPENAI_CHAT_V1,
+            egress_base_url: "https://upstream.local",
+            api_key: &provider.api_key,
+            actual_model: "gpt-test",
+            credential: None,
+            gw: &gw,
+            disable_default_auth: false,
+        };
+        let out = openai_compat_build_request(&FakeApiKeyVendor, &mut req, &ctx)
+            .await
+            .expect("build_request succeeds");
+        assert_eq!(
+            out.headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+            Some("apikey-abc"),
+            "API-key path must still propagate x-api-key to upstream",
+        );
+    }
+
+    /// Pins the rebase-time interaction with PR #105: when an OAuth driver
+    /// owns auth (`disable_default_auth=true`) AND the egress family is
+    /// Anthropic, the `Authorization → x-api-key` rewrite must NOT fire.
+    /// `ctx.api_key` on the OAuth path is the OAuth Bearer token itself —
+    /// rewriting it as `x-api-key` would forward the Bearer as a fake API
+    /// key and break the OAuth handshake.
+    #[tokio::test]
+    async fn build_request_does_not_rewrite_oauth_bearer_to_xapikey_on_anthropic_egress() {
+        let gw = build_test_gateway().await;
+        let provider = provider_with_api_key("");
+        let mut req = minimal_chat_request();
+        let ctx = ProviderCtx {
+            provider: &provider,
+            protocol: ANTHROPIC_MESSAGES_2023_06_01,
+            egress_base_url: "https://api.anthropic.com",
+            api_key: "oauth_bearer_token_should_not_become_xapikey",
+            actual_model: "claude-sonnet-4-6",
+            credential: None,
+            gw: &gw,
+            disable_default_auth: true,
+        };
+        let out = openai_compat_build_request(&FakeBearerVendor, &mut req, &ctx)
+            .await
+            .expect("build_request succeeds");
+        assert!(
+            out.headers.get("x-api-key").is_none(),
+            "OAuth Bearer must not be rewritten as x-api-key, got: {:?}",
+            out.headers.get("x-api-key"),
+        );
+        assert!(
+            out.headers.get(reqwest::header::AUTHORIZATION).is_none(),
+            "default Authorization must be suppressed under disable_default_auth too, got: {:?}",
+            out.headers.get(reqwest::header::AUTHORIZATION),
+        );
+    }
+
+    /// Mirror of #105's main use case: API-key-mode OpenAI-compat vendor
+    /// (e.g. zhipuai with anthropic endpoint) hitting Anthropic egress —
+    /// the rewrite block MUST fire and turn `Authorization: Bearer` into
+    /// `x-api-key`. Pinned alongside the OAuth-skip case so any future
+    /// refactor of either gate fails loudly here.
+    #[tokio::test]
+    async fn build_request_rewrites_bearer_to_xapikey_on_anthropic_egress_for_apikey_path() {
+        let gw = build_test_gateway().await;
+        let provider = provider_with_api_key("real-anthropic-key");
+        let mut req = minimal_chat_request();
+        let ctx = ProviderCtx {
+            provider: &provider,
+            protocol: ANTHROPIC_MESSAGES_2023_06_01,
+            egress_base_url: "https://api.anthropic.com",
+            api_key: &provider.api_key,
+            actual_model: "claude-sonnet-4-6",
+            credential: None,
+            gw: &gw,
+            disable_default_auth: false,
+        };
+        let out = openai_compat_build_request(&FakeBearerVendor, &mut req, &ctx)
+            .await
+            .expect("build_request succeeds");
+        assert_eq!(
+            out.headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+            Some("real-anthropic-key"),
+            "API-key path on Anthropic egress must produce x-api-key",
+        );
+        assert!(
+            out.headers.get(reqwest::header::AUTHORIZATION).is_none(),
+            "Authorization must be removed once x-api-key is set",
         );
     }
 }

--- a/crates/nyro-core/src/proxy/dispatcher.rs
+++ b/crates/nyro-core/src/proxy/dispatcher.rs
@@ -413,6 +413,7 @@ pub async fn dispatch_pipeline(
             actual_model: &actual_model,
             credential: None,
             gw: &gw,
+            disable_default_auth: provider_runtime.binding.disable_default_auth,
         };
 
         // Build outbound request via ProviderAdapter.
@@ -1801,7 +1802,9 @@ async fn compute_embedding(gw: &Gateway, text: &str) -> anyhow::Result<Vec<f32>>
                 Ok(h) => h,
                 Err(_) => continue,
             };
-            request_headers.extend(extension.auth_headers(&ctx));
+            if !provider_runtime.binding.disable_default_auth {
+                request_headers.extend(extension.auth_headers(&ctx));
+            }
         }
         let client = match gw.http_client_for_provider(provider.use_proxy).await {
             Ok(c) => ProxyClient::new(c),

--- a/crates/nyro-core/tests/fixtures/providers_legacy.json
+++ b/crates/nyro-core/tests/fixtures/providers_legacy.json
@@ -63,6 +63,33 @@
         "modelsSource": "https://api.anthropic.com/v1/models",
         "capabilitiesSource": "ai://models.dev/anthropic",
         "authMode": "apikey"
+      },
+      {
+        "id": "claude-code",
+        "label": { "zh": "Claude Code", "en": "Claude Code" },
+        "baseUrls": { "anthropic": "https://api.anthropic.com" },
+        "modelsSource": "ai://models.dev/anthropic",
+        "capabilitiesSource": "ai://models.dev/anthropic",
+        "staticModels": [
+          "claude-opus-4-6",
+          "claude-sonnet-4-6",
+          "claude-opus-4-5-20251101",
+          "claude-sonnet-4-5-20250929",
+          "claude-sonnet-4-20250514",
+          "claude-opus-4-1-20250805",
+          "claude-opus-4-20250514",
+          "claude-haiku-4-5-20251001",
+          "claude-3-5-haiku-20241022"
+        ],
+        "authMode": "oauth",
+        "oauth": {
+          "authBaseUrl": "https://claude.ai",
+          "authorizeUrl": "https://claude.ai/oauth/authorize",
+          "tokenUrl": "https://console.anthropic.com/v1/oauth/token",
+          "clientId": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+          "redirectUri": "https://platform.claude.com/oauth/code/callback",
+          "scope": "user:inference user:profile"
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary
- reimplement Claude Code OAuth on top of the latest vendor-registry architecture
- add the `claude-code` Anthropic channel metadata and Claude OAuth driver aliases
- route Claude OAuth runtime through Bearer auth + Anthropic beta headers while skipping default `x-api-key` auth where needed

## Notes
- this supersedes the old closed PR #86 and was rebuilt from the latest `master`
- I re-checked the new implementation against the old Claude OAuth logic: PKCE flow, token exchange/refresh payloads, token expiry handling, and runtime header binding remain aligned; the main change is adapting it to the new provider/runtime architecture

## Validation
- `cargo test -p nyro-core`
- local `nyro-server` build + launch
- WebUI reachable from Mac 01 over `http://192.168.250.21:19531/`
