### PR TITLE
refactor: remove route_type field and endpoint subset filtering (Q2)

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -914,10 +914,6 @@ impl AdminService {
             cache.match_route(route_name).cloned()
         }
         .ok_or_else(|| anyhow::anyhow!("embedding route not found: {route_name}"))?;
-        if !route.is_embedding_route() {
-            anyhow::bail!("embedding route must be type=embedding: {route_name}");
-        }
-
         let targets = load_route_targets_for_probe(&self.gw, &route).await;
         if targets.is_empty() {
             anyhow::bail!("embedding route has no targets: {route_name}");
@@ -1115,15 +1111,8 @@ impl AdminService {
         ensure_virtual_model(&input.virtual_model)?;
         self.ensure_route_unique(None, &input.virtual_model).await?;
         let strategy = normalize_route_strategy(input.strategy.as_deref())?;
-        let route_type = normalize_route_type(input.route_type.as_deref(), "chat")?;
         let targets = normalize_create_route_targets(&input)?;
         ensure_route_targets_valid(&targets)?;
-        if route_type == "embedding" {
-            self.ensure_embedding_route_targets_openai(&targets).await?;
-            if has_route_cache_overrides(input.cache.as_ref()) {
-                anyhow::bail!("embedding routes do not support route cache configuration");
-            }
-        }
         let primary_target = targets
             .first()
             .ok_or_else(|| anyhow::anyhow!("at least one route target is required"))?;
@@ -1142,7 +1131,6 @@ impl AdminService {
                 target_model: primary_target.model.clone(),
                 targets: vec![],
                 access_control: input.access_control,
-                route_type: Some(route_type),
                 cache: None,
                 cache_exact_ttl,
                 cache_semantic_ttl,
@@ -1170,29 +1158,15 @@ impl AdminService {
             .unwrap_or_else(|| current.virtual_model.clone());
         let strategy =
             normalize_route_strategy(input.strategy.as_deref().or(Some(&current.strategy)))?;
-        let route_type = normalize_optional_route_type(input.route_type.as_deref())?;
-        let effective_route_type = if let Some(value) = route_type.as_deref() {
-            normalize_route_type(Some(value), "chat")?
-        } else {
-            current.normalized_route_type().to_string()
-        };
         let targets = normalize_update_route_targets(&current, &input)?;
         ensure_route_targets_valid(&targets)?;
-        if effective_route_type == "embedding" {
-            self.ensure_embedding_route_targets_openai(&targets).await?;
-        }
         let primary_target = targets
             .first()
             .ok_or_else(|| anyhow::anyhow!("at least one route target is required"))?;
         let access_control = input.access_control.unwrap_or(current.access_control);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let (cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) =
-            if effective_route_type == "embedding" {
-                if has_route_cache_overrides(input.cache.as_ref()) {
-                    anyhow::bail!("embedding routes do not support route cache configuration");
-                }
-                (None, None, None)
-            } else if let Some(cache) = input.cache.as_ref() {
+            if let Some(cache) = input.cache.as_ref() {
                 flatten_route_cache_columns(Some(cache))
             } else {
                 (
@@ -1217,7 +1191,6 @@ impl AdminService {
                     target_model: Some(primary_target.model.clone()),
                     targets: None,
                     access_control: Some(access_control),
-                    route_type,
                     cache: None,
                     cache_exact_ttl,
                     cache_semantic_ttl,
@@ -1542,7 +1515,6 @@ impl AdminService {
                         target_model: r.target_model.clone(),
                         targets: vec![],
                         access_control: Some(r.access_control),
-                        route_type: Some("chat".to_string()),
                         cache: None,
                         cache_exact_ttl: None,
                         cache_semantic_ttl: None,
@@ -2090,27 +2062,6 @@ impl AdminService {
         Ok(before.saturating_sub(sessions.len()))
     }
 
-    async fn ensure_embedding_route_targets_openai(
-        &self,
-        targets: &[CreateRouteTarget],
-    ) -> anyhow::Result<()> {
-        for target in targets {
-            let provider = self
-                .gw
-                .storage
-                .providers()
-                .get(&target.provider_id)
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("provider not found: {}", target.provider_id))?;
-            if !provider_supports_openai_endpoint(&provider) {
-                anyhow::bail!(
-                    "embedding route target provider '{}' does not expose an openai endpoint",
-                    provider.name
-                );
-            }
-        }
-        Ok(())
-    }
 }
 
 fn parse_auth_session_bundle(session: &AuthSession) -> anyhow::Result<CredentialBundle> {
@@ -2348,9 +2299,6 @@ fn flatten_route_cache_columns(
 }
 
 fn resolve_route_cache(route: &Route) -> Option<RouteCacheConfig> {
-    if route.is_embedding_route() {
-        return None;
-    }
     let exact = route.cache_exact_ttl.map(|ttl| RouteExactCacheConfig {
         ttl: if ttl > 0 { Some(ttl) } else { None },
     });
@@ -2365,13 +2313,6 @@ fn resolve_route_cache(route: &Route) -> Option<RouteCacheConfig> {
     } else {
         Some(RouteCacheConfig { exact, semantic })
     }
-}
-
-fn has_route_cache_overrides(cache: Option<&RouteCacheConfig>) -> bool {
-    let Some(cache) = cache else {
-        return false;
-    };
-    cache.exact.is_some() || cache.semantic.is_some()
 }
 
 fn format_connectivity_error(error: &reqwest::Error) -> String {
@@ -2407,24 +2348,6 @@ fn normalize_route_strategy(strategy: Option<&str>) -> anyhow::Result<String> {
     match normalized.as_str() {
         "weighted" | "priority" => Ok(normalized),
         _ => anyhow::bail!("unsupported route strategy: {normalized}"),
-    }
-}
-
-fn normalize_route_type(route_type: Option<&str>, default_value: &str) -> anyhow::Result<String> {
-    let normalized = route_type
-        .unwrap_or(default_value)
-        .trim()
-        .to_ascii_lowercase();
-    match normalized.as_str() {
-        "chat" | "embedding" => Ok(normalized),
-        _ => anyhow::bail!("unsupported route type: {normalized}"),
-    }
-}
-
-fn normalize_optional_route_type(route_type: Option<&str>) -> anyhow::Result<Option<String>> {
-    match route_type {
-        Some(value) => Ok(Some(normalize_route_type(Some(value), "chat")?)),
-        None => Ok(None),
     }
 }
 
@@ -2570,10 +2493,6 @@ fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
     }
 }
 
-fn provider_supports_openai_endpoint(provider: &Provider) -> bool {
-    resolve_openai_base_url(provider).is_some()
-}
-
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
     if !protocols.supports(OPENAI_CHAT_COMPLETIONS_V1) {
@@ -2632,10 +2551,7 @@ fn sync_runtime_protocol_endpoints(provider: &Provider, base_url: &str) -> anyho
         endpoints
             .entry(default_protocol)
             .and_modify(|entry| entry.base_url = runtime_base_url.to_string())
-            .or_insert_with(|| ProtocolEndpointEntry {
-                base_url: runtime_base_url.to_string(),
-                endpoints: None,
-            });
+            .or_insert_with(|| ProtocolEndpointEntry { base_url: runtime_base_url.to_string() });
     }
 
     Ok(serde_json::to_string(&endpoints)?)

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -2061,7 +2061,6 @@ impl AdminService {
         });
         Ok(before.saturating_sub(sessions.len()))
     }
-
 }
 
 fn parse_auth_session_bundle(session: &AuthSession) -> anyhow::Result<CredentialBundle> {
@@ -2551,7 +2550,9 @@ fn sync_runtime_protocol_endpoints(provider: &Provider, base_url: &str) -> anyho
         endpoints
             .entry(default_protocol)
             .and_modify(|entry| entry.base_url = runtime_base_url.to_string())
-            .or_insert_with(|| ProtocolEndpointEntry { base_url: runtime_base_url.to_string() });
+            .or_insert_with(|| ProtocolEndpointEntry {
+                base_url: runtime_base_url.to_string(),
+            });
     }
 
     Ok(serde_json::to_string(&endpoints)?)

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -260,10 +260,7 @@ async fn drop_provider_column_if_exists(
     Ok(())
 }
 
-async fn drop_route_column_if_exists(
-    pool: &SqlitePool,
-    column_name: &str,
-) -> anyhow::Result<()> {
+async fn drop_route_column_if_exists(pool: &SqlitePool, column_name: &str) -> anyhow::Result<()> {
     if column_exists(pool, "routes", column_name).await? {
         let sql = format!("ALTER TABLE routes DROP COLUMN {column_name}");
         sqlx::query(&sql).execute(pool).await?;

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -63,7 +63,6 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     ensure_route_column(pool, "virtual_model", "TEXT").await?;
     ensure_route_column(pool, "strategy", "TEXT DEFAULT 'weighted'").await?;
     ensure_route_column(pool, "access_control", "INTEGER DEFAULT 0").await?;
-    ensure_route_column(pool, "route_type", "TEXT DEFAULT 'chat'").await?;
     ensure_route_column(pool, "cache_exact_ttl", "INTEGER").await?;
     ensure_route_column(pool, "cache_semantic_ttl", "INTEGER").await?;
     ensure_route_column(pool, "cache_semantic_threshold", "REAL").await?;
@@ -256,6 +255,17 @@ async fn drop_provider_column_if_exists(
 ) -> anyhow::Result<()> {
     if column_exists(pool, "providers", column_name).await? {
         let sql = format!("ALTER TABLE providers DROP COLUMN {column_name}");
+        sqlx::query(&sql).execute(pool).await?;
+    }
+    Ok(())
+}
+
+async fn drop_route_column_if_exists(
+    pool: &SqlitePool,
+    column_name: &str,
+) -> anyhow::Result<()> {
+    if column_exists(pool, "routes", column_name).await? {
+        let sql = format!("ALTER TABLE routes DROP COLUMN {column_name}");
         sqlx::query(&sql).execute(pool).await?;
     }
     Ok(())
@@ -480,13 +490,7 @@ async fn backfill_route_fields(pool: &SqlitePool) -> anyhow::Result<()> {
         .execute(pool)
         .await?;
     }
-    if column_exists(pool, "routes", "route_type").await? {
-        sqlx::query(
-            "UPDATE routes SET route_type = 'chat' WHERE route_type IS NULL OR trim(route_type) = ''",
-        )
-        .execute(pool)
-        .await?;
-    }
+    drop_route_column_if_exists(pool, "route_type").await?;
     if column_exists(pool, "routes", "cache_ttl").await? {
         sqlx::query(
             "UPDATE routes SET cache_exact_ttl = cache_ttl WHERE cache_exact_ttl IS NULL AND cache_ttl IS NOT NULL",
@@ -621,7 +625,6 @@ CREATE TABLE IF NOT EXISTS routes (
     name              TEXT NOT NULL,
     virtual_model     TEXT,
     strategy          TEXT DEFAULT 'weighted',
-    route_type        TEXT DEFAULT 'chat',
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,
     cache_exact_ttl   INTEGER,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -555,7 +555,9 @@ impl Provider {
         if !self.protocol.trim().is_empty() && !self.base_url.trim().is_empty() {
             map.insert(
                 self.protocol.trim().to_string(),
-                ProtocolEndpointEntry { base_url: self.base_url.trim().to_string() },
+                ProtocolEndpointEntry {
+                    base_url: self.base_url.trim().to_string(),
+                },
             );
         }
         map

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -124,10 +124,6 @@ pub struct Route {
     pub target_model: String,
     pub access_control: bool,
     #[serde(default)]
-    #[serde(alias = "type")]
-    #[sqlx(default)]
-    pub route_type: String,
-    #[serde(default)]
     #[sqlx(default)]
     pub cache_exact_ttl: Option<i64>,
     #[serde(default)]
@@ -299,8 +295,6 @@ pub struct UpdateRoute {
     #[serde(default)]
     pub targets: Option<Vec<UpsertRouteTarget>>,
     pub access_control: Option<bool>,
-    #[serde(alias = "type")]
-    pub route_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<RouteCacheConfig>,
     #[serde(skip)]
@@ -323,8 +317,6 @@ pub struct CreateRoute {
     #[serde(default)]
     pub targets: Vec<CreateRouteTarget>,
     pub access_control: Option<bool>,
-    #[serde(alias = "type")]
-    pub route_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<RouteCacheConfig>,
     #[serde(skip)]
@@ -563,37 +555,16 @@ impl Provider {
         if !self.protocol.trim().is_empty() && !self.base_url.trim().is_empty() {
             map.insert(
                 self.protocol.trim().to_string(),
-                ProtocolEndpointEntry {
-                    base_url: self.base_url.trim().to_string(),
-                    endpoints: None,
-                },
+                ProtocolEndpointEntry { base_url: self.base_url.trim().to_string() },
             );
         }
         map
     }
 }
 
-impl Route {
-    pub fn normalized_route_type(&self) -> &str {
-        if self.route_type.trim().eq_ignore_ascii_case("embedding") {
-            "embedding"
-        } else {
-            "chat"
-        }
-    }
-
-    pub fn is_embedding_route(&self) -> bool {
-        self.normalized_route_type() == "embedding"
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolEndpointEntry {
     pub base_url: String,
-    /// Subset of endpoint names supported by this provider under this protocol.
-    /// `None` means all endpoints declared by the protocol are supported.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub endpoints: Option<Vec<String>>,
 }
 
 impl CreateProvider {

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -285,16 +285,13 @@ impl Gateway {
                     next.semantic.enabled = false;
                     None
                 } else {
-                    let route_valid = {
+                    let route_found = {
                         let route_cache = self.route_cache.read().await;
-                        route_cache
-                            .match_route(embedding_route)
-                            .map(|route| route.is_embedding_route())
-                            .unwrap_or(false)
+                        route_cache.match_route(embedding_route).is_some()
                     };
-                    if !route_valid {
+                    if !route_found {
                         tracing::warn!(
-                            "semantic cache embedding route '{}' not found or not type=embedding; semantic cache disabled",
+                            "semantic cache embedding route '{}' not found; semantic cache disabled",
                             embedding_route
                         );
                         next.semantic.enabled = false;

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -162,7 +162,12 @@ impl ProviderProtocols {
                 for handler in reg.list_by_protocol(protocol) {
                     let id = handler.id();
                     if seen.insert(id) {
-                        endpoints.push((id, ProtocolEndpointEntry { base_url: entry.base_url.clone() }));
+                        endpoints.push((
+                            id,
+                            ProtocolEndpointEntry {
+                                base_url: entry.base_url.clone(),
+                            },
+                        ));
                     }
                 }
                 continue;
@@ -172,7 +177,12 @@ impl ProviderProtocols {
             if let Some(id) = Self::parse_protocol_key(key)
                 && seen.insert(id)
             {
-                endpoints.push((id, ProtocolEndpointEntry { base_url: entry.base_url.clone() }));
+                endpoints.push((
+                    id,
+                    ProtocolEndpointEntry {
+                        base_url: entry.base_url.clone(),
+                    },
+                ));
             }
         }
 

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -145,8 +145,8 @@ impl ProviderProtocols {
     /// Handles both old endpoint-keyed format and new protocol-keyed format:
     /// - **Old** `{"openai-compat/chat-completions/v1": {"base_url": "..."}}` —
     ///   each key resolves directly to a `ProtocolEndpoint`.
-    /// - **New** `{"openai-compat": {"base_url": "...", "endpoints": [...]}}` —
-    ///   key resolves to a `Protocol`; expands to all (or declared subset of) its endpoints.
+    /// - **New** `{"openai-compat": {"base_url": "..."}}` —
+    ///   key resolves to a `Protocol`; expands to all its endpoints.
     ///
     /// The `endpoints` Vec preserves the iteration order of the JSON map
     /// (serde_json preserves insertion order).
@@ -159,25 +159,10 @@ impl ProviderProtocols {
         for (key, entry) in &raw_map {
             // First try protocol-keyed format (new)
             if let Some(protocol) = reg.parse_protocol(key) {
-                let all_handlers = reg.list_by_protocol(protocol);
-                let supported_names: Option<&Vec<String>> = entry.endpoints.as_ref();
-
-                for handler in all_handlers {
+                for handler in reg.list_by_protocol(protocol) {
                     let id = handler.id();
-                    // If entry.endpoints is Some, only include declared names
-                    if let Some(names) = supported_names {
-                        if !names.iter().any(|n| n == id.name) {
-                            continue;
-                        }
-                    }
                     if seen.insert(id) {
-                        endpoints.push((
-                            id,
-                            ProtocolEndpointEntry {
-                                base_url: entry.base_url.clone(),
-                                endpoints: None,
-                            },
-                        ));
+                        endpoints.push((id, ProtocolEndpointEntry { base_url: entry.base_url.clone() }));
                     }
                 }
                 continue;
@@ -187,13 +172,7 @@ impl ProviderProtocols {
             if let Some(id) = Self::parse_protocol_key(key)
                 && seen.insert(id)
             {
-                endpoints.push((
-                    id,
-                    ProtocolEndpointEntry {
-                        base_url: entry.base_url.clone(),
-                        endpoints: None,
-                    },
-                ));
+                endpoints.push((id, ProtocolEndpointEntry { base_url: entry.base_url.clone() }));
             }
         }
 

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -197,11 +197,10 @@ impl ProtocolRegistry {
     /// Rewrite a `protocol_endpoints`-shaped JSON object into protocol-keyed form.
     ///
     /// Handles three input shapes:
-    /// 1. **New protocol-keyed**: `{"openai-compat": {"base_url": "...", "endpoints": [...]}}` —
-    ///    keys are normalized to canonical short names, values are preserved.
+    /// 1. **New protocol-keyed**: `{"openai-compat": {"base_url": "..."}}` —
+    ///    keys are normalized to canonical short names, values preserved (only `base_url` kept).
     /// 2. **Old endpoint-keyed**: `{"openai-compat/chat-completions/v1": {"base_url": "..."}}` —
-    ///    merged under the protocol key; `base_url` is taken from the first endpoint for that
-    ///    protocol; conflicting base_urls emit a warning (best-effort: first wins).
+    ///    merged under the protocol key; `base_url` from the first entry for that protocol wins.
     /// 3. **Legacy keys**: `{"openai": {"base_url": "..."}}` — resolved to canonical protocol.
     ///
     /// Collisions within the same protocol are resolved first-writer-wins.
@@ -221,100 +220,78 @@ impl ProtocolRegistry {
             return raw.to_string();
         };
 
-        // Accumulator: protocol_canonical_short → serde_json::Value (the entry object)
+        // Accumulator: protocol_canonical_short → {"base_url": "..."}
         let mut next: serde_json::Map<String, serde_json::Value> =
             serde_json::Map::with_capacity(obj.len());
 
         for (key, val) in obj {
-            // First try to resolve as a ProtocolEndpoint (endpoint-keyed old format)
+            // Old endpoint-keyed format: resolve to its protocol
             if let Some(ep) = self.resolve_alias(key) {
                 let protocol_key = ep.protocol.as_str().to_string();
-
-                if next.contains_key(&protocol_key) {
-                    // Protocol entry already accumulated — check base_url consistency
-                    if let Some(obj_val) = next.get_mut(&protocol_key)
-                        && let Some(entry_obj) = obj_val.as_object_mut()
-                    {
-                        let existing_url = entry_obj
-                            .get("base_url")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
-                        let incoming_url = val
-                            .as_object()
-                            .and_then(|o| o.get("base_url"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
-                        if !existing_url.is_empty()
-                            && !incoming_url.is_empty()
-                            && existing_url != incoming_url
-                        {
-                            tracing::warn!(
-                                protocol = %protocol_key,
-                                existing = %existing_url,
-                                incoming = %incoming_url,
-                                "conflicting base_url for same protocol — keeping first"
-                            );
-                        }
-                        // Accumulate endpoint name in the endpoints array
-                        let endpoints = entry_obj
-                            .entry("endpoints")
-                            .or_insert(serde_json::Value::Array(vec![]));
-                        if let Some(arr) = endpoints.as_array_mut() {
-                            let ep_name = serde_json::Value::String(ep.name.to_string());
-                            if !arr.contains(&ep_name) {
-                                arr.push(ep_name);
-                            }
-                        }
-                    }
-                } else {
-                    // First time we see this protocol — create the entry
-                    let mut entry = if let Some(o) = val.as_object() {
-                        o.clone()
-                    } else {
-                        serde_json::Map::new()
-                    };
-                    // Add the endpoint name to an endpoints array (marks it as endpoint-keyed origin)
-                    let ep_name = serde_json::Value::String(ep.name.to_string());
-                    entry
-                        .entry("endpoints")
-                        .or_insert(serde_json::Value::Array(vec![ep_name.clone()]));
+                if !next.contains_key(&protocol_key) {
+                    // Extract only base_url from the entry
+                    let base_url = val
+                        .as_object()
+                        .and_then(|o| o.get("base_url"))
+                        .cloned()
+                        .unwrap_or(serde_json::Value::String(String::new()));
+                    let mut entry = serde_json::Map::new();
+                    entry.insert("base_url".to_string(), base_url);
                     next.insert(protocol_key, serde_json::Value::Object(entry));
+                } else {
+                    let existing_url = next
+                        .get(&protocol_key)
+                        .and_then(|v| v.as_object())
+                        .and_then(|o| o.get("base_url"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let incoming_url = val
+                        .as_object()
+                        .and_then(|o| o.get("base_url"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if !existing_url.is_empty()
+                        && !incoming_url.is_empty()
+                        && existing_url != incoming_url
+                    {
+                        tracing::warn!(
+                            protocol = %protocol_key,
+                            existing = %existing_url,
+                            incoming = %incoming_url,
+                            "conflicting base_url for same protocol — keeping first"
+                        );
+                    }
                 }
                 continue;
             }
 
-            // Then try to resolve as a Protocol (protocol-keyed new format)
+            // New protocol-keyed format
             if let Some(protocol) = self.parse_protocol(key) {
                 let protocol_key = protocol.as_str().to_string();
-                next.entry(protocol_key).or_insert_with(|| val.clone());
+                if !next.contains_key(&protocol_key) {
+                    // Keep only base_url, strip legacy endpoints array if present
+                    let base_url = val
+                        .as_object()
+                        .and_then(|o| o.get("base_url"))
+                        .cloned()
+                        .unwrap_or_else(|| val.clone());
+                    let mut entry = serde_json::Map::new();
+                    if let Some(s) = base_url.as_str() {
+                        entry.insert("base_url".to_string(), serde_json::Value::String(s.to_string()));
+                    } else if let Some(o) = val.as_object() {
+                        // val itself is an object; keep base_url only
+                        if let Some(b) = o.get("base_url") {
+                            entry.insert("base_url".to_string(), b.clone());
+                        }
+                    }
+                    next.insert(protocol_key, serde_json::Value::Object(entry));
+                }
                 continue;
             }
 
             // Unknown key — pass through verbatim with a warning
             tracing::warn!(key = %key, "leaving unrecognized protocol_endpoints key unchanged");
             next.entry(key.clone()).or_insert_with(|| val.clone());
-        }
-
-        // Post-process: if a protocol was endpoint-keyed but ends up with all
-        // endpoints of its protocol, remove the explicit endpoints list (= "all supported")
-        for (protocol_key, entry_val) in next.iter_mut() {
-            if let Ok(protocol) = protocol_key.parse::<Protocol>()
-                && let Some(obj) = entry_val.as_object_mut()
-            {
-                if let Some(eps_val) = obj.get("endpoints").and_then(|v| v.as_array()) {
-                    let all_for_protocol: Vec<_> = self
-                        .list_by_protocol(protocol)
-                        .iter()
-                        .map(|h| h.id().name)
-                        .collect();
-                    let all_present = all_for_protocol
-                        .iter()
-                        .all(|n| eps_val.iter().any(|v| v.as_str() == Some(n)));
-                    if all_present && all_for_protocol.len() == eps_val.len() {
-                        obj.remove("endpoints");
-                    }
-                }
-            }
         }
 
         serde_json::Value::Object(next).to_string()

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -277,7 +277,10 @@ impl ProtocolRegistry {
                         .unwrap_or_else(|| val.clone());
                     let mut entry = serde_json::Map::new();
                     if let Some(s) = base_url.as_str() {
-                        entry.insert("base_url".to_string(), serde_json::Value::String(s.to_string()));
+                        entry.insert(
+                            "base_url".to_string(),
+                            serde_json::Value::String(s.to_string()),
+                        );
                     } else if let Some(o) = val.as_object() {
                         // val itself is an object; keep base_url only
                         if let Some(b) = o.get("base_url") {

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -96,7 +96,6 @@ pub async fn dispatch_pipeline(
     let start = Instant::now();
     let request_model = internal.model.clone();
     let is_stream = internal.stream;
-    let is_embedding_request = ingress.handler().capabilities().embeddings;
     let ingress_str = ingress.to_string();
 
     // ── Route lookup ─────────────────────────────────────────────────────────
@@ -138,76 +137,6 @@ pub async fn dispatch_pipeline(
             return error_response(404, &msg);
         }
     };
-
-    // Gate: embedding routes may only be accessed via the embeddings endpoint
-    // and chat routes may not be accessed via embeddings.
-    if is_embedding_request && !route.is_embedding_route() {
-        let msg = format!(
-            "route '{}' is type='{}', embeddings endpoint requires type='embedding'",
-            route.virtual_model,
-            route.normalized_route_type()
-        );
-        emit_log(
-            &gw,
-            &ingress_str,
-            &ingress_str,
-            &request_model,
-            "",
-            None,
-            "",
-            400,
-            start.elapsed().as_millis() as f64,
-            TokenUsage::default(),
-            false,
-            false,
-            Some(msg.clone()),
-            None,
-            LogExtras {
-                method: Some(method_owned.clone()),
-                path: Some(path_owned.clone()),
-                request_headers: request_headers_str.clone(),
-                request_body: request_body_str.clone(),
-                response_headers: None,
-                response_body: Some(
-                    serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
-                ),
-            },
-        );
-        return error_response(400, &msg);
-    }
-    if !is_embedding_request && route.is_embedding_route() {
-        let msg = format!(
-            "route '{}' is type='embedding', use /v1/embeddings",
-            route.virtual_model
-        );
-        emit_log(
-            &gw,
-            &ingress_str,
-            &ingress_str,
-            &request_model,
-            "",
-            None,
-            "",
-            400,
-            start.elapsed().as_millis() as f64,
-            TokenUsage::default(),
-            is_stream,
-            false,
-            Some(msg.clone()),
-            None,
-            LogExtras {
-                method: Some(method_owned.clone()),
-                path: Some(path_owned.clone()),
-                request_headers: request_headers_str.clone(),
-                request_body: request_body_str.clone(),
-                response_headers: None,
-                response_body: Some(
-                    serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
-                ),
-            },
-        );
-        return error_response(400, &msg);
-    }
 
     // ── Auth ─────────────────────────────────────────────────────────────────
 
@@ -2195,9 +2124,6 @@ async fn compute_embedding(gw: &Gateway, text: &str) -> anyhow::Result<Vec<f32>>
         cache.match_route(embedding_route).cloned()
     }
     .ok_or_else(|| anyhow::anyhow!("embedding route not found: {embedding_route}"))?;
-    if !route.is_embedding_route() {
-        anyhow::bail!("embedding route must be type='embedding': {embedding_route}");
-    }
 
     let targets = load_route_targets(gw, &route).await;
     if targets.is_empty() {

--- a/crates/nyro-core/src/proxy/planner/negotiator.rs
+++ b/crates/nyro-core/src/proxy/planner/negotiator.rs
@@ -211,7 +211,9 @@ mod tests {
             .map(|(id, url)| {
                 (
                     *id,
-                    ProtocolEndpointEntry { base_url: url.to_string() },
+                    ProtocolEndpointEntry {
+                        base_url: url.to_string(),
+                    },
                 )
             })
             .collect();

--- a/crates/nyro-core/src/proxy/planner/negotiator.rs
+++ b/crates/nyro-core/src/proxy/planner/negotiator.rs
@@ -211,10 +211,7 @@ mod tests {
             .map(|(id, url)| {
                 (
                     *id,
-                    ProtocolEndpointEntry {
-                        base_url: url.to_string(),
-                        endpoints: None,
-                    },
+                    ProtocolEndpointEntry { base_url: url.to_string() },
                 )
             })
             .collect();

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -544,13 +544,8 @@ impl RouteStore for PostgresRouteStore {
     async fn create(&self, input: CreateRoute) -> anyhow::Result<Route> {
         let id = uuid::Uuid::new_v4().to_string();
         let virtual_model = input.virtual_model.trim().to_string();
-        let route_type = input
-            .route_type
-            .unwrap_or_else(|| "chat".to_string())
-            .trim()
-            .to_string();
         sqlx::query(
-            "INSERT INTO routes (id, name, virtual_model, strategy, target_provider, target_model, access_control, route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            "INSERT INTO routes (id, name, virtual_model, strategy, target_provider, target_model, access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
         .bind(&id)
         .bind(input.name.trim())
@@ -559,7 +554,6 @@ impl RouteStore for PostgresRouteStore {
         .bind(input.target_provider.trim())
         .bind(input.target_model.trim())
         .bind(input.access_control.unwrap_or(false))
-        .bind(route_type)
         .bind(input.cache_exact_ttl)
         .bind(input.cache_semantic_ttl)
         .bind(input.cache_semantic_threshold)
@@ -580,18 +574,13 @@ impl RouteStore for PostgresRouteStore {
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
         let access_control = input.access_control.unwrap_or(current.access_control);
-        let route_type = input
-            .route_type
-            .unwrap_or(current.route_type)
-            .trim()
-            .to_string();
         let cache_exact_ttl = input.cache_exact_ttl;
         let cache_semantic_ttl = input.cache_semantic_ttl;
         let cache_semantic_threshold = input.cache_semantic_threshold;
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE routes SET name=$1, virtual_model=$2, strategy=$3, target_provider=$4, target_model=$5, access_control=$6, route_type=$7, cache_exact_ttl=$8, cache_semantic_ttl=$9, cache_semantic_threshold=$10, is_enabled=$11 WHERE id=$12",
+            "UPDATE routes SET name=$1, virtual_model=$2, strategy=$3, target_provider=$4, target_model=$5, access_control=$6, cache_exact_ttl=$7, cache_semantic_ttl=$8, cache_semantic_threshold=$9, is_enabled=$10 WHERE id=$11",
         )
         .bind(name.trim())
         .bind(&virtual_model)
@@ -599,7 +588,6 @@ impl RouteStore for PostgresRouteStore {
         .bind(target_provider.trim())
         .bind(target_model.trim())
         .bind(access_control)
-        .bind(route_type)
         .bind(cache_exact_ttl)
         .bind(cache_semantic_ttl)
         .bind(cache_semantic_threshold)
@@ -1202,9 +1190,6 @@ impl StorageBootstrap for PostgresBootstrap {
         sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS strategy TEXT DEFAULT 'weighted'")
             .execute(self.adapter.pool())
             .await?;
-        sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS route_type TEXT DEFAULT 'chat'")
-            .execute(self.adapter.pool())
-            .await?;
         sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS cache_exact_ttl BIGINT")
             .execute(self.adapter.pool())
             .await?;
@@ -1217,9 +1202,6 @@ impl StorageBootstrap for PostgresBootstrap {
         .execute(self.adapter.pool())
         .await?;
         sqlx::query("UPDATE routes SET strategy = 'weighted' WHERE strategy IS NULL OR btrim(strategy) = ''")
-            .execute(self.adapter.pool())
-            .await?;
-        sqlx::query("UPDATE routes SET route_type = 'chat' WHERE route_type IS NULL OR btrim(route_type) = ''")
             .execute(self.adapter.pool())
             .await?;
         sqlx::query(
@@ -1371,6 +1353,10 @@ END $$;"#,
         // PR4: rewrite provider protocol identifiers into canonical
         // `family/dialect/version` form. Idempotent.
         normalize_provider_protocols_pg(self.adapter.pool()).await?;
+        // Q2: drop route_type column (idempotent via IF EXISTS).
+        sqlx::query("ALTER TABLE routes DROP COLUMN IF EXISTS route_type")
+            .execute(self.adapter.pool())
+            .await?;
         Ok(())
     }
 
@@ -1525,7 +1511,7 @@ fn provider_select(suffix: Option<&str>) -> String {
 
 fn route_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM routes",
+        "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, false) AS access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM routes",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1645,7 +1631,6 @@ CREATE TABLE IF NOT EXISTS routes (
     name TEXT NOT NULL,
     virtual_model TEXT,
     strategy TEXT DEFAULT 'weighted',
-    route_type TEXT DEFAULT 'chat',
     target_provider TEXT NOT NULL REFERENCES providers(id),
     target_model TEXT NOT NULL,
     cache_exact_ttl BIGINT,

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -492,7 +492,7 @@ impl SqliteRouteStore {
 impl RouteStore for SqliteRouteStore {
     async fn list(&self) -> anyhow::Result<Vec<Route>> {
         Ok(sqlx::query_as::<_, Route>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes ORDER BY created_at DESC",
+            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -500,7 +500,7 @@ impl RouteStore for SqliteRouteStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Route>> {
         Ok(sqlx::query_as::<_, Route>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(route_type, 'chat') AS route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes WHERE id = ?",
+            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM routes WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -511,14 +511,9 @@ impl RouteStore for SqliteRouteStore {
         let id = uuid::Uuid::new_v4().to_string();
         let virtual_model = input.virtual_model.trim().to_string();
         let strategy = input.strategy.unwrap_or_else(|| "weighted".to_string());
-        let route_type = input
-            .route_type
-            .unwrap_or_else(|| "chat".to_string())
-            .trim()
-            .to_string();
         if self.has_match_pattern_column().await? {
             sqlx::query(
-                "INSERT INTO routes (id, name, virtual_model, match_pattern, strategy, target_provider, target_model, access_control, route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO routes (id, name, virtual_model, match_pattern, strategy, target_provider, target_model, access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(input.name.trim())
@@ -528,7 +523,6 @@ impl RouteStore for SqliteRouteStore {
             .bind(input.target_provider.trim())
             .bind(input.target_model.trim())
             .bind(input.access_control.unwrap_or(false))
-            .bind(route_type)
             .bind(input.cache_exact_ttl)
             .bind(input.cache_semantic_ttl)
             .bind(input.cache_semantic_threshold)
@@ -536,7 +530,7 @@ impl RouteStore for SqliteRouteStore {
             .await?;
         } else {
             sqlx::query(
-                "INSERT INTO routes (id, name, virtual_model, strategy, target_provider, target_model, access_control, route_type, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO routes (id, name, virtual_model, strategy, target_provider, target_model, access_control, cache_exact_ttl, cache_semantic_ttl, cache_semantic_threshold) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(input.name.trim())
@@ -545,7 +539,6 @@ impl RouteStore for SqliteRouteStore {
             .bind(input.target_provider.trim())
             .bind(input.target_model.trim())
             .bind(input.access_control.unwrap_or(false))
-            .bind(route_type)
             .bind(input.cache_exact_ttl)
             .bind(input.cache_semantic_ttl)
             .bind(input.cache_semantic_threshold)
@@ -567,11 +560,6 @@ impl RouteStore for SqliteRouteStore {
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
         let access_control = input.access_control.unwrap_or(current.access_control);
-        let route_type = input
-            .route_type
-            .unwrap_or(current.route_type)
-            .trim()
-            .to_string();
         let cache_exact_ttl = input.cache_exact_ttl;
         let cache_semantic_ttl = input.cache_semantic_ttl;
         let cache_semantic_threshold = input.cache_semantic_threshold;
@@ -579,7 +567,7 @@ impl RouteStore for SqliteRouteStore {
 
         if self.has_match_pattern_column().await? {
             sqlx::query(
-                "UPDATE routes SET name=?, virtual_model=?, match_pattern=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
+                "UPDATE routes SET name=?, virtual_model=?, match_pattern=?, strategy=?, target_provider=?, target_model=?, access_control=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
@@ -588,7 +576,6 @@ impl RouteStore for SqliteRouteStore {
             .bind(target_provider.trim())
             .bind(target_model.trim())
             .bind(access_control)
-            .bind(route_type)
             .bind(cache_exact_ttl)
             .bind(cache_semantic_ttl)
             .bind(cache_semantic_threshold)
@@ -598,7 +585,7 @@ impl RouteStore for SqliteRouteStore {
             .await?;
         } else {
             sqlx::query(
-                "UPDATE routes SET name=?, virtual_model=?, strategy=?, target_provider=?, target_model=?, access_control=?, route_type=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
+                "UPDATE routes SET name=?, virtual_model=?, strategy=?, target_provider=?, target_model=?, access_control=?, cache_exact_ttl=?, cache_semantic_ttl=?, cache_semantic_threshold=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
@@ -606,7 +593,6 @@ impl RouteStore for SqliteRouteStore {
             .bind(target_provider.trim())
             .bind(target_model.trim())
             .bind(access_control)
-            .bind(route_type)
             .bind(cache_exact_ttl)
             .bind(cache_semantic_ttl)
             .bind(cache_semantic_threshold)
@@ -689,7 +675,6 @@ impl RouteSnapshotStore for SqliteRouteStore {
                 COALESCE(strategy, 'weighted') AS strategy,
                 target_provider, target_model,
                 COALESCE(access_control, 0) AS access_control,
-                COALESCE(route_type, 'chat') AS route_type,
                 cache_exact_ttl,
                 cache_semantic_ttl,
                 cache_semantic_threshold,

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -55,34 +55,10 @@ async fn build_test_gateway() -> Gateway {
 
 fn all_four_decl() -> ProviderProtocols {
     let endpoints = vec![
-        (
-            OPENAI_CHAT_COMPLETIONS_V1,
-            ProtocolEndpointEntry {
-                base_url: "https://chat.example.com".into(),
-                endpoints: None,
-            },
-        ),
-        (
-            OPENAI_RESPONSES_V1,
-            ProtocolEndpointEntry {
-                base_url: "https://responses.example.com".into(),
-                endpoints: None,
-            },
-        ),
-        (
-            ANTHROPIC_MESSAGES_2023_06_01,
-            ProtocolEndpointEntry {
-                base_url: "https://messages.example.com".into(),
-                endpoints: None,
-            },
-        ),
-        (
-            GOOGLE_GENERATE_CONTENT_V1BETA,
-            ProtocolEndpointEntry {
-                base_url: "https://generate.example.com".into(),
-                endpoints: None,
-            },
-        ),
+        (OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpointEntry { base_url: "https://chat.example.com".into() }),
+        (OPENAI_RESPONSES_V1, ProtocolEndpointEntry { base_url: "https://responses.example.com".into() }),
+        (ANTHROPIC_MESSAGES_2023_06_01, ProtocolEndpointEntry { base_url: "https://messages.example.com".into() }),
+        (GOOGLE_GENERATE_CONTENT_V1BETA, ProtocolEndpointEntry { base_url: "https://generate.example.com".into() }),
     ];
     ProviderProtocols {
         default: OPENAI_CHAT_COMPLETIONS_V1,
@@ -91,13 +67,7 @@ fn all_four_decl() -> ProviderProtocols {
 }
 
 fn single_decl(proto: ProtocolId, url: &str) -> ProviderProtocols {
-    let endpoints = vec![(
-        proto,
-        ProtocolEndpointEntry {
-            base_url: url.to_string(),
-            endpoints: None,
-        },
-    )];
+    let endpoints = vec![(proto, ProtocolEndpointEntry { base_url: url.to_string() })];
     ProviderProtocols {
         default: proto,
         endpoints,

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -55,10 +55,30 @@ async fn build_test_gateway() -> Gateway {
 
 fn all_four_decl() -> ProviderProtocols {
     let endpoints = vec![
-        (OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpointEntry { base_url: "https://chat.example.com".into() }),
-        (OPENAI_RESPONSES_V1, ProtocolEndpointEntry { base_url: "https://responses.example.com".into() }),
-        (ANTHROPIC_MESSAGES_2023_06_01, ProtocolEndpointEntry { base_url: "https://messages.example.com".into() }),
-        (GOOGLE_GENERATE_CONTENT_V1BETA, ProtocolEndpointEntry { base_url: "https://generate.example.com".into() }),
+        (
+            OPENAI_CHAT_COMPLETIONS_V1,
+            ProtocolEndpointEntry {
+                base_url: "https://chat.example.com".into(),
+            },
+        ),
+        (
+            OPENAI_RESPONSES_V1,
+            ProtocolEndpointEntry {
+                base_url: "https://responses.example.com".into(),
+            },
+        ),
+        (
+            ANTHROPIC_MESSAGES_2023_06_01,
+            ProtocolEndpointEntry {
+                base_url: "https://messages.example.com".into(),
+            },
+        ),
+        (
+            GOOGLE_GENERATE_CONTENT_V1BETA,
+            ProtocolEndpointEntry {
+                base_url: "https://generate.example.com".into(),
+            },
+        ),
     ];
     ProviderProtocols {
         default: OPENAI_CHAT_COMPLETIONS_V1,
@@ -67,7 +87,12 @@ fn all_four_decl() -> ProviderProtocols {
 }
 
 fn single_decl(proto: ProtocolId, url: &str) -> ProviderProtocols {
-    let endpoints = vec![(proto, ProtocolEndpointEntry { base_url: url.to_string() })];
+    let endpoints = vec![(
+        proto,
+        ProtocolEndpointEntry {
+            base_url: url.to_string(),
+        },
+    )];
     ProviderProtocols {
         default: proto,
         endpoints,

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -174,8 +174,6 @@ pub struct YamlRoute {
     pub virtual_model: String,
     #[serde(default = "default_strategy")]
     pub strategy: String,
-    #[serde(default = "default_route_type", alias = "type")]
-    pub route_type: String,
     pub targets: Vec<YamlRouteTarget>,
     #[serde(default)]
     pub access_control: bool,
@@ -183,10 +181,6 @@ pub struct YamlRoute {
 
 fn default_strategy() -> String {
     "weighted".to_string()
-}
-
-fn default_route_type() -> String {
-    "chat".to_string()
 }
 
 #[derive(Debug, Deserialize)]
@@ -272,13 +266,6 @@ impl YamlConfig {
             if r.targets.is_empty() {
                 anyhow::bail!("routes[{i}] ({}): at least one target is required", r.name);
             }
-            parse_route_type(&r.route_type).map_err(|_| {
-                anyhow::anyhow!(
-                    "routes[{i}] ({}): unsupported route type '{}', expected chat|embedding",
-                    r.name,
-                    r.route_type
-                )
-            })?;
             for (j, t) in r.targets.iter().enumerate() {
                 if !provider_names.contains(&t.provider.as_str()) {
                     anyhow::bail!(
@@ -424,9 +411,6 @@ pub fn build_routes(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Route> {
                 target_provider: primary.map(|t| t.provider_id.clone()).unwrap_or_default(),
                 target_model: primary.map(|t| t.model.clone()).unwrap_or_default(),
                 access_control: yr.access_control,
-                route_type: parse_route_type(&yr.route_type)
-                    .unwrap_or("chat")
-                    .to_string(),
                 cache_exact_ttl: None,
                 cache_semantic_ttl: None,
                 cache_semantic_threshold: None,
@@ -437,14 +421,6 @@ pub fn build_routes(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Route> {
             }
         })
         .collect()
-}
-
-fn parse_route_type(raw: &str) -> anyhow::Result<&'static str> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "chat" => Ok("chat"),
-        "embedding" => Ok("embedding"),
-        _ => anyhow::bail!("unsupported route type"),
-    }
 }
 
 #[cfg(test)]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -30,7 +30,6 @@ export interface Route {
   target_provider: string;
   target_model: string;
   access_control: boolean;
-  route_type?: "chat" | "embedding";
   cache?: RouteCacheConfig;
   is_enabled: boolean;
   created_at: string;
@@ -224,7 +223,6 @@ export interface CreateRoute {
   target_model: string;
   targets?: CreateRouteTarget[];
   access_control?: boolean;
-  route_type?: "chat" | "embedding";
   cache?: RouteCacheConfig | null;
 }
 
@@ -236,7 +234,6 @@ export interface UpdateRoute {
   target_model?: string;
   targets?: UpsertRouteTarget[];
   access_control?: boolean;
-  route_type?: "chat" | "embedding";
   cache?: RouteCacheConfig | null;
   is_enabled?: boolean;
 }

--- a/webui/src/pages/connect.tsx
+++ b/webui/src/pages/connect.tsx
@@ -94,18 +94,8 @@ function protocolApiPath(protocol: CodeProtocol) {
   return "/v1beta/models/{model}:generateContent";
 }
 
-function protocolApiPathForRoute(protocol: CodeProtocol, routeType: RouteKind) {
-  if (routeType === "embedding") return "/v1/embeddings";
+function protocolApiPathForRoute(protocol: CodeProtocol, _routeType: RouteKind) {
   return protocolApiPath(protocol);
-}
-
-function normalizeRouteType(routeType?: string): RouteKind {
-  return routeType === "embedding" ? "embedding" : "chat";
-}
-
-function routeTypeLabel(routeType: RouteKind, isZh: boolean) {
-  if (routeType === "embedding") return isZh ? "向量路由" : "Embedding";
-  return isZh ? "对话路由" : "Chat";
 }
 
 function jsonText(input: unknown) {
@@ -499,10 +489,7 @@ export default function ConnectPage() {
     [],
   );
 
-  const codeRoutes = useMemo(() => {
-    if (selectedCodeProtocol === "openai-compat") return routes;
-    return routes.filter((route) => normalizeRouteType(route.route_type) === "chat");
-  }, [routes, selectedCodeProtocol]);
+  const codeRoutes = routes;
 
   useEffect(() => {
     if (selectedCodeRouteId && !codeRoutes.some((route) => route.id === selectedCodeRouteId)) {
@@ -541,15 +528,12 @@ export default function ConnectPage() {
   const hasProxyPort = typeof proxyPort === "number" && Number.isFinite(proxyPort) && proxyPort > 0;
   const host = hasProxyPort ? `http://localhost:${proxyPort}` : "http://localhost:<proxy-port>";
   const codeModel = selectedRoute?.virtual_model ?? "gpt-4o";
-  const codeRouteType: RouteKind = normalizeRouteType(selectedRoute?.route_type);
+  const codeRouteType: RouteKind = "chat";
   const codeProtocol = selectedCodeProtocol;
   const selectedCliTool =
     CLI_TOOLS.find((tool) => tool.id === selectedCliToolId) ?? CLI_TOOLS.find((tool) => tool.id === "claude-code")!;
   const selectedCliReady = IS_TAURI ? Boolean(cliReadyStatus[selectedCliTool.id]) : true;
-  const cliRoutes = useMemo(
-    () => routes.filter((route) => normalizeRouteType(route.route_type) === "chat"),
-    [routes],
-  );
+  const cliRoutes = routes;
   const selectedCliRoute = useMemo(
     () => cliRoutes.find((route) => route.id === selectedCliRouteId) ?? null,
     [cliRoutes, selectedCliRouteId],
@@ -849,12 +833,12 @@ export default function ConnectPage() {
                       }}
                     options={cliRoutes.map((route) => ({
                       value: route.id,
-                      label: `${route.name} · ${route.virtual_model} · ${routeTypeLabel(normalizeRouteType(route.route_type), isZh)}`,
+                      label: `${route.name} · ${route.virtual_model}`,
                     }))}
                     placeholder={
                       cliRoutes.length > 0
                         ? (isZh ? "选择路由" : "Select route")
-                        : (isZh ? "请先创建对话路由" : "Create a chat route first")
+                        : (isZh ? "请先创建路由" : "Create a route first")
                     }
                     searchPlaceholder={isZh ? "搜索路由..." : "Search routes..."}
                     emptyText={isZh ? "暂无可选路由" : "No routes available"}
@@ -1081,14 +1065,12 @@ export default function ConnectPage() {
                     onValueChange={setSelectedCodeRouteId}
                     options={codeRoutes.map((route) => ({
                       value: route.id,
-                      label: `${route.name} · ${route.virtual_model} · ${routeTypeLabel(normalizeRouteType(route.route_type), isZh)}`,
+                      label: `${route.name} · ${route.virtual_model}`,
                     }))}
                     placeholder={
                       codeRoutes.length > 0
                         ? (isZh ? "选择路由" : "Select route")
-                        : selectedCodeProtocol === "openai-compat"
-                          ? (isZh ? "请先创建路由" : "Create route first")
-                          : (isZh ? "请先创建对话路由" : "Create a chat route first")
+                        : (isZh ? "请先创建路由" : "Create a route first")
                     }
                     searchPlaceholder={isZh ? "搜索路由..." : "Search routes..."}
                     emptyText={isZh ? "暂无可选路由" : "No routes available"}

--- a/webui/src/pages/routes.tsx
+++ b/webui/src/pages/routes.tsx
@@ -17,7 +17,6 @@ import type {
   UpsertRouteTarget,
 } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
-import { isOpenAiProtocol } from "@/lib/protocol";
 import { ProviderIcon } from "@/components/ui/provider-icon";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -39,7 +38,6 @@ type RouteForm = {
   name: string;
   virtual_model: string;
   strategy: RouteStrategy;
-  route_type: "chat" | "embedding";
   targets: RouteTargetForm[];
   access_control: boolean;
   cache_exact_enabled: boolean;
@@ -59,7 +57,6 @@ const emptyCreate: RouteForm = {
   name: "",
   virtual_model: "",
   strategy: "weighted",
-  route_type: "chat",
   targets: [{ provider_id: "", model: "", weight: 100, priority: 1 }],
   access_control: false,
   cache_exact_enabled: false,
@@ -76,45 +73,8 @@ function strategyLabel(value: RouteStrategy, isZh: boolean) {
   return isZh ? "加权轮询" : "Weighted";
 }
 
-function routeTypeLabel(value: "chat" | "embedding", isZh: boolean) {
-  return value === "embedding" ? (isZh ? "向量路由" : "Embedding") : (isZh ? "对话路由" : "Chat");
-}
-
 function hasProviderModelsEndpoint(provider?: Provider) {
   return Boolean(provider?.models_source?.trim());
-}
-
-function providerSupportsOpenAiEndpoint(provider?: Provider) {
-  if (!provider) return false;
-  const raw = provider.protocol_endpoints?.trim();
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw) as Record<string, { base_url?: string }>;
-      for (const [key, value] of Object.entries(parsed)) {
-        if (isOpenAiProtocol(key) && Boolean(value?.base_url?.trim())) {
-          return true;
-        }
-      }
-    } catch {
-      // ignore invalid json and fallback to legacy protocol/base_url fields
-    }
-  }
-  return isOpenAiProtocol(provider.protocol) && Boolean(provider.base_url.trim());
-}
-
-function normalizeTargetsForRouteType(
-  routeType: "chat" | "embedding",
-  targets: RouteTargetForm[],
-  providerMap: Map<string, Provider>,
-) {
-  if (routeType !== "embedding") return targets;
-  return targets.map((target) => {
-    const provider = providerMap.get(target.provider_id);
-    if (!target.provider_id || providerSupportsOpenAiEndpoint(provider)) {
-      return target;
-    }
-    return { ...target, provider_id: "", model: "" };
-  });
 }
 
 function withCurrentModel(options: string[], current?: string) {
@@ -452,10 +412,6 @@ export default function RoutesPage() {
     () => new Map(providers.map((p) => [p.id, p])),
     [providers],
   );
-  const embeddingProviderOptions = useMemo(
-    () => providerOptions.filter((option) => providerSupportsOpenAiEndpoint(option.provider)),
-    [providerOptions],
-  );
 
   const totalPages = Math.max(1, Math.ceil(routes.length / PAGE_SIZE));
   const pagedRoutes = routes.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
@@ -481,15 +437,12 @@ export default function RoutesPage() {
       name: route.name,
       virtual_model: route.virtual_model,
       strategy: route.strategy ?? "weighted",
-      route_type: route.route_type === "embedding" ? "embedding" : "chat",
       targets,
       access_control: route.access_control,
-      cache_exact_enabled: route.route_type === "embedding" ? false : Boolean(route.cache?.exact),
-      cache_semantic_enabled: route.route_type === "embedding" ? false : Boolean(route.cache?.semantic),
+      cache_exact_enabled: Boolean(route.cache?.exact),
+      cache_semantic_enabled: Boolean(route.cache?.semantic),
       cache_semantic_threshold:
-        route.route_type === "embedding"
-          ? ""
-          : route.cache?.semantic?.threshold != null
+        route.cache?.semantic?.threshold != null
           ? String(route.cache.semantic.threshold)
           : (route.cache?.semantic ? defaultThresholdInput(globalSemanticThreshold) : ""),
     });
@@ -604,30 +557,6 @@ export default function RoutesPage() {
               />
             </div>
             <div className="space-y-2">
-              <FieldLabel>{isZh ? "路由类型" : "Route Type"}</FieldLabel>
-              <Select
-                value={createForm.route_type}
-                onValueChange={(value: "chat" | "embedding") =>
-                  setCreateForm((prev) => ({
-                    ...prev,
-                    route_type: value,
-                    targets: normalizeTargetsForRouteType(value, prev.targets, providerMap),
-                    cache_exact_enabled: value === "embedding" ? false : prev.cache_exact_enabled,
-                    cache_semantic_enabled: value === "embedding" ? false : prev.cache_semantic_enabled,
-                    cache_semantic_threshold: value === "embedding" ? "" : prev.cache_semantic_threshold,
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="chat">{isZh ? "对话路由" : "Chat"}</SelectItem>
-                  <SelectItem value="embedding">{isZh ? "向量路由" : "Embedding"}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
               <FieldLabel>{isZh ? "负载策略" : "Load Strategy"}</FieldLabel>
               <Select
                 value={createForm.strategy}
@@ -660,18 +589,13 @@ export default function RoutesPage() {
                     target={target}
                     strategy={createForm.strategy}
                     isZh={isZh}
-                    providerOptions={createForm.route_type === "embedding" ? embeddingProviderOptions : providerOptions}
+                    providerOptions={providerOptions}
                     providerMap={providerMap}
                     onUpdate={updateCreateTarget}
                     onRemove={removeCreateTarget}
                     disableRemove={createForm.targets.length <= 1}
                   />
                 ))}
-                {createForm.route_type === "embedding" && embeddingProviderOptions.length === 0 && (
-                  <p className="px-1 text-xs text-amber-600">
-                    {isZh ? "没有可用的 OpenAI 协议提供商，无法配置向量路由目标。" : "No providers with OpenAI endpoints are available for embedding routes."}
-                  </p>
-                )}
                 <Button
                   type="button"
                   variant="secondary"
@@ -692,18 +616,17 @@ export default function RoutesPage() {
               switchId="create-route-access-control"
               onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, access_control: checked }))}
             />
-            {createForm.route_type !== "embedding" && (
-              <>
-                {globalExactCacheEnabled && (
-                  <RouteToggleControl
-                    title={isZh ? "精确匹配缓存" : "Exact Cache"}
-                    isZh={isZh}
-                    checked={createForm.cache_exact_enabled}
-                    onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, cache_exact_enabled: checked }))}
-                  />
-                )}
-                {globalSemanticCacheEnabled && (
-                  <>
+            <>
+              {globalExactCacheEnabled && (
+                <RouteToggleControl
+                  title={isZh ? "精确匹配缓存" : "Exact Cache"}
+                  isZh={isZh}
+                  checked={createForm.cache_exact_enabled}
+                  onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, cache_exact_enabled: checked }))}
+                />
+              )}
+              {globalSemanticCacheEnabled && (
+                <>
                     <RouteToggleControl
                       title={isZh ? "语义相似缓存" : "Semantic Cache"}
                       isZh={isZh}
@@ -728,8 +651,7 @@ export default function RoutesPage() {
                     )}
                   </>
                 )}
-              </>
-            )}
+            </>
           </div>
           <div className="flex gap-3">
             <Button
@@ -804,32 +726,6 @@ export default function RoutesPage() {
                       />
                     </div>
                     <div className="space-y-2">
-                      <FieldLabel>{isZh ? "路由类型" : "Route Type"}</FieldLabel>
-                      <Select
-                        value={editForm.route_type}
-                        onValueChange={(value: "chat" | "embedding") =>
-                          setEditForm((prev) => (prev
-                            ? {
-                              ...prev,
-                              route_type: value,
-                              targets: normalizeTargetsForRouteType(value, prev.targets, providerMap),
-                              cache_exact_enabled: value === "embedding" ? false : prev.cache_exact_enabled,
-                              cache_semantic_enabled: value === "embedding" ? false : prev.cache_semantic_enabled,
-                              cache_semantic_threshold: value === "embedding" ? "" : prev.cache_semantic_threshold,
-                            }
-                            : prev))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="chat">{isZh ? "对话路由" : "Chat"}</SelectItem>
-                          <SelectItem value="embedding">{isZh ? "向量路由" : "Embedding"}</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
                       <FieldLabel>{isZh ? "负载策略" : "Load Strategy"}</FieldLabel>
                       <Select
                         value={editForm.strategy}
@@ -862,18 +758,13 @@ export default function RoutesPage() {
                             target={target}
                             strategy={editForm.strategy}
                             isZh={isZh}
-                            providerOptions={editForm.route_type === "embedding" ? embeddingProviderOptions : providerOptions}
+                            providerOptions={providerOptions}
                             providerMap={providerMap}
                             onUpdate={updateEditTarget}
                             onRemove={removeEditTarget}
                             disableRemove={editForm.targets.length <= 1}
                           />
                         ))}
-                        {editForm.route_type === "embedding" && embeddingProviderOptions.length === 0 && (
-                          <p className="px-1 text-xs text-amber-600">
-                            {isZh ? "没有可用的 OpenAI 协议提供商，无法配置向量路由目标。" : "No providers with OpenAI endpoints are available for embedding routes."}
-                          </p>
-                        )}
                         <Button
                           type="button"
                           variant="secondary"
@@ -895,48 +786,46 @@ export default function RoutesPage() {
                         setEditForm((prev) => (prev ? { ...prev, access_control: checked } : prev))
                       }
                     />
-                    {editForm.route_type !== "embedding" && (
-                      <>
-                        {globalExactCacheEnabled && (
+                    <>
+                      {globalExactCacheEnabled && (
+                        <RouteToggleControl
+                          title={isZh ? "精确匹配缓存" : "Exact Cache"}
+                          isZh={isZh}
+                          checked={editForm.cache_exact_enabled}
+                          onCheckedChange={(checked) =>
+                            setEditForm((prev) => (prev ? { ...prev, cache_exact_enabled: checked } : prev))
+                          }
+                        />
+                      )}
+                      {globalSemanticCacheEnabled && (
+                        <>
                           <RouteToggleControl
-                            title={isZh ? "精确匹配缓存" : "Exact Cache"}
+                            title={isZh ? "语义相似缓存" : "Semantic Cache"}
                             isZh={isZh}
-                            checked={editForm.cache_exact_enabled}
-                            onCheckedChange={(checked) =>
-                              setEditForm((prev) => (prev ? { ...prev, cache_exact_enabled: checked } : prev))
-                            }
+                            checked={editForm.cache_semantic_enabled}
+                            onCheckedChange={(checked) => updateEditSemanticEnabled(checked)}
                           />
-                        )}
-                        {globalSemanticCacheEnabled && (
-                          <>
-                            <RouteToggleControl
-                              title={isZh ? "语义相似缓存" : "Semantic Cache"}
-                              isZh={isZh}
-                              checked={editForm.cache_semantic_enabled}
-                              onCheckedChange={(checked) => updateEditSemanticEnabled(checked)}
-                            />
-                            {editForm.cache_semantic_enabled && (
-                              <div className="space-y-2">
-                                <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
-                                <Input
-                                  type="number"
-                                  step="0.01"
-                                  min={0}
-                                  max={1}
-                                  value={editForm.cache_semantic_threshold}
-                                  onChange={(e) =>
-                                    setEditForm((prev) =>
-                                      prev ? { ...prev, cache_semantic_threshold: e.target.value } : prev
-                                    )
-                                  }
-                                  placeholder={defaultThresholdInput(globalSemanticThreshold)}
-                                />
-                              </div>
-                            )}
-                          </>
-                        )}
-                      </>
-                    )}
+                          {editForm.cache_semantic_enabled && (
+                            <div className="space-y-2">
+                              <FieldLabel>{isZh ? "语义相似度" : "Semantic Threshold"}</FieldLabel>
+                              <Input
+                                type="number"
+                                step="0.01"
+                                min={0}
+                                max={1}
+                                value={editForm.cache_semantic_threshold}
+                                onChange={(e) =>
+                                  setEditForm((prev) =>
+                                    prev ? { ...prev, cache_semantic_threshold: e.target.value } : prev
+                                  )
+                                }
+                                placeholder={defaultThresholdInput(globalSemanticThreshold)}
+                              />
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </>
                   </div>
                   <div className="flex gap-3">
                     <Button
@@ -991,16 +880,6 @@ export default function RoutesPage() {
                     >
                       {strategyLabel(route.strategy ?? "weighted", isZh)}
                     </Badge>
-                    <Badge
-                      variant="secondary"
-                      className={
-                        route.route_type === "embedding"
-                          ? "connect-label-badge bg-violet-50 text-violet-700"
-                          : "connect-label-badge bg-emerald-50 text-emerald-700"
-                      }
-                    >
-                      {routeTypeLabel(route.route_type === "embedding" ? "embedding" : "chat", isZh)}
-                    </Badge>
                     {route.access_control && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? "鉴权" : "Auth"}
@@ -1049,22 +928,7 @@ export default function RoutesPage() {
                     <Pencil className="h-4 w-4" />
                   </button>
                   <button
-                    onClick={() => {
-                      if (
-                        route.route_type === "embedding" &&
-                        cacheSettings?.semantic?.enabled &&
-                        cacheSettings.semantic.embedding_route === route.virtual_model
-                      ) {
-                        setErrorDialog({
-                          title: isZh ? "无法删除该路由" : "Cannot delete this route",
-                          description: isZh
-                            ? `该 Embedding 路由「${route.name}」正被系统设置中的语义相似缓存引用，请先在系统设置中关闭语义相似缓存或更换 Embedding 路由后再删除。`
-                            : `The embedding route "${route.name}" is referenced by semantic cache in system settings. Please disable semantic cache or change the embedding route in settings before deleting.`,
-                        });
-                        return;
-                      }
-                      setRouteToDelete(route);
-                    }}
+                    onClick={() => setRouteToDelete(route)}
                     className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
                   >
                     <Trash2 className="h-4 w-4" />
@@ -1165,7 +1029,6 @@ function buildCreatePayload(form: RouteForm): CreateRoute {
     name: form.name.trim(),
     virtual_model: form.virtual_model.trim(),
     strategy: form.strategy,
-    route_type: form.route_type,
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,
@@ -1187,7 +1050,6 @@ function buildUpdatePayload(form: RouteForm & { id: string }): UpdateRoute {
     name: form.name.trim(),
     virtual_model: form.virtual_model.trim(),
     strategy: form.strategy,
-    route_type: form.route_type,
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,
@@ -1197,9 +1059,6 @@ function buildUpdatePayload(form: RouteForm & { id: string }): UpdateRoute {
 }
 
 function buildRouteCacheConfig(form: RouteForm): RouteCacheConfig {
-  if (form.route_type === "embedding") {
-    return {};
-  }
   const cache: RouteCacheConfig = {};
   const semanticThreshold = parseOptionalFloat(form.cache_semantic_threshold);
 

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -131,8 +131,7 @@ export default function SettingsPage() {
       expose_headers: true,
     },
   });
-  const embeddingRoutes = routes.filter((route) => route.route_type === "embedding");
-  const selectedEmbeddingRouteExists = embeddingRoutes.some(
+  const selectedEmbeddingRouteExists = routes.some(
     (route) => route.virtual_model === cacheForm.semantic.embedding_route,
   );
   const exactCacheDirty = cacheSettings
@@ -546,7 +545,7 @@ export default function SettingsPage() {
                     />
                   </SelectTrigger>
                   <SelectContent>
-                    {embeddingRoutes.map((route) => (
+                    {routes.map((route) => (
                       <SelectItem key={route.id} value={route.virtual_model}>
                         {route.name} · {route.virtual_model}
                       </SelectItem>
@@ -554,13 +553,13 @@ export default function SettingsPage() {
                     {!selectedEmbeddingRouteExists && cacheForm.semantic.embedding_route.trim() && (
                       <SelectItem value={cacheForm.semantic.embedding_route}>
                         {isZh
-                          ? `当前值（未匹配到 embedding 路由）: ${cacheForm.semantic.embedding_route}`
-                          : `Current value (not an embedding route): ${cacheForm.semantic.embedding_route}`}
+                          ? `当前值（路由不存在）: ${cacheForm.semantic.embedding_route}`
+                          : `Current value (route not found): ${cacheForm.semantic.embedding_route}`}
                       </SelectItem>
                     )}
-                    {embeddingRoutes.length === 0 && (
+                    {routes.length === 0 && (
                       <SelectItem value="__empty__" disabled>
-                        {isZh ? "暂无向量路由" : "No embedding routes"}
+                        {isZh ? "暂无路由" : "No routes configured"}
                       </SelectItem>
                     )}
                   </SelectContent>


### PR DESCRIPTION
- Drop routes.route_type from DB schema (SQLite/Postgres), models, storage SQL, YAML config, and all admin/dispatcher logic
- Remove is_embedding_route / normalized_route_type helpers and the embedding-vs-chat gate in dispatch_pipeline; routes now accept any ingress protocol without type gating
- Allow cache config on all routes (previously blocked for embedding type)
- detect_embedding_dimensions no longer requires route_type=embedding; try-call /v1/embeddings directly on any route
- Semantic cache route validation simplified to existence check only
- Remove ProtocolEndpointEntry.endpoints subset field; normalize_endpoints_json now emits protocol→{base_url} only; from_provider expands all endpoints for a declared protocol unconditionally
- WebUI: remove Route Type dropdown, type badge, embedding-only provider filter; settings embedding_routdropdown lists all routes; connect page shows all routes without chat/embedding split
- Add DROP COLUMN migrations for both SQLite and Postgres (idempotent)