### PR TITLE
fix(core): preserve thinking metadata across protocol conversion

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic/encoder.rs
@@ -348,20 +348,44 @@ fn encode_message(msg: &InternalMessage) -> Result<Value> {
 
     let content = match &msg.content {
         MessageContent::Text(t) => {
-            if let Some(ref tcs) = msg.tool_calls {
+            let reasoning = msg
+                .extra
+                .get("reasoning_content")
+                .and_then(|v| v.as_str())
+                .filter(|v| !v.trim().is_empty());
+            let reasoning_signature = msg
+                .extra
+                .get("reasoning_signature")
+                .and_then(|v| v.as_str())
+                .filter(|v| !v.trim().is_empty());
+
+            if reasoning.is_some() || msg.tool_calls.is_some() {
                 let mut blocks: Vec<Value> = vec![];
+                if let Some(text) = reasoning {
+                    let mut block = serde_json::json!({
+                        "type": "thinking",
+                        "thinking": text,
+                    });
+                    if let Some(signature) = reasoning_signature
+                        && let Some(obj) = block.as_object_mut() {
+                            obj.insert("signature".into(), serde_json::json!(signature));
+                        }
+                    blocks.push(block);
+                }
                 if !t.is_empty() {
                     blocks.push(serde_json::json!({"type": "text", "text": t}));
                 }
-                for tc in tcs {
-                    let input: Value = serde_json::from_str(&tc.arguments)
-                        .unwrap_or(Value::Object(Default::default()));
-                    blocks.push(serde_json::json!({
-                        "type": "tool_use",
-                        "id": normalize_anthropic_tool_id(&tc.id),
-                        "name": tc.name,
-                        "input": input,
-                    }));
+                if let Some(ref tcs) = msg.tool_calls {
+                    for tc in tcs {
+                        let input: Value = serde_json::from_str(&tc.arguments)
+                            .unwrap_or(Value::Object(Default::default()));
+                        blocks.push(serde_json::json!({
+                            "type": "tool_use",
+                            "id": normalize_anthropic_tool_id(&tc.id),
+                            "name": tc.name,
+                            "input": input,
+                        }));
+                    }
                 }
                 Value::Array(blocks)
             } else {
@@ -496,6 +520,42 @@ fn normalize_anthropic_messages(messages: Vec<Value>) -> Vec<Value> {
             "content": Value::Array(blocks),
         }));
     }
+
+    // DeepSeek's Anthropic-compatible endpoint requires assistant tool_use
+    // blocks to trail the assistant turn when the next user turn contains
+    // matching tool_result blocks. Codex Responses input may place assistant
+    // commentary after function_call items, which otherwise normalizes into
+    // `[tool_use, tool_use, text]`.
+    for msg in &mut normalized {
+        if msg.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(arr) = msg.get_mut("content").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        if !arr.iter().any(|b| {
+            b.get("type").and_then(|v| v.as_str()) == Some("tool_use")
+        }) {
+            continue;
+        }
+        let mut thinking: Vec<Value> = Vec::new();
+        let mut others: Vec<Value> = Vec::new();
+        let mut tool_uses: Vec<Value> = Vec::new();
+        for b in arr.drain(..) {
+            match b.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+                "thinking" => thinking.push(b),
+                "tool_use" => tool_uses.push(b),
+                _ => others.push(b),
+            }
+        }
+        let mut reordered = thinking;
+        reordered.extend(others);
+        reordered.extend(tool_uses);
+        if let Some(obj) = msg.as_object_mut() {
+            obj.insert("content".into(), Value::Array(reordered));
+        }
+    }
+
     normalized
 }
 

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -45,12 +45,17 @@ impl From<InternalRequest> for AiRequest {
 }
 
 fn msg_from_old(old: InternalMessage) -> Message {
+    let meta = if old.extra.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(old.extra.into_iter().collect()))
+    };
     Message {
         role: role_from_old(old.role),
         content: content_from_old(old.content),
         tool_calls: old.tool_calls.map(|tcs| tcs.into_iter().map(tc_from_old).collect()),
         tool_call_id: old.tool_call_id,
-        meta: None,
+        meta,
     }
 }
 
