### PR TITLE
refactor(ingress): restructure proxy/ingress into protocol subdirs

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -17,7 +17,7 @@ use crate::auth::types::{
 };
 use crate::db::models::*;
 use crate::protocol::ProviderProtocols;
-use crate::protocol::ids::OPENAI_CHAT_V1;
+use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
 use crate::provider::{VendorCtx, VendorRegistry};
 use crate::proxy::client::ProxyClient;
@@ -2593,10 +2593,10 @@ fn provider_supports_openai_endpoint(provider: &Provider) -> bool {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(OPENAI_CHAT_V1) {
+    if !protocols.supports(OPENAI_CHAT_COMPLETIONS_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(OPENAI_CHAT_V1);
+    let resolved = protocols.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         return None;

--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/messages.rs
@@ -16,7 +16,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
     embeddings: false,
     force_upstream_stream: false,
     override_model_in_body: false,
-    ingress_routes: &[("POST", "/v1/messages"), ("POST", "/messages")],
+    ingress_routes: &[("POST", "/v1/messages")],
     extended_reasoning: true,
     ..EndpointCapabilities::CHAT_STANDARD
 };

--- a/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
-use crate::protocol::ids::GOOGLE_GENERATE_V1BETA;
+use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
 use crate::protocol::types::*;
 
 use super::types::*;
@@ -164,7 +164,7 @@ impl GoogleDecoder {
             top_p,
             tools,
             tool_choice: None,
-            source_protocol: GOOGLE_GENERATE_V1BETA,
+            source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
             extra,
         })
     }

--- a/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
@@ -20,10 +20,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
     embeddings: false,
     force_upstream_stream: false,
     override_model_in_body: true,
-    ingress_routes: &[
-        ("POST", "/v1beta/models/:model_action"),
-        ("POST", "/models/:model_action"),
-    ],
+    ingress_routes: &[("POST", "/v1beta/models/:model_action")],
     ..EndpointCapabilities::CHAT_STANDARD
 };
 

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
@@ -16,10 +16,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
     embeddings: false,
     force_upstream_stream: false,
     override_model_in_body: false,
-    ingress_routes: &[
-        ("POST", "/v1/chat/completions"),
-        ("POST", "/chat/completions"),
-    ],
+    ingress_routes: &[("POST", "/v1/chat/completions")],
     ..EndpointCapabilities::CHAT_STANDARD
 };
 

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
-use crate::protocol::ids::OPENAI_CHAT_V1;
+use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use crate::protocol::types::*;
 
 use super::types::*;
@@ -145,7 +145,7 @@ impl IngressDecoder for OpenAIDecoder {
             top_p: req.top_p,
             tools,
             tool_choice: req.tool_choice,
-            source_protocol: OPENAI_CHAT_V1,
+            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
             extra,
         })
     }

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
@@ -52,7 +52,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
     embeddings: true,
     force_upstream_stream: false,
     override_model_in_body: false,
-    ingress_routes: &[("POST", "/v1/embeddings"), ("POST", "/embeddings")],
+    ingress_routes: &[("POST", "/v1/embeddings")],
     multimodal: false,
     structured_output: false,
     function_calling: false,

--- a/crates/nyro-core/src/protocol/codec/openai_responses/responses.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/responses.rs
@@ -16,7 +16,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
     embeddings: false,
     force_upstream_stream: true,
     override_model_in_body: false,
-    ingress_routes: &[("POST", "/v1/responses"), ("POST", "/responses")],
+    ingress_routes: &[("POST", "/v1/responses")],
     ..EndpointCapabilities::CHAT_STANDARD
 };
 

--- a/crates/nyro-core/src/protocol/codec/tool_correlation.rs
+++ b/crates/nyro-core/src/protocol/codec/tool_correlation.rs
@@ -129,7 +129,7 @@ fn extract_tool_result_hint(content: &MessageContent) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_V1;
+    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
     use crate::protocol::types::MessageContent;
 
     fn make_req(messages: Vec<InternalMessage>) -> InternalRequest {
@@ -142,7 +142,7 @@ mod tests {
             top_p: None,
             tools: None,
             tool_choice: None,
-            source_protocol: OPENAI_CHAT_V1,
+            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
             extra: Default::default(),
         }
     }

