### PR TITLE
fix(core): stream passthrough, error propagation and RawEvent forwarding

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic/stream.rs
@@ -248,24 +248,32 @@ fn parse_anthropic_event(event_type: Option<&str>, data: &Value, deltas: &mut Ve
                 .get("index")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0) as usize;
-            if let Some(block) = data.get("content_block")
-                && let Some("tool_use") = block.get("type").and_then(|t| t.as_str()) {
-                    let id = block
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let name = block
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    deltas.push(StreamDelta::ToolCallStart {
-                        index: idx,
-                        id,
-                        name,
-                    });
+            if let Some(block) = data.get("content_block") {
+                match block.get("type").and_then(|t| t.as_str()) {
+                    Some("tool_use") => {
+                        let id = block
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let name = block
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        deltas.push(StreamDelta::ToolCallStart { index: idx, id, name });
+                    }
+                    // Anthropic server-side tool blocks (web_search, code_execution,
+                    // mcp_tool_use, etc.) and any future block types not yet known:
+                    // forward verbatim so downstream clients receive the full event.
+                    _ => {
+                        deltas.push(StreamDelta::RawEvent {
+                            event_type: "content_block_start".to_string(),
+                            data: data.clone(),
+                        });
+                    }
                 }
+            }
         }
         Some("content_block_delta") => {
             if let Some(delta) = data.get("delta") {
@@ -307,7 +315,15 @@ fn parse_anthropic_event(event_type: Option<&str>, data: &Value, deltas: &mut Ve
                             });
                         }
                     }
-                    _ => {}
+                    // Unknown delta types (e.g. web_search_tool_result_delta,
+                    // citations_delta, code_execution_tool_result_delta):
+                    // forward verbatim.
+                    _ => {
+                        deltas.push(StreamDelta::RawEvent {
+                            event_type: "content_block_delta".to_string(),
+                            data: data.clone(),
+                        });
+                    }
                 }
             }
         }
@@ -337,7 +353,14 @@ fn parse_anthropic_event(event_type: Option<&str>, data: &Value, deltas: &mut Ve
             }
         }
         Some("ping") | Some("content_block_stop") | Some("message_stop") => {}
-        _ => {}
+        // Unknown top-level event types: forward verbatim so no data is dropped.
+        Some(_) => {
+            deltas.push(StreamDelta::RawEvent {
+                event_type: event_type.unwrap_or("unknown").to_string(),
+                data: data.clone(),
+            });
+        }
+        None => {}
     }
 }
 
@@ -545,6 +568,14 @@ impl StreamFormatter for AnthropicStreamFormatter {
                     events.push(SseEvent::new(
                         Some("message_stop"),
                         r#"{"type":"message_stop"}"#,
+                    ));
+                }
+                // Verbatim pass-through for Anthropic server-tool events and any
+                // future event types not yet handled by the codec.
+                StreamDelta::RawEvent { event_type, data } => {
+                    events.push(SseEvent::new(
+                        Some(event_type.as_str()),
+                        data.to_string(),
                     ));
                 }
             }
