### PR TITLE
feat(ci): add musl static build support for Linux

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -16,9 +16,17 @@ jobs:
           - os: ubuntu-latest
             artifact_name: nyro-server-linux-x86_64
             binary_name: nyro-server
+          - os: ubuntu-latest
+            artifact_name: nyro-server-linux-x86_64-musl
+            binary_name: nyro-server
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
             artifact_name: nyro-server-linux-aarch64
             binary_name: nyro-server
+          - os: ubuntu-24.04-arm
+            artifact_name: nyro-server-linux-aarch64-musl
+            binary_name: nyro-server
+            target: aarch64-unknown-linux-musl
           - os: macos-15-intel
             artifact_name: nyro-server-macos-x86_64
             binary_name: nyro-server
@@ -39,6 +47,14 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Add musl target
+        if: matrix.target != ''
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install musl-tools
+        if: matrix.target != '' && runner.os == 'Linux'
+        run: sudo apt-get install -y musl-tools
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -56,13 +72,14 @@ jobs:
         run: pnpm -C webui build
 
       - name: Build nyro-server
-        run: cargo build -p nyro-server --release
+        run: cargo build -p nyro-server --release ${{ matrix.target != '' && format('--target {0}', matrix.target) || '' }}
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'
         run: |
           mkdir -p dist
-          cp "target/release/${{ matrix.binary_name }}" "dist/${{ matrix.artifact_name }}"
+          BIN_PATH=${{ matrix.target != '' && format('target/{0}/release/{1}', matrix.target, matrix.binary_name) || format('target/release/{0}', matrix.binary_name) }}
+          cp "$BIN_PATH" "dist/${{ matrix.artifact_name }}"
 
       - name: Package binary (Windows)
         if: runner.os == 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4219,7 +4219,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4991,6 +4991,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -5000,6 +5001,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6571,6 +6573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["macros"] }
 reqwest = { version = "0.12", features = ["stream", "json", "rustls-tls"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "tls-rustls"] }
 sqlite-vec = "0.1.9"
 libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 zerocopy = { version = "0.7", features = ["derive"] }

--- a/crates/nyro-core/src/crypto/mod.rs
+++ b/crates/nyro-core/src/crypto/mod.rs
@@ -13,6 +13,20 @@ fn get_or_create_master_key() -> anyhow::Result<[u8; 32]> {
         return Ok(*key);
     }
 
+    #[cfg(not(target_env = "musl"))]
+    let key = get_key_from_keyring()?;
+
+    #[cfg(target_env = "musl")]
+    let key = get_key_from_env_or_file()?;
+
+    let _ = MASTER_KEY_CACHE.set(key);
+    Ok(key)
+}
+
+/// 通过系统 keyring（Secret Service / Keychain / Credential Manager）存取主密钥。
+/// 仅在非 musl 构建下编译，因为 Linux Secret Service 依赖 dbus 动态库，无法静态链接。
+#[cfg(not(target_env = "musl"))]
+fn get_key_from_keyring() -> anyhow::Result<[u8; 32]> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)?;
 
     let key = match entry.get_password() {
@@ -36,8 +50,78 @@ fn get_or_create_master_key() -> anyhow::Result<[u8; 32]> {
         }
     };
 
-    let _ = MASTER_KEY_CACHE.set(key);
     Ok(key)
+}
+
+/// musl 静态构建下的主密钥获取策略（不依赖任何系统动态库）：
+///
+/// 1. 环境变量 `NYRO_MASTER_KEY`（base64, >= 32 bytes）—— 推荐用于容器/K8s
+/// 2. 文件 `~/.local/share/nyro/master.key`（首次运行自动生成）—— 适合裸机部署
+/// 3. 进程内随机 key（降级兜底，重启后密文不可用，启动时打印警告）
+#[cfg(target_env = "musl")]
+fn get_key_from_env_or_file() -> anyhow::Result<[u8; 32]> {
+    if let Ok(val) = std::env::var("NYRO_MASTER_KEY") {
+        let bytes = base64::engine::general_purpose::STANDARD.decode(val.trim())?;
+        if bytes.len() < 32 {
+            anyhow::bail!("NYRO_MASTER_KEY must decode to at least 32 bytes");
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes[..32]);
+        return Ok(key);
+    }
+
+    if let Some(key) = try_load_or_create_key_file() {
+        return Ok(key);
+    }
+
+    tracing::warn!(
+        "No persistent master key found (set NYRO_MASTER_KEY or ensure ~/.local/share/nyro is writable). \
+         Using a per-process random key — encrypted values will not survive restarts."
+    );
+    let raw = Aes256Gcm::generate_key(OsRng);
+    let mut key = [0u8; 32];
+    key.copy_from_slice(raw.as_slice());
+    Ok(key)
+}
+
+#[cfg(target_env = "musl")]
+fn try_load_or_create_key_file() -> Option<[u8; 32]> {
+    use std::io::{Read, Write};
+
+    let dir = dirs::data_local_dir()?.join("nyro");
+    let path = dir.join("master.key");
+
+    if path.exists() {
+        let mut f = std::fs::File::open(&path).ok()?;
+        let mut buf = String::new();
+        f.read_to_string(&mut buf).ok()?;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(buf.trim())
+            .ok()?;
+        if bytes.len() < 32 {
+            return None;
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes[..32]);
+        return Some(key);
+    }
+
+    std::fs::create_dir_all(&dir).ok()?;
+    let raw = Aes256Gcm::generate_key(OsRng);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(raw.as_slice());
+    let mut f = std::fs::File::create(&path).ok()?;
+    f.write_all(b64.as_bytes()).ok()?;
+
+    // 权限设为 0600，仅所有者可读
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(raw.as_slice());
+    Some(key)
 }
 
 pub fn encrypt(plaintext: &str) -> String {


### PR DESCRIPTION
- Add tls-rustls feature to sqlx to eliminate OpenSSL dependency
- Add cfg(target_env=musl) branch in crypto/mod.rs with env var / file fallback for master key (avoids dbus/libsecret static link issue)
- Add x86_64-unknown-linux-musl and aarch64-unknown-linux-musl matrix entries in release-server.yml using musl-tools

FIX #110 