### PR TITLE
feat: add system tray support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod commands;
 use nyro_core::{config::GatewayConfig, logging, Gateway};
 use tauri::{
     menu::{Menu, MenuItem},
-    tray::TrayIconBuilder,
+    tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
     Manager,
 };
 
@@ -14,8 +14,15 @@ pub fn run() {
         .init();
 
     tauri::Builder::default()
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
+            }
+        })
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             if let Some(w) = app.get_webview_window("main") {
+                let _ = w.show();
                 let _ = w.set_focus();
             }
         }))
@@ -54,7 +61,8 @@ pub fn run() {
 
             app.manage(gateway);
 
-            setup_tray(app, proxy_port)?;
+            let tray = setup_tray(app, proxy_port)?;
+            app.manage(tray);
 
             Ok(())
         })
@@ -112,7 +120,7 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-fn setup_tray(app: &tauri::App, proxy_port: u16) -> Result<(), Box<dyn std::error::Error>> {
+fn setup_tray(app: &tauri::App, proxy_port: u16) -> Result<TrayIcon, Box<dyn std::error::Error>> {
     let show = MenuItem::with_id(app, "show", "Show Dashboard", true, None::<&str>)?;
     let copy_url = MenuItem::with_id(
         app,
@@ -124,9 +132,24 @@ fn setup_tray(app: &tauri::App, proxy_port: u16) -> Result<(), Box<dyn std::erro
     let quit = MenuItem::with_id(app, "quit", "Quit Nyro", true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&show, &copy_url, &quit])?;
 
-    let _tray = TrayIconBuilder::new()
+    let tray = TrayIconBuilder::new()
+        .icon(app.default_window_icon().unwrap().clone())
         .tooltip(&format!("Nyro AI Gateway — :{proxy_port}"))
         .menu(&menu)
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                let app = tray.app_handle();
+                if let Some(w) = app.get_webview_window("main") {
+                    let _ = w.show();
+                    let _ = w.set_focus();
+                }
+            }
+        })
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "show" => {
                 if let Some(w) = app.get_webview_window("main") {
@@ -148,5 +171,5 @@ fn setup_tray(app: &tauri::App, proxy_port: u16) -> Result<(), Box<dyn std::erro
         })
         .build(app)?;
 
-    Ok(())
+    Ok(tray)
 }


### PR DESCRIPTION
- Prevent app exit on window close; hide to tray instead
- Fix TrayIcon drop bug by managing lifetime via app.manage()
- Add left-click tray icon handler to restore window