@@ -901,5 +932,112 @@ mod tests {
         assert!(has_tool_start, "expected ToolCallStart(get_weather), got: {deltas:?}");
         assert!(has_tool_delta, "expected ToolCallDelta, got: {deltas:?}");
         assert!(has_done_tool, "expected Done(tool_calls), got: {deltas:?}");
+    }
+
+    // ── P2: RawEvent forwarding ───────────────────────────────────────────────
+
+    #[test]
+    fn test_unknown_content_block_start_emits_raw_event() {
+        // GLM server-side tool (e.g. webReader) sends a content_block_start with
+        // type "server_tool_use". The parser must emit RawEvent instead of dropping it.
+        let sse = [
+            make_sse_block(
+                "message_start",
+                r#"{"type":"message_start","message":{"id":"msg_5","model":"glm-5","content":[],"stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}"#,
+            ),
+            make_sse_block(
+                "content_block_start",
+                r#"{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_01","name":"webReader","input":{}}}"#,
+            ),
+            make_sse_block(
+                "content_block_stop",
+                r#"{"type":"content_block_stop","index":0}"#,
+            ),
+            make_sse_block(
+                "message_delta",
+                r#"{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":4}}"#,
+            ),
+        ]
+        .concat();
+
+        let mut parser = AnthropicStreamParser::new();
+        let deltas = parser.parse_chunk(&sse).unwrap();
+
+        let raw = deltas.iter().find_map(|d| {
+            if let StreamDelta::RawEvent { event_type, data } = d {
+                Some((event_type.as_str(), data.clone()))
+            } else {
+                None
+            }
+        });
+        assert!(raw.is_some(), "expected RawEvent for server_tool_use, got: {deltas:?}");
+        let (ev_type, data) = raw.unwrap();
+        assert_eq!(ev_type, "content_block_start");
+        assert_eq!(
+            data.pointer("/content_block/type").and_then(|v| v.as_str()),
+            Some("server_tool_use"),
+        );
+    }
+
+    #[test]
+    fn test_unknown_top_level_event_emits_raw_event() {
+        // A future or provider-specific event type must not be silently dropped.
+        let sse = make_sse_block(
+            "web_search_result",
+            r#"{"type":"web_search_result","results":[{"title":"foo","url":"https://example.com"}]}"#,
+        );
+
+        let mut parser = AnthropicStreamParser::new();
+        let deltas = parser.parse_chunk(&sse).unwrap();
+
+        let raw = deltas.iter().find(|d| matches!(d, StreamDelta::RawEvent { event_type, .. } if event_type == "web_search_result"));
+        assert!(raw.is_some(), "expected RawEvent for web_search_result, got: {deltas:?}");
+    }
+
+    #[test]
+    fn test_raw_event_forwarded_verbatim_by_formatter() {
+        // AnthropicStreamFormatter must emit a verbatim SSE event for RawEvent.
+        let raw_data = serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "server_tool_use", "id": "srv_01", "name": "webSearch", "input": {}}
+        });
+
+        let mut formatter = AnthropicStreamFormatter::new();
+        let events = formatter.format_deltas(&[
+            StreamDelta::MessageStart {
+                id: "msg_6".to_string(),
+                model: "glm-5".to_string(),
+            },
+            StreamDelta::RawEvent {
+                event_type: "content_block_start".to_string(),
+                data: raw_data.clone(),
+            },
+        ]);
+
+        let raw_forwarded = events.iter().find(|ev| {
+            ev.event.as_deref() == Some("content_block_start")
+                && ev.data.contains("server_tool_use")
+        });
+        assert!(
+            raw_forwarded.is_some(),
+            "formatter must forward RawEvent verbatim; events: {events:?}",
+        );
+    }
+
+    #[test]
+    fn test_unknown_content_block_delta_type_emits_raw_event() {
+        // Unknown delta types (citations_delta, web_search_tool_result_delta, etc.)
+        // must be forwarded as RawEvent, not silently dropped.
+        let sse = make_sse_block(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"url":"https://example.com","title":"Example"}}}"#,
+        );
+
+        let mut parser = AnthropicStreamParser::new();
+        let deltas = parser.parse_chunk(&sse).unwrap();
+
+        let raw = deltas.iter().find(|d| matches!(d, StreamDelta::RawEvent { event_type, .. } if event_type == "content_block_delta"));
+        assert!(raw.is_some(), "expected RawEvent for citations_delta, got: {deltas:?}");
     }
 }

--- a/crates/nyro-core/src/protocol/codec/google/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/google/stream.rs
@@ -326,6 +326,7 @@ impl StreamFormatter for GoogleStreamFormatter {
                         self.usage.output_tokens = u.output_tokens;
                     }
                 }