@@ -125,12 +130,16 @@ impl From<AiRequest> for InternalRequest {
 }
 
 fn msg_to_old(msg: Message) -> InternalMessage {
+    let extra = match msg.meta {
+        Some(serde_json::Value::Object(obj)) => obj.into_iter().collect(),
+        _ => Default::default(),
+    };
     InternalMessage {
         role: role_to_old(msg.role),
         content: content_to_old(msg.content),
         tool_calls: msg.tool_calls.map(|tcs| tcs.into_iter().map(tc_to_old).collect()),
         tool_call_id: msg.tool_call_id,
-        extra: Default::default(),
+        extra,
     }
 }
 

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -13,6 +13,7 @@ use nyro_core::protocol::codec::openai::responses::parser::{
 };
 use nyro_core::protocol::codec::reasoning::normalize_response_reasoning;
 use nyro_core::protocol::codec::tool_correlation::normalize_request_tool_results;
+use nyro_core::protocol::ir::AiRequest;
 use nyro_core::protocol::types::{
     ContentBlock, InternalMessage, InternalRequest, InternalResponse, MessageContent, ResponseItem, Role,
     StreamDelta,
@@ -52,6 +53,95 @@ fn openai_to_anthropic_thinking_blocks() {
         content[0].get("thinking").and_then(|v| v.as_str()),
         Some("reasoning summary")
     );
+}
+
+#[test]
+fn ir_compat_preserves_per_message_reasoning_extra() {
+    let mut extra = std::collections::HashMap::new();
+    extra.insert(
+        "reasoning_content".to_string(),
+        serde_json::Value::String("preserved reasoning".to_string()),
+    );
+
+    let req = InternalRequest {
+        messages: vec![InternalMessage {
+            role: Role::Assistant,
+            content: MessageContent::Text(String::new()),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "exec_command".to_string(),
+                arguments: "{\"cmd\":\"echo hello\"}".to_string(),
+            }]),
+            tool_call_id: None,
+            extra,
+        }],
+        model: "deepseek-v4-flash".to_string(),
+        stream: false,
+        temperature: None,
+        max_tokens: None,
+        top_p: None,
+        tools: None,
+        tool_choice: None,
+        source_protocol: OPENAI_RESPONSES_V1,
+        extra: Default::default(),
+    };
+
+    let ai: AiRequest = req.into();
+    let back: InternalRequest = ai.into();
+
+    assert_eq!(
+        back.messages[0]
+            .extra
+            .get("reasoning_content")
+            .and_then(|v| v.as_str()),
+        Some("preserved reasoning")
+    );
+}
+
+#[test]
+fn anthropic_encoder_replays_reasoning_extra_as_thinking_block() {
+    let mut extra = std::collections::HashMap::new();
+    extra.insert(
+        "reasoning_content".to_string(),
+        serde_json::Value::String("I should run a shell command.".to_string()),
+    );
+
+    let req = InternalRequest {
+        messages: vec![InternalMessage {
+            role: Role::Assistant,
+            content: MessageContent::Text("".to_string()),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "exec_command".to_string(),
+                arguments: "{\"cmd\":\"echo hello\"}".to_string(),
+            }]),
+            tool_call_id: None,
+            extra,
+        }],
+        model: "deepseek-v4-flash".to_string(),
+        stream: false,
+        temperature: None,
+        max_tokens: None,
+        top_p: None,
+        tools: None,
+        tool_choice: None,
+        source_protocol: OPENAI_RESPONSES_V1,
+        extra: Default::default(),
+    };
+
+    let (body, _) = AnthropicEncoder
+        .encode_request(&req)
+        .expect("encode anthropic body");
+    let blocks = body["messages"][0]["content"]
+        .as_array()
+        .expect("assistant content blocks");
+
+    assert_eq!(blocks[0]["type"].as_str(), Some("thinking"));
+    assert_eq!(
+        blocks[0]["thinking"].as_str(),
+        Some("I should run a shell command.")
+    );
+    assert_eq!(blocks[1]["type"].as_str(), Some("tool_use"));
 }
 
 #[test]
