### PR TITLE
fix(core): passthrough_run now substitutes virtual model alias with actual_model

### DIFF
--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -167,9 +167,15 @@ pub fn stream_parser(
 /// URL are computed; the client body is forwarded verbatim.
 pub async fn passthrough_run(
     vendor: &dyn Vendor,
-    raw_body: serde_json::Value,
+    mut raw_body: serde_json::Value,
     ctx: &crate::provider::vendor::ProviderCtx<'_>,
 ) -> Result<crate::provider::outbound::OutboundRequest, GatewayError> {
+    // Replace the model field with the route-configured actual model so the
+    // upstream receives the real model name, not the client's virtual alias.
+    if let Some(obj) = raw_body.as_object_mut() {
+        obj.insert("model".to_string(), serde_json::Value::String(ctx.actual_model.to_string()));
+    }
+
     let vendor_ctx = ctx.to_vendor_ctx();
 
     let mut headers = if ctx.disable_default_auth {

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -257,11 +257,17 @@ async fn passthrough_run_preserves_vendor_specific_fields() {
     .await
     .expect("passthrough_run must succeed");
 
-    // Body is forwarded verbatim (JSON-value equality).
+    // Vendor-specific extension fields must survive; model is replaced with
+    // actual_model (same value here, so body equality still holds).
     assert_eq!(
-        out.body, raw_body,
-        "passthrough_run must not modify the request body"
+        out.body["vendor_extension_field"], raw_body["vendor_extension_field"],
+        "vendor extension fields must be forwarded verbatim"
     );
+    assert_eq!(
+        out.body["another_custom"], raw_body["another_custom"],
+        "nested vendor fields must be forwarded verbatim"
+    );
+    assert_eq!(out.body["model"], "gpt-4o", "model must equal actual_model");
     // Auth header must be present.
     assert!(
         out.headers.contains_key(reqwest::header::AUTHORIZATION),
@@ -272,6 +278,40 @@ async fn passthrough_run_preserves_vendor_specific_fields() {
         out.url.contains("/v1/chat/completions"),
         "URL must include the egress path, got: {}",
         out.url
+    );
+}
+
+#[tokio::test]
+async fn passthrough_run_rewrites_model_to_actual_model() {
+    let gw = build_test_gateway().await;
+    let provider = fake_provider("sk-test");
+    let vendor = BearerVendor("test");
+
+    // Client sends a virtual alias; route target maps it to the real model name.
+    let raw_body = json!({
+        "model": "my-virtual-alias",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": false,
+    });
+
+    let ctx = ProviderCtx {
+        provider: &provider,
+        protocol: OPENAI_CHAT_V1,
+        egress_base_url: "https://api.openai.com",
+        api_key: &provider.api_key,
+        actual_model: "glm-4-flash",
+        credential: None,
+        gw: &gw,
+        disable_default_auth: false,
+    };
+
+    let out = nyro_core::provider::common::pipeline::passthrough_run(&vendor, raw_body, &ctx)
+        .await
+        .expect("passthrough_run must succeed");
+
+    assert_eq!(
+        out.body["model"], "glm-4-flash",
+        "passthrough_run must substitute the virtual alias with the route-configured actual model"
     );
 }
 


### PR DESCRIPTION
In PassThrough mode the raw request body was forwarded verbatim, causing the upstream to receive the client's virtual model alias instead of the real model name configured on the route target. Reproduce: client sends model="my-alias", upstream responds with "model not found".

Fix: before forwarding, overwrite body["model"] with ctx.actual_model so the upstream always sees the resolved model name regardless of PassThrough being active.

Added regression test: passthrough_run_rewrites_model_to_actual_model.