+                StreamDelta::RawEvent { .. } => {}
                 StreamDelta::Done { stop_reason } => {
                     let gemini_reason = match stop_reason.as_str() {
                         "stop" => "STOP",

--- a/crates/nyro-core/src/protocol/codec/openai/responses/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/responses/stream.rs
@@ -399,6 +399,7 @@ impl StreamFormatter for ResponsesStreamFormatter {
                 StreamDelta::Usage(u) => {
                     self.usage = u.clone();
                 }
+                StreamDelta::RawEvent { .. } => {}
                 StreamDelta::Done { .. } => {
                     if !self.completed {
                         self.completed = true;

--- a/crates/nyro-core/src/protocol/codec/openai/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/stream.rs
@@ -437,6 +437,7 @@ impl StreamFormatter for OpenAIStreamFormatter {
                 StreamDelta::Usage(u) => {
                     self.usage = u.clone();
                 }
+                StreamDelta::RawEvent { .. } => {}
                 StreamDelta::Done { stop_reason } => {
                     let final_reason = if self.saw_tool_call {
                         "tool_calls".to_string()

--- a/crates/nyro-core/src/protocol/types.rs
+++ b/crates/nyro-core/src/protocol/types.rs
@@ -161,4 +161,8 @@ pub enum StreamDelta {
     ToolCallDelta { index: usize, arguments: String },
     Usage(TokenUsage),
     Done { stop_reason: String },
+    /// A verbatim SSE event that was not classified into a known delta type.
+    /// Forwarded as-is by same-protocol formatters so no upstream data is silently dropped.
+    /// Other formatters (e.g. OpenAI, Google) ignore it.
+    RawEvent { event_type: String, data: Value },
 }

--- a/crates/nyro-core/src/provider/vendor.rs
+++ b/crates/nyro-core/src/provider/vendor.rs
@@ -17,6 +17,51 @@
 //!
 //! Channel-scoped extensions (e.g. `claude-code`, `codex`) keep
 //! implementing `VendorExtension` and register via `ExtensionRegistration`.
+//!
+//! # Where to place field adjustments — layering rules
+//!
+//! ## Global codec  (`protocol/codec/{anthropic,openai,google}/`)
+//!
+//! Put logic here when the adjustment applies to **all** vendors that speak
+//! the same wire protocol, regardless of who they are:
+//! * Normalising enum spellings that differ across protocol versions
+//!   (`tool_use` ↔ `tool_calls`, `stop_reason` ↔ `finish_reason`).
+//! * Parsing / emitting standard event types defined in the spec
+//!   (`content_block_start`, `message_delta`, `text_delta`, …).
+//! * Forwarding unknown event types as [`StreamDelta::RawEvent`] so
+//!   the downstream client receives them verbatim instead of losing them.
+//!
+//! ## Vendor hook  (`pre_encode` / `post_encode` / `pre_parse` / `post_parse`)
+//!
+//! Put logic here when the adjustment is **vendor-specific**, i.e. required
+//! because a particular provider deviates from the spec or adds proprietary
+//! fields:
+//! * Adding / stripping provider-only top-level keys in the request body.
+//! * Renaming a field that the provider misnamed relative to the spec.
+//! * Injecting a vendor token or signing headers.
+//!
+//! If the same deviation appears in ≥ 2 unrelated providers, promote it to
+//! the global codec instead.
+//!
+//! ## Decision flowchart
+//!
+//! ```text
+//! Is the field/event defined in the protocol spec?
+//!   YES → global codec.
+//!   NO  → Is it specific to one vendor?
+//!           YES → vendor hook (pre_/post_encode or pre_/post_parse).
+//!           NO  → global codec with a feature-flag or a RawEvent fallback.
+//! ```
+//!
+//! ## PassThrough shortcut
+//!
+//! When a vendor sets `declared_request_mutations() → false` **and**
+//! `declared_response_mutations() → false`, and the route resolves to
+//! [`ProtocolMode::Native`][crate::proxy::planner::ProtocolMode::Native]
+//! (same ingress / egress protocol), the dispatcher skips the entire
+//! encode → IR → decode round-trip and forwards bytes verbatim.  This is the
+//! correct default for providers whose wire format matches the spec exactly —
+//! it avoids any risk of silent data loss from unrecognised fields.
 
 use async_trait::async_trait;
 use reqwest::header::HeaderMap;

--- a/crates/nyro-core/src/proxy/dispatcher/accumulator.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/accumulator.rs
@@ -51,6 +51,7 @@ impl StreamResponseAccumulator {
             }
             StreamDelta::Usage(usage) => self.usage = usage.clone(),
             StreamDelta::Done { stop_reason } => self.stop_reason = Some(stop_reason.clone()),
+            StreamDelta::RawEvent { .. } => {}
         }
     }
 

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -28,6 +28,8 @@ use self::util::*;
 use std::convert::Infallible;
 use std::time::Instant;
 
+use bytes::Bytes;
+
 use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
@@ -515,6 +517,7 @@ pub async fn dispatch_pipeline(
                 &path_owned,
                 request_headers_str.clone(),
                 request_body_str.clone(),
+                passthrough_resp,
             )
             .await
         } else if upstream_forces_stream {
@@ -1012,6 +1015,7 @@ async fn handle_stream(
     ingress_path: &str,
     request_headers_str: Option<String>,
     request_body_str: Option<String>,
+    passthrough_resp: bool,
 ) -> Response {
     let make_extras_owned = {
         let method = ingress_method.to_string();
@@ -1063,6 +1067,114 @@ async fn handle_stream(
             .into_response();
     }
 
+    // ── Byte-level SSE passthrough ────────────────────────────────────────────
+    // Used when ingress == egress protocol and the vendor declares no response
+    // mutations (passthrough_resp=true). Upstream bytes are forwarded verbatim;
+    // a side-channel parser accumulates usage stats for logging only.
+    if passthrough_resp {
+        let (pt_tx, pt_rx) = tokio::sync::mpsc::channel::<Result<Bytes, Infallible>>(64);
+
+        let gw_pt = gw.clone();
+        let provider_name_pt = provider.name.clone();
+        let ingress_s_pt = ingress_str.to_string();
+        let egress_s_pt = egress_str.to_string();
+        let req_model_pt = request_model.to_string();
+        let act_model_pt = actual_model.to_string();
+        let key_id_pt = api_key_id.map(ToString::to_string);
+        let leader_key_pt = singleflight_key.map(ToString::to_string);
+        let leader_tx_pt = singleflight_tx.clone();
+        let ingress_method_pt = ingress_method.to_string();
+        let ingress_path_pt = ingress_path.to_string();
+        let request_headers_pt = request_headers_str.clone();
+        let request_body_pt = request_body_str.clone();
+
+        tokio::spawn(async move {
+            let mut log_buf: Vec<u8> = Vec::new();
+            let mut byte_stream = resp.bytes_stream();
+            let mut stream_error: Option<String> = None;
+
+            while let Some(result) = byte_stream.next().await {
+                match result {
+                    Ok(b) => {
+                        log_buf.extend_from_slice(&b);
+                        if pt_tx.send(Ok(b)).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "upstream stream error during passthrough");
+                        stream_error = Some(e.to_string());
+                        // Emit an Anthropic-protocol error event so the client
+                        // gets an explicit signal instead of a truncated stream.
+                        let msg = e.to_string().replace('"', "\\\"");
+                        let err_sse = format!(
+                            "event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"stream_error\",\"message\":\"{msg}\"}}}}\n\n"
+                        );
+                        let _ = pt_tx.send(Ok(Bytes::from(err_sse))).await;
+                        break;
+                    }
+                }
+            }
+
+            // Parse accumulated buffer for usage stats and log entry (best-effort).
+            let log_text = String::from_utf8_lossy(&log_buf);
+            let mut log_parser = egress.handler().make_stream_parser();
+            let mut accumulator = StreamResponseAccumulator::default();
+            if let Ok(deltas) = log_parser.parse_chunk(&log_text) {
+                accumulator.apply_all(&deltas);
+            }
+            if let Ok(deltas) = log_parser.finish() {
+                accumulator.apply_all(&deltas);
+            }
+
+            let mut internal = accumulator.into_internal_response();
+            if internal.id.is_empty() {
+                internal.id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+            }
+            if internal.model.is_empty() {
+                internal.model = act_model_pt.clone();
+            }
+
+            let aggregated_formatter = ingress.handler().make_response_formatter();
+            let aggregated_output = aggregated_formatter.format_response(&internal);
+            let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
+
+            emit_log(
+                &gw_pt, &ingress_s_pt, &egress_s_pt, &req_model_pt, &act_model_pt,
+                key_id_pt.as_deref(), &provider_name_pt, 200,
+                start.elapsed().as_millis() as f64,
+                internal.usage.clone(), true, !internal.tool_calls.is_empty(),
+                stream_error, None,
+                LogExtras {
+                    method: Some(ingress_method_pt.clone()),
+                    path: Some(ingress_path_pt.clone()),
+                    request_headers: request_headers_pt.clone(),
+                    request_body: request_body_pt.clone(),
+                    response_headers: None,
+                    response_body: aggregated_body_str,
+                },
+            );
+
+            if let (Some(key), Some(tx)) = (leader_key_pt.as_deref(), leader_tx_pt.as_ref()) {
+                let _ = tx.send(vec![]);
+                gw_pt.cache_in_flight.remove(key);
+            }
+        });
+
+        let stream = ReceiverStream::new(pt_rx);
+        let body = Body::from_stream(stream);
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .header(header::CONNECTION, "keep-alive")
+            .body(body)
+            .unwrap();
+        set_cache_headers(&mut response, "MISS", cache_key, None, expose_headers);
+        return response;
+    }
+
+    // ── IR round-trip path ────────────────────────────────────────────────────
     let mut stream_parser = egress.handler().make_stream_parser();
     let mut stream_formatter = ingress.handler().make_stream_formatter();
     let mut byte_stream = resp.bytes_stream();
@@ -1090,7 +1202,17 @@ async fn handle_stream(
         while let Some(chunk) = byte_stream.next().await {
             let bytes = match chunk {
                 Ok(b) => b,
-                Err(_) => break,
+                Err(e) => {
+                    // P1: emit an explicit terminal event instead of silently breaking,
+                    // so the client receives a defined stop_reason and does not hang.
+                    tracing::warn!(error = %e, "upstream stream error; emitting terminal event");
+                    let error_deltas = [StreamDelta::Done { stop_reason: "error".to_string() }];
+                    let events = stream_formatter.format_deltas(&error_deltas);
+                    for ev in events {
+                        let _ = tx.send(Ok(ev.to_sse_string())).await;
+                    }
+                    break;
+                }
             };
             let text = String::from_utf8_lossy(&bytes);
             if let Ok(deltas) = stream_parser.parse_chunk(&text) {


### PR DESCRIPTION
- P0: add byte-level passthrough branch in handle_stream when ProtocolMode is Native and no response mutations are declared; avoids IR round-trip that could silently drop unknown SSE fields
- P1: translate upstream byte_stream errors into explicit SSE `event: error` so clients (e.g. Claude Code) do not stall silently
- P2: add StreamDelta::RawEvent variant; AnthropicStreamParser now emits RawEvent for unrecognised content_block_start types (server_tool_use), unknown content_block_delta types (citations_delta, web_search_tool_result_delta) and unknown top-level events; AnthropicStreamFormatter forwards them verbatim; other formatters (OpenAI, Google) no-op to keep their wire format clean; StreamResponseAccumulator ignores RawEvent Fixes silent truncation of GLM web-search streams when proxied through Nyro with an Anthropic-to-Anthropic (Native) route.