### PR TITLE
chore: release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Nyro will be documented in this file.
 
 ---
 
+## v1.7.2
+
+> Released on 2026-05-12
+
+#### Fixes
+
+- **musl static build: eliminate OpenSSL dependency** (#125): move `keyring = "3"` from unconditional `[dependencies]` to `[target.'cfg(not(target_env = "musl"))'.dependencies]` so that the entire keyring/dbus/openssl-sys transitive dependency chain is excluded when compiling for `*-unknown-linux-musl` targets; the `#[cfg(target_env = "musl")]` code path in `crypto/mod.rs` was already in place — this completes the fix at the Cargo level
+
+---
+
 ## v1.7.1
 
 > Released on 2026-05-12

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -4,6 +4,16 @@ Nyro 的所有重要变更均记录在此文件中。
 
 ---
 
+## v1.7.2
+
+> 发布于 2026-05-12
+
+#### 修复
+
+- **musl 静态构建：消除 OpenSSL 依赖** (#125)：将 `keyring = "3"` 从无条件的 `[dependencies]` 移至 `[target.'cfg(not(target_env = "musl"))'.dependencies]`，使 `keyring` → `dbus` → `openssl-sys` 整条传递依赖链在编译 `*-unknown-linux-musl` target 时完全不参与构建；`crypto/mod.rs` 中的 `#[cfg(target_env = "musl")]` 代码路径已在 v1.7.1 就位，本次补全 Cargo 层面的对称修复
+
+---
+
 ## v1.7.1
 
 > 发布于 2026-05-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "nyro-core"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "nyro-desktop"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "nyro-core",
  "serde",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "nyro-server"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "nyro-tools"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/nyro-core", "crates/nyro-tools", "src-tauri", "src-server"]
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/nyroway/nyro"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/nicegui/static/tauri/tauri.conf.json",
   "productName": "Nyro",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "identifier": "com.nyro.ai-gateway",
   "build": {
     "frontendDist": "../webui/dist",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nyro-console",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
- fix(musl): move keyring to cfg(not(target_env=musl)) deps to eliminate openssl-sys transitive dependency on musl targets