@@ -1738,4 +1828,85 @@ fn responses_response_parser_extracts_text_tool_calls_and_usage() {
     assert_eq!(resp.tool_calls[0].id, "call_1");
     assert_eq!(resp.tool_calls[0].name, "search");
     assert_eq!(resp.tool_calls[0].arguments, "{\"q\":\"rust\"}");
+}
+
+#[test]
+fn codex_parallel_calls_with_intermediate_text_anthropic_egress() {
+    let body = serde_json::json!({
+        "model": "deepseek-v4-flash",
+        "input": [
+            {"type": "message", "role": "user",
+                "content": [{"type":"input_text","text":"do parallel work"}]},
+            {"type": "function_call", "call_id": "call_00_A",
+                "name": "exec_command", "arguments": "{\"cmd\":\"ls\"}"},
+            {"type": "function_call", "call_id": "call_00_B",
+                "name": "exec_command", "arguments": "{\"cmd\":\"pwd\"}"},
+            {"type": "message", "role": "assistant",
+                "content": [{"type":"output_text","text":"running both"}]},
+            {"type": "function_call_output", "call_id": "call_00_A",
+                "output": "{\"stdout\":\"a\"}"},
+            {"type": "function_call_output", "call_id": "call_00_B",
+                "output": "{\"stdout\":\"b\"}"},
+        ]
+    });
+    let internal = ResponsesDecoder.decode_request(body).expect("decode");
+    let mut req: InternalRequest = internal;
+    normalize_request_tool_results(&mut req);
+
+    let (encoded, _) = AnthropicEncoder
+        .encode_request(&req)
+        .expect("encode anthropic body");
+    let msgs = encoded
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .expect("messages array");
+
+    for (i, m) in msgs.iter().enumerate() {
+        if m.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        let blocks = m
+            .get("content")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let tool_use_ids: Vec<String> = blocks
+            .iter()
+            .filter(|b| b.get("type").and_then(|v| v.as_str()) == Some("tool_use"))
+            .filter_map(|b| b.get("id").and_then(|v| v.as_str()).map(String::from))
+            .collect();
+        if tool_use_ids.is_empty() {
+            continue;
+        }
+
+        assert_eq!(
+            blocks
+                .last()
+                .and_then(|b| b.get("type"))
+                .and_then(|v| v.as_str()),
+            Some("tool_use"),
+            "assistant message {i} must end with tool_use; got blocks={blocks:?}",
+        );
+
+        let next = msgs.get(i + 1).expect("must have next user msg");
+        assert_eq!(next.get("role").and_then(|v| v.as_str()), Some("user"));
+        let next_blocks = next
+            .get("content")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let result_ids: Vec<String> = next_blocks
+            .iter()
+            .filter(|b| b.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+            .filter_map(|b| {
+                b.get("tool_use_id").and_then(|v| v.as_str()).map(String::from)
+            })
+            .collect();
+        for id in &tool_use_ids {
+            assert!(
+                result_ids.contains(id),
+                "tool_use {id} has no matching tool_result in next user message; got {next_blocks:?}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #113.

This PR preserves reasoning/thinking metadata across Nyro's Responses-to-egress conversion path so DeepSeek thinking-mode models can continue multi-turn Codex tool workflows.

Changes:

- Preserve per-message `InternalMessage.extra` through the `InternalRequest -> AiRequest -> InternalRequest` compatibility conversion.
- Encode preserved `reasoning_content` / `reasoning_signature` as Anthropic `thinking` blocks during Anthropic egress.
- Normalize assistant Anthropic content so `tool_use` blocks trail the assistant turn when Codex Responses input places text after function calls.
- Add regression coverage for the DeepSeek thinking metadata path and Codex parallel tool-call Anthropic egress ordering.

## Validation

```bash
cargo test -p nyro-core --test protocol_conversion
cargo test -p nyro-core
```

Local live validation was also performed with Codex using `model_reasoning_effort = "high"` through Nyro against DeepSeek-compatible OpenAI and Anthropic endpoints.