--- a/crates/nyro-core/src/protocol/ids.rs
+++ b/crates/nyro-core/src/protocol/ids.rs
@@ -117,7 +117,7 @@ impl fmt::Display for ProtocolEndpoint {
 pub const OPENAI_CHAT_COMPLETIONS_V1: ProtocolEndpoint =
     ProtocolEndpoint::new(Protocol::OpenAICompatible, "chat-completions", "v1");
 
-/// Backward-compat alias — prefer `OPENAI_CHAT_COMPLETIONS_V1`.
+#[deprecated(since = "0.1.0", note = "use `OPENAI_CHAT_COMPLETIONS_V1` instead")]
 pub const OPENAI_CHAT_V1: ProtocolEndpoint = OPENAI_CHAT_COMPLETIONS_V1;
 
 pub const OPENAI_EMBEDDINGS_V1: ProtocolEndpoint =
@@ -132,7 +132,7 @@ pub const ANTHROPIC_MESSAGES_2023_06_01: ProtocolEndpoint =
 pub const GOOGLE_GENERATE_CONTENT_V1BETA: ProtocolEndpoint =
     ProtocolEndpoint::new(Protocol::GoogleGenerativeAI, "generate-content", "v1beta");
 
-/// Backward-compat alias — prefer `GOOGLE_GENERATE_CONTENT_V1BETA`.
+#[deprecated(since = "0.1.0", note = "use `GOOGLE_GENERATE_CONTENT_V1BETA` instead")]
 pub const GOOGLE_GENERATE_V1BETA: ProtocolEndpoint = GOOGLE_GENERATE_CONTENT_V1BETA;
 
 // ── Backward-compat type alias ────────────────────────────────────────────────
@@ -316,6 +316,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn backward_compat_aliases() {
         assert_eq!(OPENAI_CHAT_V1, OPENAI_CHAT_COMPLETIONS_V1);
         assert_eq!(GOOGLE_GENERATE_V1BETA, GOOGLE_GENERATE_CONTENT_V1BETA);

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -134,7 +134,7 @@ impl From<AiRequest> for InternalRequest {
         let source_protocol = new
             .meta
             .source_protocol
-            .unwrap_or(crate::protocol::ids::OPENAI_CHAT_V1);
+            .unwrap_or(crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1);
         let mut extra = std::collections::HashMap::new();
         for (k, v) in new.meta.vendor.ingress {
             extra.insert(k, v);
@@ -308,7 +308,7 @@ impl From<AiResponse> for InternalResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_V1;
+    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 
     fn sample_old_request() -> InternalRequest {
         InternalRequest {
@@ -326,7 +326,7 @@ mod tests {
             top_p: None,
             tools: None,
             tool_choice: None,
-            source_protocol: OPENAI_CHAT_V1,
+            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
             extra: Default::default(),
         }
     }

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -591,9 +591,9 @@ mod tests {
             Some(ANTHROPIC_MESSAGES_2023_06_01)
         );
         assert_eq!(
-            reg.find_by_ingress_route("post", "/chat/completions")
+            reg.find_by_ingress_route("POST", "/v1/embeddings")
                 .map(|h| h.id()),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_EMBEDDINGS_V1)
         );
         assert!(
             reg.find_by_ingress_route("GET", "/v1/chat/completions")

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -230,7 +230,9 @@ mod tests {
     use crate::GatewayConfig;
     use crate::db::models::Provider;
     use crate::error::GatewayError;
-    use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1, ProtocolId};
+    use crate::protocol::ids::{
+        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1, ProtocolId,
+    };
     use crate::protocol::types::{
         InternalMessage, InternalRequest, InternalResponse, MessageContent, Role,
     };
@@ -272,7 +274,7 @@ mod tests {
             "fake-test"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_V1]
+            &[OPENAI_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -322,7 +324,7 @@ mod tests {
             "fake-bearer"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_V1]
+            &[OPENAI_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -387,7 +389,7 @@ mod tests {
             top_p: None,
             tools: None,
             tool_choice: None,
-            source_protocol: OPENAI_CHAT_V1,
+            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
             extra: HashMap::new(),
         }
     }
@@ -407,7 +409,7 @@ mod tests {
         let mut req = minimal_chat_request();
         let ctx = ProviderCtx {
             provider: &provider,
-            protocol: OPENAI_CHAT_V1,
+            protocol: OPENAI_CHAT_COMPLETIONS_V1,
             egress_base_url: "https://upstream.local",
             api_key: &provider.api_key,
             actual_model: "gpt-test",
@@ -432,7 +434,7 @@ mod tests {
         let mut req = minimal_chat_request();
         let ctx = ProviderCtx {
             provider: &provider,
-            protocol: OPENAI_CHAT_V1,
+            protocol: OPENAI_CHAT_COMPLETIONS_V1,
             egress_base_url: "https://upstream.local",
             api_key: &provider.api_key,
             actual_model: "gpt-test",

--- a/crates/nyro-core/src/provider/custom/mod.rs
+++ b/crates/nyro-core/src/provider/custom/mod.rs
@@ -64,8 +64,8 @@ impl Vendor for CustomVendor {
         "custom"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/deepseek/mod.rs
+++ b/crates/nyro-core/src/provider/deepseek/mod.rs
@@ -75,8 +75,8 @@ impl Vendor for DeepseekVendor {
         "deepseek"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/google/mod.rs
+++ b/crates/nyro-core/src/provider/google/mod.rs
@@ -73,8 +73,8 @@ impl Vendor for GoogleVendor {
         "google"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::GOOGLE_GENERATE_V1BETA;
-        &[GOOGLE_GENERATE_V1BETA]
+        use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
+        &[GOOGLE_GENERATE_CONTENT_V1BETA]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/minimax/mod.rs
+++ b/crates/nyro-core/src/provider/minimax/mod.rs
@@ -101,8 +101,8 @@ impl Vendor for MinimaxVendor {
         "minimax"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1]
+        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1};
+        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/moonshotai/mod.rs
+++ b/crates/nyro-core/src/provider/moonshotai/mod.rs
@@ -101,8 +101,8 @@ impl Vendor for MoonshotaiVendor {
         "moonshotai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/nvidia/mod.rs
+++ b/crates/nyro-core/src/provider/nvidia/mod.rs
@@ -69,8 +69,8 @@ impl Vendor for NvidiaVendor {
         "nvidia"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/ollama/mod.rs
+++ b/crates/nyro-core/src/provider/ollama/mod.rs
@@ -112,8 +112,8 @@ impl Vendor for OllamaVendor {
         "ollama"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     async fn build_request(
         &self,

--- a/crates/nyro-core/src/provider/openai/mod.rs
+++ b/crates/nyro-core/src/provider/openai/mod.rs
@@ -104,8 +104,14 @@ impl Vendor for OpenAiVendor {
         "openai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{OPENAI_CHAT_V1, OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1};
-        &[OPENAI_CHAT_V1, OPENAI_RESPONSES_V1, OPENAI_EMBEDDINGS_V1]
+        use crate::protocol::ids::{
+            OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+        };
+        &[
+            OPENAI_CHAT_COMPLETIONS_V1,
+            OPENAI_RESPONSES_V1,
+            OPENAI_EMBEDDINGS_V1,
+        ]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/openrouter/mod.rs
+++ b/crates/nyro-core/src/provider/openrouter/mod.rs
@@ -75,8 +75,8 @@ impl Vendor for OpenrouterVendor {
         "openrouter"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/xai/mod.rs
+++ b/crates/nyro-core/src/provider/xai/mod.rs
@@ -67,8 +67,8 @@ impl Vendor for XaiVendor {
         "xai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/zai/mod.rs
+++ b/crates/nyro-core/src/provider/zai/mod.rs
@@ -99,8 +99,8 @@ impl Vendor for ZaiVendor {
         "zai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_V1;
-        &[OPENAI_CHAT_V1]
+        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/zhipuai/mod.rs
+++ b/crates/nyro-core/src/provider/zhipuai/mod.rs
@@ -101,8 +101,8 @@ impl Vendor for ZhipuaiVendor {
         "zhipuai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1]
+        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1};
+        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/proxy/context.rs
+++ b/crates/nyro-core/src/proxy/context.rs
@@ -280,8 +280,8 @@ pub async fn inject_context(mut request: Request, next: Next) -> Response {
     // We don't know the ingress protocol at middleware time; it will be
     // overwritten by the ingress handler via `inject_context_with_protocol`.
     // Use a sentinel until then.
-    use crate::protocol::ids::OPENAI_CHAT_V1;
-    let ctx = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(300));
+    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+    let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(300));
     request.extensions_mut().insert(ctx);
     next.run(request).await
 }
@@ -297,19 +297,19 @@ pub fn stamp_ingress_protocol(ctx: &mut RequestContext, protocol: ProtocolId) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_V1;
+    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 
     #[test]
     fn request_id_is_unique() {
-        let a = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30));
-        let b = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30));
+        let a = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let b = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         assert_ne!(a.request_id, b.request_id);
         assert!(a.request_id.starts_with("req-"));
     }
 
     #[test]
     fn outcome_write_once() {
-        let ctx = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         ctx.set_outcome(RequestOutcome::Success);
         ctx.set_outcome(RequestOutcome::ClientCancelled); // second write ignored
         assert_eq!(ctx.get_outcome(), Some(&RequestOutcome::Success));
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn cancellation_token_shared() {
-        let ctx = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         let token = ctx.cancellation.clone();
         assert!(!token.is_cancelled());
         ctx.cancellation.cancel();
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn trace_sink_push_snapshot() {
-        let ctx = RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         ctx.trace("intake", "body parsed");
         ctx.trace("security", "api_key validated");
         let events = ctx.trace.snapshot();

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -49,7 +49,7 @@ use crate::cache::key::{build_cache_key, build_semantic_partition};
 use crate::db::models::{Provider, Route};
 use crate::error::{AuthFailure, GatewayError};
 use crate::protocol::ProviderProtocols;
-use crate::protocol::ids::{OPENAI_CHAT_V1, OPENAI_EMBEDDINGS_V1, ProtocolId};
+use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, ProtocolId};
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta, TokenUsage};
 use crate::provider::inbound::InboundResponse;
@@ -2295,10 +2295,10 @@ fn parse_embedding_vector(payload: &Value) -> Option<Vec<f32>> {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(OPENAI_CHAT_V1) {
+    if !protocols.supports(OPENAI_CHAT_COMPLETIONS_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(OPENAI_CHAT_V1);
+    let resolved = protocols.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         None

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
@@ -1,4 +1,4 @@
-//! Thin ingress shell: POST /v1/responses
+//! Thin ingress shell: POST /v1/messages
 
 use axum::Json;
 use axum::extract::State;
@@ -7,18 +7,18 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::OPENAI_RESPONSES_V1;
+use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
-pub async fn openai_responses(
+pub async fn handler(
     State(gw): State<Gateway>,
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = OPENAI_RESPONSES_V1;
+    ctx.ingress_protocol = ANTHROPIC_MESSAGES_2023_06_01;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -27,12 +27,19 @@ pub async fn openai_responses(
                 .map(|vs| (k.as_str().to_lowercase(), vs.to_string()))
         })
         .collect();
-    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/responses");
-    let decoder = OPENAI_RESPONSES_V1.handler().make_decoder();
+    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/messages");
+    let decoder = ANTHROPIC_MESSAGES_2023_06_01.handler().make_decoder();
     let internal = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
     let request: AiRequest = internal.into();
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1).await
+    dispatch_pipeline(
+        gw,
+        headers,
+        envelope,
+        request,
+        ANTHROPIC_MESSAGES_2023_06_01,
+    )
+    .await
 }

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/mod.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -8,19 +8,19 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::codec::google_generative::decoder::GoogleDecoder;
-use crate::protocol::ids::GOOGLE_GENERATE_V1BETA;
+use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
-pub async fn google_generate(
+pub async fn handler(
     State(gw): State<Gateway>,
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Path(model_action): Path<String>,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = GOOGLE_GENERATE_V1BETA;
+    ctx.ingress_protocol = GOOGLE_GENERATE_CONTENT_V1BETA;
     let (model, action) = match model_action.rsplit_once(':') {
         Some((m, a)) => (m.to_string(), a.to_string()),
         None => (model_action.clone(), "generateContent".to_string()),
@@ -41,5 +41,12 @@ pub async fn google_generate(
         Err(e) => return error_response(400, &format!("invalid Gemini request: {e}")),
     };
     let request: AiRequest = internal.into();
-    dispatch_pipeline(gw, headers, envelope, request, GOOGLE_GENERATE_V1BETA).await
+    dispatch_pipeline(
+        gw,
+        headers,
+        envelope,
+        request,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
+    )
+    .await
 }

--- a/crates/nyro-core/src/proxy/ingress/google_generative/mod.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/mod.rs
@@ -1,0 +1,1 @@
+pub mod generate_content;

--- a/crates/nyro-core/src/proxy/ingress/mod.rs
+++ b/crates/nyro-core/src/proxy/ingress/mod.rs
@@ -1,5 +1,4 @@
 pub mod anthropic_messages;
-pub mod google_generate;
-pub mod openai_chat;
-pub mod openai_embeddings;
+pub mod google_generative;
+pub mod openai_compatible;
 pub mod openai_responses;

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -1,4 +1,4 @@
-//! Thin ingress shell: POST /v1/embeddings
+//! Thin ingress shell: POST /v1/chat/completions
 
 use axum::Json;
 use axum::extract::State;
@@ -7,18 +7,18 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
+use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
-pub async fn openai_embeddings(
+pub async fn handler(
     State(gw): State<Gateway>,
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = OPENAI_EMBEDDINGS_V1;
+    ctx.ingress_protocol = OPENAI_CHAT_COMPLETIONS_V1;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -27,12 +27,17 @@ pub async fn openai_embeddings(
                 .map(|vs| (k.as_str().to_lowercase(), vs.to_string()))
         })
         .collect();
-    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
-    let decoder = OPENAI_EMBEDDINGS_V1.handler().make_decoder();
+    let envelope = RawEnvelope::new(
+        Some(body.clone()),
+        flat_headers,
+        "POST",
+        "/v1/chat/completions",
+    );
+    let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_decoder();
     let internal = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
     let request: AiRequest = internal.into();
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_EMBEDDINGS_V1).await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_CHAT_COMPLETIONS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -1,4 +1,4 @@
-//! Thin ingress shell: POST /v1/chat/completions
+//! Thin ingress shell: POST /v1/embeddings
 
 use axum::Json;
 use axum::extract::State;
@@ -7,18 +7,18 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::OPENAI_CHAT_V1;
+use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
-pub async fn openai_chat(
+pub async fn handler(
     State(gw): State<Gateway>,
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = OPENAI_CHAT_V1;
+    ctx.ingress_protocol = OPENAI_EMBEDDINGS_V1;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -27,17 +27,12 @@ pub async fn openai_chat(
                 .map(|vs| (k.as_str().to_lowercase(), vs.to_string()))
         })
         .collect();
-    let envelope = RawEnvelope::new(
-        Some(body.clone()),
-        flat_headers,
-        "POST",
-        "/v1/chat/completions",
-    );
-    let decoder = OPENAI_CHAT_V1.handler().make_decoder();
+    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
+    let decoder = OPENAI_EMBEDDINGS_V1.handler().make_decoder();
     let internal = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
     let request: AiRequest = internal.into();
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_CHAT_V1).await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_EMBEDDINGS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/mod.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/mod.rs
@@ -1,0 +1,2 @@
+pub mod chat_completions;
+pub mod embeddings;

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/mod.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/mod.rs
@@ -1,0 +1,1 @@
+pub mod responses;

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
@@ -1,4 +1,4 @@
-//! Thin ingress shell: POST /v1/messages
+//! Thin ingress shell: POST /v1/responses
 
 use axum::Json;
 use axum::extract::State;
@@ -7,18 +7,18 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
+use crate::protocol::ids::OPENAI_RESPONSES_V1;
 use crate::protocol::ir::{AiRequest, RawEnvelope};
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
-pub async fn anthropic_messages(
+pub async fn handler(
     State(gw): State<Gateway>,
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = ANTHROPIC_MESSAGES_2023_06_01;
+    ctx.ingress_protocol = OPENAI_RESPONSES_V1;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -27,19 +27,12 @@ pub async fn anthropic_messages(
                 .map(|vs| (k.as_str().to_lowercase(), vs.to_string()))
         })
         .collect();
-    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/messages");
-    let decoder = ANTHROPIC_MESSAGES_2023_06_01.handler().make_decoder();
+    let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/responses");
+    let decoder = OPENAI_RESPONSES_V1.handler().make_decoder();
     let internal = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
     let request: AiRequest = internal.into();
-    dispatch_pipeline(
-        gw,
-        headers,
-        envelope,
-        request,
-        ANTHROPIC_MESSAGES_2023_06_01,
-    )
-    .await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1).await
 }

--- a/crates/nyro-core/src/proxy/planner/negotiator.rs
+++ b/crates/nyro-core/src/proxy/planner/negotiator.rs
@@ -201,7 +201,7 @@ mod tests {
     use super::*;
     use crate::db::models::ProtocolEndpointEntry;
     use crate::protocol::ids::{
-        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1, OPENAI_RESPONSES_V1,
     };
     use std::time::Duration;
 
@@ -219,45 +219,48 @@ mod tests {
             })
             .collect();
         ProviderProtocols {
-            default: pairs.first().map(|(id, _)| *id).unwrap_or(OPENAI_CHAT_V1),
+            default: pairs
+                .first()
+                .map(|(id, _)| *id)
+                .unwrap_or(OPENAI_CHAT_COMPLETIONS_V1),
             endpoints,
         }
     }
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30))
+        RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
     }
 
     #[test]
     fn native_when_ingress_exact_match() {
-        let decl = make_decl(&[(OPENAI_CHAT_V1, "https://api.openai.com")]);
+        let decl = make_decl(&[(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com")]);
         let mut c = ctx();
-        let plan = negotiate(OPENAI_CHAT_V1, None, Some(&decl), &mut c).unwrap();
+        let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
-        assert_eq!(plan.egress, OPENAI_CHAT_V1);
+        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
         assert!(!plan.needs_conversion);
     }
 
     #[test]
     fn transform_when_same_family_fallback() {
         // Provider only declares chat; ingress is responses.
-        let decl = make_decl(&[(OPENAI_CHAT_V1, "https://api.openai.com")]);
+        let decl = make_decl(&[(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com")]);
         let mut c = ctx();
         let plan = negotiate(OPENAI_RESPONSES_V1, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Transform);
-        assert_eq!(plan.egress, OPENAI_CHAT_V1);
+        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
         assert!(plan.needs_conversion);
     }
 
     #[test]
     fn route_pref_wins_over_ingress_match() {
         let decl = make_decl(&[
-            (OPENAI_CHAT_V1, "https://api.openai.com"),
+            (OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com"),
             (ANTHROPIC_MESSAGES_2023_06_01, "https://api.anthropic.com"),
         ]);
         let mut c = ctx();
         let plan = negotiate(
-            OPENAI_CHAT_V1,
+            OPENAI_CHAT_COMPLETIONS_V1,
             Some(ANTHROPIC_MESSAGES_2023_06_01),
             Some(&decl),
             &mut c,
@@ -269,9 +272,9 @@ mod tests {
     #[test]
     fn no_decl_returns_native() {
         let mut c = ctx();
-        let plan = negotiate(OPENAI_CHAT_V1, None, None, &mut c).unwrap();
+        let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, None, &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
-        assert_eq!(plan.egress, OPENAI_CHAT_V1);
+        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
     }
 
     #[test]
@@ -279,14 +282,14 @@ mod tests {
         // The first same-protocol entry in Vec order is always chosen.
         let decl = make_decl(&[
             (OPENAI_RESPONSES_V1, "https://responses.openai.com"),
-            (OPENAI_CHAT_V1, "https://chat.openai.com"),
+            (OPENAI_CHAT_COMPLETIONS_V1, "https://chat.openai.com"),
         ]);
         let mut c = ctx();
         // Ingress is embeddings (OpenAICompatible — no exact match).
         use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
         let plan = negotiate(OPENAI_EMBEDDINGS_V1, None, Some(&decl), &mut c).unwrap();
         // OPENAI_RESPONSES_V1 is OpenAIResponses (different protocol) — Tier 2 skips it.
-        // OPENAI_CHAT_V1 is OpenAICompatible (same protocol as embeddings) — first match wins.
-        assert_eq!(plan.egress, OPENAI_CHAT_V1);
+        // OPENAI_CHAT_COMPLETIONS_V1 is OpenAICompatible (same protocol as embeddings) — first match wins.
+        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
     }
 }

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -14,43 +14,25 @@ pub fn create_router(gateway: Gateway) -> Router {
     let router = Router::new()
         .route(
             "/v1/chat/completions",
-            post(ingress::openai_chat::openai_chat),
+            post(ingress::openai_compatible::chat_completions::handler),
         )
-        .route("/chat/completions", post(ingress::openai_chat::openai_chat))
         .route(
             "/v1/responses",
-            post(ingress::openai_responses::openai_responses),
-        )
-        .route(
-            "/responses",
-            post(ingress::openai_responses::openai_responses),
+            post(ingress::openai_responses::responses::handler),
         )
         .route(
             "/v1/messages",
-            post(ingress::anthropic_messages::anthropic_messages),
-        )
-        .route(
-            "/messages",
-            post(ingress::anthropic_messages::anthropic_messages),
+            post(ingress::anthropic_messages::messages::handler),
         )
         .route(
             "/v1/embeddings",
-            post(ingress::openai_embeddings::openai_embeddings),
-        )
-        .route(
-            "/embeddings",
-            post(ingress::openai_embeddings::openai_embeddings),
+            post(ingress::openai_compatible::embeddings::handler),
         )
         .route(
             "/v1beta/models/:model_action",
-            post(ingress::google_generate::google_generate),
-        )
-        .route(
-            "/models/:model_action",
-            post(ingress::google_generate::google_generate),
+            post(ingress::google_generative::generate_content::handler),
         )
         .route("/v1/models", get(handler::models_list))
-        .route("/models", get(handler::models_list))
         .route("/health", get(health))
         .route("/", get(health));
 

--- a/crates/nyro-core/src/proxy/stream.rs
+++ b/crates/nyro-core/src/proxy/stream.rs
@@ -281,13 +281,13 @@ impl Drop for StreamBridge<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_V1;
+    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
     use crate::proxy::context::RequestContext;
     use std::sync::Arc;
     use std::time::Duration;
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_CHAT_V1, Duration::from_secs(30))
+        RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
     }
 
     // ── Fault 1: read interrupt ───────────────────────────────────────────────
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn fault_timeout_detected_in_push_chunk() {
-        let c = RequestContext::new(OPENAI_CHAT_V1, Duration::from_nanos(1));
+        let c = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_nanos(1));
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut b = StreamBridge::new(&c);
         b.on_connected();

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -26,8 +26,8 @@ use nyro_core::db::models::Provider;
 use nyro_core::error::GatewayError;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
-    ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::protocol::types::{InternalRequest, InternalResponse};
 use nyro_core::provider::inbound::InboundResponse;
@@ -56,7 +56,7 @@ async fn build_test_gateway() -> Gateway {
 fn all_four_decl() -> ProviderProtocols {
     let endpoints = vec![
         (
-            OPENAI_CHAT_V1,
+            OPENAI_CHAT_COMPLETIONS_V1,
             ProtocolEndpointEntry {
                 base_url: "https://chat.example.com".into(),
                 endpoints: None,
@@ -77,7 +77,7 @@ fn all_four_decl() -> ProviderProtocols {
             },
         ),
         (
-            GOOGLE_GENERATE_V1BETA,
+            GOOGLE_GENERATE_CONTENT_V1BETA,
             ProtocolEndpointEntry {
                 base_url: "https://generate.example.com".into(),
                 endpoints: None,
@@ -85,7 +85,7 @@ fn all_four_decl() -> ProviderProtocols {
         ),
     ];
     ProviderProtocols {
-        default: OPENAI_CHAT_V1,
+        default: OPENAI_CHAT_COMPLETIONS_V1,
         endpoints,
     }
 }
@@ -131,7 +131,7 @@ impl Vendor for BearerVendor {
         self.0
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        &[OPENAI_CHAT_V1]
+        &[OPENAI_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false
@@ -190,11 +190,11 @@ fn fake_provider(api_key: &str) -> Provider {
 
 #[test]
 fn diagonal_chat_chat_is_native() {
-    let decl = single_decl(OPENAI_CHAT_V1, "https://api.openai.com");
-    let mut ctx = req_ctx(OPENAI_CHAT_V1);
-    let plan = negotiate(OPENAI_CHAT_V1, None, Some(&decl), &mut ctx).unwrap();
+    let decl = single_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+    let mut ctx = req_ctx(OPENAI_CHAT_COMPLETIONS_V1);
+    let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut ctx).unwrap();
     assert_eq!(plan.mode, ProtocolMode::Native, "chat→chat must be Native");
-    assert_eq!(plan.egress, OPENAI_CHAT_V1);
+    assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
     assert!(!plan.needs_conversion);
 }
 
@@ -229,17 +229,17 @@ fn diagonal_messages_messages_is_native() {
 #[test]
 fn diagonal_generate_generate_is_native() {
     let decl = single_decl(
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
         "https://generativelanguage.googleapis.com",
     );
-    let mut ctx = req_ctx(GOOGLE_GENERATE_V1BETA);
-    let plan = negotiate(GOOGLE_GENERATE_V1BETA, None, Some(&decl), &mut ctx).unwrap();
+    let mut ctx = req_ctx(GOOGLE_GENERATE_CONTENT_V1BETA);
+    let plan = negotiate(GOOGLE_GENERATE_CONTENT_V1BETA, None, Some(&decl), &mut ctx).unwrap();
     assert_eq!(
         plan.mode,
         ProtocolMode::Native,
         "generate→generate must be Native"
     );
-    assert_eq!(plan.egress, GOOGLE_GENERATE_V1BETA);
+    assert_eq!(plan.egress, GOOGLE_GENERATE_CONTENT_V1BETA);
     assert!(!plan.needs_conversion);
 }
 
@@ -270,24 +270,24 @@ macro_rules! off_diagonal_test {
 
 off_diagonal_test!(
     chat_to_responses_is_transform,
-    ingress = OPENAI_CHAT_V1,
+    ingress = OPENAI_CHAT_COMPLETIONS_V1,
     egress = OPENAI_RESPONSES_V1
 );
 off_diagonal_test!(
     chat_to_messages_is_transform,
-    ingress = OPENAI_CHAT_V1,
+    ingress = OPENAI_CHAT_COMPLETIONS_V1,
     egress = ANTHROPIC_MESSAGES_2023_06_01
 );
 off_diagonal_test!(
     chat_to_generate_is_transform,
-    ingress = OPENAI_CHAT_V1,
-    egress = GOOGLE_GENERATE_V1BETA
+    ingress = OPENAI_CHAT_COMPLETIONS_V1,
+    egress = GOOGLE_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     responses_to_chat_is_transform,
     ingress = OPENAI_RESPONSES_V1,
-    egress = OPENAI_CHAT_V1
+    egress = OPENAI_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     responses_to_messages_is_transform,
@@ -297,13 +297,13 @@ off_diagonal_test!(
 off_diagonal_test!(
     responses_to_generate_is_transform,
     ingress = OPENAI_RESPONSES_V1,
-    egress = GOOGLE_GENERATE_V1BETA
+    egress = GOOGLE_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     messages_to_chat_is_transform,
     ingress = ANTHROPIC_MESSAGES_2023_06_01,
-    egress = OPENAI_CHAT_V1
+    egress = OPENAI_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     messages_to_responses_is_transform,
@@ -313,22 +313,22 @@ off_diagonal_test!(
 off_diagonal_test!(
     messages_to_generate_is_transform,
     ingress = ANTHROPIC_MESSAGES_2023_06_01,
-    egress = GOOGLE_GENERATE_V1BETA
+    egress = GOOGLE_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     generate_to_chat_is_transform,
-    ingress = GOOGLE_GENERATE_V1BETA,
-    egress = OPENAI_CHAT_V1
+    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
+    egress = OPENAI_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     generate_to_responses_is_transform,
-    ingress = GOOGLE_GENERATE_V1BETA,
+    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
     egress = OPENAI_RESPONSES_V1
 );
 off_diagonal_test!(
     generate_to_messages_is_transform,
-    ingress = GOOGLE_GENERATE_V1BETA,
+    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
     egress = ANTHROPIC_MESSAGES_2023_06_01
 );
 
@@ -351,7 +351,7 @@ async fn passthrough_run_preserves_vendor_specific_fields() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_V1,
+        protocol: OPENAI_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "gpt-4o",
@@ -404,7 +404,7 @@ async fn passthrough_run_rewrites_model_to_actual_model() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_V1,
+        protocol: OPENAI_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "glm-4-flash",
@@ -432,7 +432,7 @@ async fn passthrough_run_sets_stream_path_for_streaming_body() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_V1,
+        protocol: OPENAI_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "gpt-4o",
@@ -469,7 +469,7 @@ fn vendor_declared_mutations_defaults_are_conservative() {
             "default"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_V1]
+            &[OPENAI_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -510,10 +510,10 @@ fn all_four_provider_each_ingress_selects_own_native() {
     let decl = all_four_decl();
 
     for proto in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let mut ctx = req_ctx(proto);
         let plan = negotiate(proto, None, Some(&decl), &mut ctx).unwrap();

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -14,7 +14,8 @@ use nyro_core::protocol::codec::openai_responses::parser::{
 use nyro_core::protocol::codec::reasoning::normalize_response_reasoning;
 use nyro_core::protocol::codec::tool_correlation::normalize_request_tool_results;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::ir::AiRequest;
 use nyro_core::protocol::types::{
@@ -300,7 +301,7 @@ fn gemini_tool_result_correlation_success() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: GOOGLE_GENERATE_V1BETA,
+        source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
         extra: Default::default(),
     };
 
@@ -362,7 +363,7 @@ fn gemini_tool_result_id_hint_matches_out_of_order_calls() {
         top_p: None,
         tools: None,
         tool_choice: None,
-        source_protocol: GOOGLE_GENERATE_V1BETA,
+        source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
         extra: Default::default(),
     };
 
@@ -1013,7 +1014,7 @@ fn anthropic_encoder_normalizes_tool_use_ids_for_tool_and_result() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: GOOGLE_GENERATE_V1BETA,
+        source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
         extra: Default::default(),
     };
 
@@ -1115,7 +1116,7 @@ fn openai_encoder_remaps_reused_tool_result_id_with_synthetic_adjacent_call() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: OPENAI_CHAT_V1,
+        source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
         extra: Default::default(),
     };
 
@@ -1303,7 +1304,7 @@ fn openai_encoder_preserves_reasoning_content_across_parallel_tool_calls() {
             parameters: serde_json::json!({"type":"object","properties":{"location":{"type":"string"}}}),
         }]),
         tool_choice: None,
-        source_protocol: OPENAI_CHAT_V1,
+        source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
         extra: Default::default(),
     };
 
@@ -1406,7 +1407,7 @@ fn openai_encoder_drops_orphan_assistant_tool_calls_without_results() {
             parameters: serde_json::json!({"type":"object","properties":{}}),
         }]),
         tool_choice: None,
-        source_protocol: GOOGLE_GENERATE_V1BETA,
+        source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
         extra: Default::default(),
     };
 
@@ -1576,7 +1577,7 @@ fn gemini_encoder_sanitizes_unsupported_json_schema_fields() {
             }),
         }]),
         tool_choice: None,
-        source_protocol: OPENAI_CHAT_V1,
+        source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
         extra: Default::default(),
     };
 

--- a/crates/nyro-core/tests/protocol_migration.rs
+++ b/crates/nyro-core/tests/protocol_migration.rs
@@ -13,7 +13,7 @@
 //!    by snapshotting the row state before and after.
 
 use nyro_core::db::{init_pool, migrate};
-use nyro_core::protocol::ids::OPENAI_CHAT_V1;
+use nyro_core::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use sqlx::Row;
 
 #[tokio::test]
@@ -48,7 +48,7 @@ async fn migration_normalizes_legacy_protocol_keys_then_idempotent() {
     let endpoints: serde_json::Value = serde_json::from_str(&endpoints_raw).unwrap();
     let obj = endpoints.as_object().unwrap();
 
-    assert_eq!(default_protocol, OPENAI_CHAT_V1.to_string());
+    assert_eq!(default_protocol, OPENAI_CHAT_COMPLETIONS_V1.to_string());
     // After normalization keys are protocol short names, not endpoint canonical strings.
     assert!(
         obj.contains_key("openai-compat"),

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -8,8 +8,8 @@
 //!   request pipeline still bypasses its codec)
 
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_EMBEDDINGS_V1,
-    OPENAI_RESPONSES_V1, Protocol, ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolId,
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
 use nyro_core::protocol::types::Role;
@@ -21,11 +21,11 @@ fn registers_all_handlers_with_correct_ids() {
     assert_eq!(reg.list().len(), 5);
 
     for id in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         OPENAI_EMBEDDINGS_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let h = reg.get(&id).unwrap_or_else(|| panic!("missing {id}"));
         assert_eq!(h.id(), id);
@@ -46,18 +46,14 @@ fn ingress_routes_match_axum_router() {
     let reg = ProtocolRegistry::global();
 
     let cases: &[(&str, &str, ProtocolId)] = &[
-        ("POST", "/v1/chat/completions", OPENAI_CHAT_V1),
-        ("POST", "/chat/completions", OPENAI_CHAT_V1),
+        ("POST", "/v1/chat/completions", OPENAI_CHAT_COMPLETIONS_V1),
         ("POST", "/v1/responses", OPENAI_RESPONSES_V1),
-        ("POST", "/responses", OPENAI_RESPONSES_V1),
         ("POST", "/v1/messages", ANTHROPIC_MESSAGES_2023_06_01),
-        ("POST", "/messages", ANTHROPIC_MESSAGES_2023_06_01),
         (
             "POST",
             "/v1beta/models/:model_action",
-            GOOGLE_GENERATE_V1BETA,
+            GOOGLE_GENERATE_CONTENT_V1BETA,
         ),
-        ("POST", "/models/:model_action", GOOGLE_GENERATE_V1BETA),
     ];
 
     for (method, path, expected) in cases {
@@ -79,13 +75,13 @@ fn capabilities_match_dialect_special_cases() {
         "Responses must force upstream streaming"
     );
     assert!(
-        !reg.get(&OPENAI_CHAT_V1)
+        !reg.get(&OPENAI_CHAT_COMPLETIONS_V1)
             .unwrap()
             .capabilities()
             .force_upstream_stream
     );
     assert!(
-        reg.get(&GOOGLE_GENERATE_V1BETA)
+        reg.get(&GOOGLE_GENERATE_CONTENT_V1BETA)
             .unwrap()
             .capabilities()
             .override_model_in_body,
@@ -96,7 +92,7 @@ fn capabilities_match_dialect_special_cases() {
 // ── Decoder / encoder smoke ──
 
 fn sample_body(id: ProtocolId) -> serde_json::Value {
-    if id == OPENAI_CHAT_V1 {
+    if id == OPENAI_CHAT_COMPLETIONS_V1 {
         json!({
             "model": "gpt-4o-mini",
             "messages": [
@@ -126,7 +122,7 @@ fn sample_body(id: ProtocolId) -> serde_json::Value {
             "max_tokens": 256,
             "stream": false
         })
-    } else if id == GOOGLE_GENERATE_V1BETA {
+    } else if id == GOOGLE_GENERATE_CONTENT_V1BETA {
         json!({
             "system_instruction": {"parts": [{"text": "be helpful"}]},
             "contents": [
@@ -142,10 +138,10 @@ fn sample_body(id: ProtocolId) -> serde_json::Value {
 fn decoder_preserves_role_sequence_and_source_protocol() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let body = sample_body(id);
         let req = reg
@@ -165,10 +161,10 @@ fn decoder_preserves_role_sequence_and_source_protocol() {
 fn encoder_round_trips_body_for_every_handler() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let body = sample_body(id);
         let h = reg.get(&id).unwrap();
@@ -193,10 +189,10 @@ fn encoder_round_trips_body_for_every_handler() {
 fn parser_and_formatter_factories_construct() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let h = reg.get(&id).unwrap();
         let _ = h.make_response_parser();
@@ -222,7 +218,7 @@ fn embeddings_handler_advertises_passthrough_capabilities() {
 #[test]
 fn embeddings_routes_resolve_to_handler() {
     let reg = ProtocolRegistry::global();
-    for path in ["/v1/embeddings", "/embeddings"] {
+    for path in ["/v1/embeddings"] {
         let h = reg
             .find_by_ingress_route("POST", path)
             .unwrap_or_else(|| panic!("no handler for POST {path}"));

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -18,7 +18,8 @@
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
 use serde_json::json;
@@ -61,11 +62,11 @@ fn parses_legacy_protocol_keys() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
     assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
-    assert!(pp.supports(GOOGLE_GENERATE_V1BETA));
+    assert!(pp.supports(GOOGLE_GENERATE_CONTENT_V1BETA));
     assert!(pp.supports(OPENAI_RESPONSES_V1));
-    assert_eq!(pp.default, OPENAI_CHAT_V1);
+    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
 }
 
 #[test]
@@ -80,10 +81,10 @@ fn parses_canonical_protocol_id_keys() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
     assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
-    assert!(pp.supports(GOOGLE_GENERATE_V1BETA));
-    assert_eq!(pp.default, OPENAI_CHAT_V1);
+    assert!(pp.supports(GOOGLE_GENERATE_CONTENT_V1BETA));
+    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
 }
 
 #[test]
@@ -98,10 +99,10 @@ fn parses_short_name_aliases() {
     );
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_V1));
+    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
     assert!(pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
     assert!(pp.supports(OPENAI_RESPONSES_V1));
-    assert_eq!(pp.default, OPENAI_CHAT_V1);
+    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
 }
 
 #[test]
@@ -111,9 +112,9 @@ fn resolve_egress_exact_match_skips_conversion() {
         json!({ "openai": { "base_url": "https://a.example/v1" } }),
     );
     let pp = ProviderProtocols::from_provider(&provider);
-    let r = pp.resolve_egress(OPENAI_CHAT_V1);
+    let r = pp.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
 
-    assert_eq!(r.protocol, OPENAI_CHAT_V1);
+    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(!r.needs_conversion);
 }
@@ -124,7 +125,7 @@ fn resolve_egress_responses_falls_back_to_provider_default() {
     // separate protocols; there is no same-protocol Tier-2 fallback between them.
     // A client speaking Responses API falls through to Tier 3 (provider default).
     let provider = provider_with_endpoints(
-        "openai", // default_protocol → resolves to OPENAI_CHAT_V1
+        "openai", // default_protocol → resolves to OPENAI_CHAT_COMPLETIONS_V1
         json!({
             "openai": { "base_url": "https://a.example/v1" },
             "anthropic": { "base_url": "https://b.example/v1" },
@@ -134,8 +135,8 @@ fn resolve_egress_responses_falls_back_to_provider_default() {
     let r = pp.resolve_egress(OPENAI_RESPONSES_V1);
 
     // No exact match, no same-protocol match (OpenAIResponses ≠ OpenAICompatible).
-    // Tier 3: provider default = OPENAI_CHAT_V1.
-    assert_eq!(r.protocol, OPENAI_CHAT_V1);
+    // Tier 3: provider default = OPENAI_CHAT_COMPLETIONS_V1.
+    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(r.needs_conversion);
 }
@@ -150,7 +151,7 @@ fn resolve_egress_falls_back_to_global_default_when_family_missing() {
     // Anthropic ingress, no Anthropic endpoint → fall back to default.
     let r = pp.resolve_egress(ANTHROPIC_MESSAGES_2023_06_01);
 
-    assert_eq!(r.protocol, OPENAI_CHAT_V1);
+    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
     assert!(r.needs_conversion);
 }
 
@@ -159,10 +160,10 @@ fn protocol_handler_resolves_for_every_canonical_id() {
     let reg = ProtocolRegistry::global();
 
     for id in [
-        OPENAI_CHAT_V1,
+        OPENAI_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_V1BETA,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         assert!(reg.get(&id).is_some(), "no handler registered for {id}");
         assert_eq!(id.handler().id(), id);

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -8,8 +8,8 @@
 use nyro_core::auth::types::StoredCredential;
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_V1BETA, OPENAI_CHAT_V1, OPENAI_RESPONSES_V1,
-    ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::provider::{VendorCtx, VendorRegistry, VendorScope};
 use serde_json::Value;
@@ -77,7 +77,9 @@ fn resolve_channel_scope_takes_priority() {
 fn resolve_falls_back_to_vendor_when_channel_unknown() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("openai"), Some("unknown-channel"));
-    let ext = reg.resolve(&p, OPENAI_CHAT_V1).expect("openai vendor ext");
+    let ext = reg
+        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .expect("openai vendor ext");
     assert!(matches!(
         ext.scope(),
         VendorScope::Vendor {
@@ -91,13 +93,13 @@ fn resolve_falls_back_to_protocol_default_vendor_when_vendor_unknown() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("unmapped-vendor"), None);
     let openai = reg
-        .resolve(&p, OPENAI_CHAT_V1)
+        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
         .expect("openai protocol default");
     let anthropic = reg
         .resolve(&p, ANTHROPIC_MESSAGES_2023_06_01)
         .expect("anthropic protocol default");
     let google = reg
-        .resolve(&p, GOOGLE_GENERATE_V1BETA)
+        .resolve(&p, GOOGLE_GENERATE_CONTENT_V1BETA)
         .expect("google protocol default");
 
     // Resolves to the default vendor for each protocol suite
@@ -140,7 +142,9 @@ fn resolve_uses_protocol_default_vendor_when_vendor_field_blank() {
 fn ollama_vendor_resolves_even_without_channel() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("ollama"), None);
-    let ext = reg.resolve(&p, OPENAI_CHAT_V1).expect("ollama vendor");
+    let ext = reg
+        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .expect("ollama vendor");
     assert!(matches!(
         ext.scope(),
         VendorScope::Vendor {
@@ -155,8 +159,14 @@ fn ollama_vendor_resolves_even_without_channel() {
 fn openai_family_default_emits_bearer() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_CHAT_V1).unwrap();
-    let h = ext.auth_headers(&ctx(&p, OPENAI_CHAT_V1, "sk-abc", "gpt-4", None));
+    let ext = reg.resolve(&p, OPENAI_CHAT_COMPLETIONS_V1).unwrap();
+    let h = ext.auth_headers(&ctx(
+        &p,
+        OPENAI_CHAT_COMPLETIONS_V1,
+        "sk-abc",
+        "gpt-4",
+        None,
+    ));
     assert_eq!(h.get("Authorization").unwrap(), "Bearer sk-abc");
 }
 
@@ -180,8 +190,14 @@ fn anthropic_family_default_emits_x_api_key_and_version() {
 fn google_family_default_appends_key_query_param() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, GOOGLE_GENERATE_V1BETA).unwrap();
-    let c = ctx(&p, GOOGLE_GENERATE_V1BETA, "AIzaXYZ", "gemini-1.5", None);
+    let ext = reg.resolve(&p, GOOGLE_GENERATE_CONTENT_V1BETA).unwrap();
+    let c = ctx(
+        &p,
+        GOOGLE_GENERATE_CONTENT_V1BETA,
+        "AIzaXYZ",
+        "gemini-1.5",
+        None,
+    );
 
     let url1 = ext.build_url(
         &c,
@@ -208,8 +224,8 @@ fn google_family_default_appends_key_query_param() {
 fn openai_compat_strips_v1_when_base_already_has_path() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_CHAT_V1).unwrap();
-    let c = ctx(&p, OPENAI_CHAT_V1, "k", "m", None);
+    let ext = reg.resolve(&p, OPENAI_CHAT_COMPLETIONS_V1).unwrap();
+    let c = ctx(&p, OPENAI_CHAT_COMPLETIONS_V1, "k", "m", None);
 
     let stripped = ext.build_url(&c, "https://api.deepseek.com/v1", "/v1/chat/completions");
     assert_eq!(stripped, "https://api.deepseek.com/v1/chat/completions");


### PR DESCRIPTION
- Split proxy/ingress/ into 4 protocol subdirs mirroring codec layout: openai_compatible/{chat_completions,embeddings}, openai_responses/responses, anthropic_messages/messages, google_generative/generate_content
- All handlers now named pub async fn handler(...)
- Remove 6 legacy (no /v1/ prefix) axum routes from server.rs: /chat/completions, /responses, /messages, /embeddings, /models/:model_action, /models
- Sync codec ingress_routes: remove bare paths from all 5 endpoint files, keeping only the canonical /v1/ prefixed routes
- Rename deprecated aliases OPENAI_CHAT_V1 and GOOGLE_GENERATE_V1BETA with #[deprecated] attributes; update all internal usages to OPENAI_CHAT_COMPLETIONS_V1 and GOOGLE_GENERATE_CONTENT_V1BETA

BREAKING: clients must use /v1/chat/completions, /v1/responses, /v1/messages, /v1/embeddings, /v1beta/models/:model_action