### PR TITLE
followup: deprecation warnings, tests, and doc cleanup

### DIFF
--- a/crates/nyro-core/tests/protocol_endpoints_normalize.rs
+++ b/crates/nyro-core/tests/protocol_endpoints_normalize.rs
@@ -1,0 +1,135 @@
+//! Tests for `ProtocolRegistry::normalize_endpoints_json`.
+//!
+//! Guarantees:
+//! 1. Endpoint-keyed (old) keys are promoted to protocol-keyed (new) form.
+//! 2. Legacy `endpoints` sub-array inside an entry is stripped; only `base_url` survives.
+//! 3. Already-canonical protocol keys are preserved as-is.
+//! 4. Duplicate keys (same protocol, two aliases) keep the first `base_url`.
+//! 5. Empty / `{}` input passes through unchanged.
+
+use nyro_core::protocol::registry::ProtocolRegistry;
+use serde_json::json;
+
+fn reg() -> &'static ProtocolRegistry {
+    ProtocolRegistry::global()
+}
+
+fn normalize(input: &serde_json::Value) -> serde_json::Value {
+    let s = input.to_string();
+    let out = reg().normalize_endpoints_json(&s);
+    serde_json::from_str(&out).expect("normalize must produce valid JSON")
+}
+
+#[test]
+fn endpoint_keyed_old_format_converts_to_protocol_keyed() {
+    // Old DB rows used endpoint-id keys like "openai/chat/v1".
+    // After normalization they should appear under the protocol short-name.
+    let input = json!({
+        "openai/chat/v1": { "base_url": "https://a.example/v1" },
+        "anthropic/messages/2023-06-01": { "base_url": "https://b.example/v1" },
+    });
+    let out = normalize(&input);
+    let obj = out.as_object().expect("result must be an object");
+    assert!(
+        obj.contains_key("openai-compat"),
+        "openai-compat key expected"
+    );
+    assert!(
+        obj.contains_key("anthropic-msgs"),
+        "anthropic-msgs key expected"
+    );
+    assert_eq!(
+        obj["openai-compat"]["base_url"].as_str().unwrap(),
+        "https://a.example/v1"
+    );
+    assert_eq!(
+        obj["anthropic-msgs"]["base_url"].as_str().unwrap(),
+        "https://b.example/v1"
+    );
+}
+
+#[test]
+fn legacy_endpoints_array_is_stripped() {
+    // Prior to Q2, entries could carry an `endpoints` sub-array that restricted
+    // which API operations were supported. That field has been removed; only
+    // `base_url` must survive normalization.
+    let input = json!({
+        "openai-compat": {
+            "base_url": "https://a.example/v1",
+            "endpoints": ["chat-completions", "embeddings"]
+        }
+    });
+    let out = normalize(&input);
+    let entry = &out["openai-compat"];
+    assert!(entry.is_object(), "entry must be an object");
+    assert_eq!(
+        entry["base_url"].as_str().unwrap(),
+        "https://a.example/v1",
+        "base_url must be preserved"
+    );
+    assert!(
+        entry.get("endpoints").is_none(),
+        "endpoints array must be stripped after Q2"
+    );
+}
+
+#[test]
+fn already_canonical_protocol_keys_are_preserved() {
+    let input = json!({
+        "openai-compat": { "base_url": "https://a.example/v1" },
+        "anthropic-msgs": { "base_url": "https://b.example/v1" },
+        "google-genai": { "base_url": "https://c.example/v1" },
+    });
+    let out = normalize(&input);
+    let obj = out.as_object().expect("object");
+    assert!(obj.contains_key("openai-compat"));
+    assert!(obj.contains_key("anthropic-msgs"));
+    assert!(obj.contains_key("google-genai"));
+}
+
+#[test]
+fn empty_and_empty_object_pass_through_unchanged() {
+    assert_eq!(reg().normalize_endpoints_json(""), "");
+    assert_eq!(reg().normalize_endpoints_json("{}"), "{}");
+}
+
+#[test]
+fn duplicate_aliases_for_same_protocol_keep_first_base_url() {
+    // "openai-chat" and "openai/chat/v1" both resolve to the same protocol
+    // endpoint. Only the first `base_url` should survive.
+    let input = json!({
+        "openai-chat": { "base_url": "https://first.example/v1" },
+        "openai/chat/v1": { "base_url": "https://second.example/v1" },
+    });
+    let out = normalize(&input);
+    let obj = out.as_object().expect("object");
+    let entry = obj.get("openai-compat").expect("openai-compat key present");
+    assert_eq!(
+        entry["base_url"].as_str().unwrap(),
+        "https://first.example/v1",
+        "first base_url must win on duplicate"
+    );
+    // Exactly one openai-compat key.
+    let count = obj.keys().filter(|k| *k == "openai-compat").count();
+    assert_eq!(count, 1, "no duplicate protocol keys after normalization");
+}
+
+#[test]
+fn short_aliases_resolve_correctly() {
+    // "openai", "claude", "gemini" are tier-3 legacy brand aliases.
+    let input = json!({
+        "openai":   { "base_url": "https://a.example/v1" },
+        "claude":   { "base_url": "https://b.example/v1" },
+        "gemini":   { "base_url": "https://c.example/v1" },
+        "responses":{ "base_url": "https://d.example/v1" },
+    });
+    let out = normalize(&input);
+    let obj = out.as_object().expect("object");
+    assert!(obj.contains_key("openai-compat"), "openai → openai-compat");
+    assert!(
+        obj.contains_key("anthropic-msgs"),
+        "claude → anthropic-msgs"
+    );
+    assert!(obj.contains_key("google-genai"), "gemini → google-genai");
+    assert!(obj.contains_key("openai-resps"), "responses → openai-resps");
+}

--- a/crates/nyro-core/tests/protocol_gate.rs
+++ b/crates/nyro-core/tests/protocol_gate.rs
@@ -1,0 +1,171 @@
+//! Tests confirming the dispatcher-level route-type gate has been removed (Q2).
+//!
+//! Before Q2, routes carried a `route_type` field and the dispatcher rejected
+//! embedding requests on "chat" routes (and vice-versa). That gate no longer
+//! exists at the DB / protocol-negotiation layer. These tests document the new
+//! invariants:
+//!
+//! 1. A provider declaring the `openai-compat` *protocol* suite automatically
+//!    exposes **all** endpoints in that suite — including embeddings — without
+//!    any subset filtering.
+//! 2. A provider that only stores an endpoint-keyed entry (`"openai/chat/v1"`)
+//!    exposes that single endpoint; embeddings are resolved via the normal
+//!    three-tier fallback (no hard rejection).
+//! 3. `ProtocolEndpointEntry` carries only `base_url`; the removed `endpoints`
+//!    field is never present.
+
+use nyro_core::db::models::Provider;
+use nyro_core::protocol::ProviderProtocols;
+use nyro_core::protocol::ids::{
+    OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+};
+use serde_json::json;
+
+fn provider(default_protocol: &str, endpoints: serde_json::Value) -> Provider {
+    Provider {
+        id: "p".to_string(),
+        name: "p".to_string(),
+        vendor: None,
+        protocol: String::new(),
+        base_url: String::new(),
+        default_protocol: default_protocol.to_string(),
+        protocol_endpoints: serde_json::to_string(&endpoints).unwrap(),
+        preset_key: None,
+        channel: None,
+        models_source: None,
+        static_models: None,
+        api_key: String::new(),
+        auth_mode: "apikey".to_string(),
+        use_proxy: false,
+        last_test_success: None,
+        last_test_at: None,
+        is_enabled: true,
+        created_at: String::new(),
+        updated_at: String::new(),
+    }
+}
+
+/// A provider declaring the `openai-compat` protocol *suite* must expose every
+/// endpoint registered under that suite, including embeddings.
+#[test]
+fn openai_compat_protocol_suite_includes_embeddings() {
+    let p = provider(
+        "openai-compat",
+        json!({ "openai-compat": { "base_url": "https://a.example/v1" } }),
+    );
+    let pp = ProviderProtocols::from_provider(&p);
+
+    assert!(
+        pp.supports(OPENAI_CHAT_COMPLETIONS_V1),
+        "chat-completions must be included in openai-compat suite"
+    );
+    assert!(
+        pp.supports(OPENAI_EMBEDDINGS_V1),
+        "embeddings must be included in openai-compat suite"
+    );
+}
+
+/// When `endpoints` noise is present in a protocol-suite entry (legacy YAML or
+/// DB data), it must be ignored; all endpoints in the suite are still included.
+#[test]
+fn legacy_endpoints_array_noise_does_not_restrict_suite() {
+    let p = provider(
+        "openai-compat",
+        json!({
+            "openai-compat": {
+                "base_url": "https://a.example/v1",
+                // This field no longer restricts which endpoints are supported.
+                "endpoints": ["chat-completions"]
+            }
+        }),
+    );
+    let pp = ProviderProtocols::from_provider(&p);
+
+    assert!(
+        pp.supports(OPENAI_EMBEDDINGS_V1),
+        "embeddings must be supported despite legacy endpoints array"
+    );
+    let entry = pp
+        .get(OPENAI_CHAT_COMPLETIONS_V1)
+        .expect("chat-completions present");
+    assert_eq!(
+        entry.base_url, "https://a.example/v1",
+        "base_url extracted correctly"
+    );
+}
+
+/// `parse_protocol` resolves any endpoint-id key to its parent `Protocol`, so
+/// even a single endpoint-keyed entry triggers full protocol-suite expansion.
+/// `"openai/chat/v1"` belongs to `OpenAICompatible`, so embeddings is included.
+#[test]
+fn endpoint_keyed_format_expands_to_full_protocol_suite() {
+    let p = provider(
+        "openai/chat/v1",
+        json!({ "openai/chat/v1": { "base_url": "https://a.example/v1" } }),
+    );
+    let pp = ProviderProtocols::from_provider(&p);
+
+    // parse_protocol("openai/chat/v1") → Protocol::OpenAICompatible → suite expansion
+    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
+    assert!(
+        pp.supports(OPENAI_EMBEDDINGS_V1),
+        "endpoint-keyed key triggers suite expansion; embeddings included"
+    );
+
+    // Embeddings resolves directly (Tier 1 — exact match after expansion).
+    let resolved = pp.resolve_egress(OPENAI_EMBEDDINGS_V1);
+    assert_eq!(resolved.protocol, OPENAI_EMBEDDINGS_V1);
+    assert!(!resolved.needs_conversion);
+    assert_eq!(resolved.base_url, "https://a.example/v1");
+}
+
+/// `"openai/embeddings/v1"` also belongs to `OpenAICompatible`, so the full
+/// suite (chat + embeddings) is included — no separate "embeddings-only" mode.
+#[test]
+fn embeddings_endpoint_key_also_expands_to_full_openai_compat_suite() {
+    let p = provider(
+        "openai/embeddings/v1",
+        json!({ "openai/embeddings/v1": { "base_url": "https://a.example/v1" } }),
+    );
+    let pp = ProviderProtocols::from_provider(&p);
+
+    // Both chat and embeddings present after suite expansion.
+    assert!(pp.supports(OPENAI_EMBEDDINGS_V1));
+    assert!(
+        pp.supports(OPENAI_CHAT_COMPLETIONS_V1),
+        "chat-completions included via OpenAICompatible suite expansion"
+    );
+
+    // Chat resolves directly with no conversion needed.
+    let resolved = pp.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
+    assert_eq!(resolved.protocol, OPENAI_CHAT_COMPLETIONS_V1);
+    assert!(!resolved.needs_conversion);
+}
+
+/// Two different protocol suites declared — embeddings comes from openai-compat;
+/// responses from openai-resps — no cross-suite collision.
+#[test]
+fn multi_suite_provider_supports_all_declared_endpoints() {
+    let p = provider(
+        "openai-compat",
+        json!({
+            "openai-compat": { "base_url": "https://compat.example/v1" },
+            "openai-resps":  { "base_url": "https://resps.example/v1" },
+        }),
+    );
+    let pp = ProviderProtocols::from_provider(&p);
+
+    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
+    assert!(pp.supports(OPENAI_EMBEDDINGS_V1));
+    assert!(pp.supports(OPENAI_RESPONSES_V1));
+
+    // Embeddings uses the openai-compat base_url.
+    let emb = pp.get(OPENAI_EMBEDDINGS_V1).expect("embeddings present");
+    assert_eq!(emb.base_url, "https://compat.example/v1");
+
+    // Responses uses the openai-resps base_url.
+    let resp = pp.resolve_egress(OPENAI_RESPONSES_V1);
+    assert_eq!(resp.protocol, OPENAI_RESPONSES_V1);
+    assert!(!resp.needs_conversion);
+    assert_eq!(resp.base_url, "https://resps.example/v1");
+}

--- a/docs/standalone/README.md
+++ b/docs/standalone/README.md
@@ -71,7 +71,6 @@ routes:
 
   - name: text-embedding-3-small
     vmodel: text-embedding-3-small
-    type: embedding
     targets:
       - provider: openai
         model: text-embedding-3-small

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -110,6 +110,9 @@ struct YamlProviderRaw {
     pub models_source: Option<String>,
     #[serde(default)]
     pub static_models: Option<Vec<String>>,
+    // Deprecated: capabilities_source was removed; captured here only to emit a warning.
+    #[serde(default)]
+    pub capabilities_source: Option<serde_json::Value>,
 }
 
 impl TryFrom<YamlProviderRaw> for YamlProvider {
@@ -138,6 +141,13 @@ impl TryFrom<YamlProviderRaw> for YamlProvider {
                 return Err(format!("provider '{}': 'api_key' is required", r.name));
             }
         };
+        if r.capabilities_source.is_some() {
+            tracing::warn!(
+                provider = %r.name,
+                "YAML field 'capabilities_source' is no longer supported and will be ignored; \
+                 remove it from your config file"
+            );
+        }
         Ok(YamlProvider {
             name: r.name,
             vendor: r.vendor,
@@ -177,6 +187,9 @@ pub struct YamlRoute {
     pub targets: Vec<YamlRouteTarget>,
     #[serde(default)]
     pub access_control: bool,
+    // Deprecated: route_type / type was removed; captured here only to emit a warning.
+    #[serde(default, alias = "type")]
+    pub route_type: Option<String>,
 }
 
 fn default_strategy() -> String {
@@ -259,6 +272,13 @@ impl YamlConfig {
         for (i, r) in self.routes.iter().enumerate() {
             if r.name.trim().is_empty() {
                 anyhow::bail!("routes[{i}]: name is required");
+            }
+            if r.route_type.is_some() {
+                tracing::warn!(
+                    route = %r.name,
+                    "YAML field 'type' (route_type) is no longer supported and will be ignored; \
+                     remove it from your config file"
+                );
             }
             if r.virtual_model.trim().is_empty() {
                 anyhow::bail!("routes[{i}] ({}): virtual_model is required", r.name);
@@ -582,15 +602,24 @@ providers:
         let providers = build_providers(&cfg);
         assert_eq!(providers.len(), 1);
         let p = &providers[0];
-        assert_eq!(p.protocol, "openai/chat/v1");
-        assert_eq!(p.default_protocol, "openai/chat/v1");
+        // Canonical IDs now use `<protocol-short>/<name>/<version>` form.
+        assert_eq!(p.protocol, "openai-compat/chat-completions/v1");
+        assert_eq!(p.default_protocol, "openai-compat/chat-completions/v1");
         let endpoints: serde_json::Value =
             serde_json::from_str(&p.protocol_endpoints).expect("valid json");
         let obj = endpoints.as_object().expect("object");
-        assert!(obj.contains_key("openai/chat/v1"));
-        assert!(obj.contains_key("anthropic/messages/2023-06-01"));
-        assert!(!obj.contains_key("openai"));
-        assert!(!obj.contains_key("anthropic"));
+        // build_providers canonicalizes via resolve_alias → ProtocolEndpoint::to_string,
+        // so keys are full canonical endpoint IDs.
+        assert!(
+            obj.contains_key("openai-compat/chat-completions/v1"),
+            "expected openai-compat/chat-completions/v1 key"
+        );
+        assert!(
+            obj.contains_key("anthropic-msgs/messages/2023-06-01"),
+            "expected anthropic-msgs/messages/2023-06-01 key"
+        );
+        assert!(!obj.contains_key("openai"), "raw alias must not appear");
+        assert!(!obj.contains_key("anthropic"), "raw alias must not appear");
     }
 
     #[test]
@@ -610,5 +639,100 @@ providers:
             err.contains("protocol 'gemini'") && err.contains("no matching endpoint"),
             "unexpected error: {err}"
         );
+    }
+
+    // ── Deprecated field acceptance ────────────────────────────────────────────
+
+    #[test]
+    fn deprecated_route_type_field_is_silently_parsed() {
+        // `type` / `route_type` was removed in Q2. Existing YAML configs that
+        // still carry this field must parse and validate without error, and must
+        // produce the same `Route` output as configs without it.
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+routes:
+  - name: embeddings
+    vmodel: text-embedding-3-small
+    type: embedding
+    targets:
+      - provider: openai
+        model: text-embedding-3-small
+  - name: chat
+    vmodel: gpt-4o
+    route_type: chat
+    targets:
+      - provider: openai
+        model: gpt-4o
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate()
+            .expect("validate must succeed for deprecated type field");
+        assert_eq!(cfg.routes.len(), 2);
+
+        let providers = build_providers(&cfg);
+        let routes = build_routes(&cfg, &providers);
+        assert_eq!(routes.len(), 2);
+        // Both routes are built correctly; route_type is not propagated.
+        assert_eq!(routes[0].name, "embeddings");
+        assert_eq!(routes[1].name, "chat");
+    }
+
+    #[test]
+    fn deprecated_capabilities_source_field_is_silently_parsed() {
+        // `capabilities_source` was removed in Q3. Configs that still carry it
+        // must parse and validate without error; the field is not propagated.
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+    capabilities_source: models.dev
+routes:
+  - name: chat
+    vmodel: gpt-4o
+    targets:
+      - provider: openai
+        model: gpt-4o
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate()
+            .expect("validate must succeed for deprecated capabilities_source");
+
+        let providers = build_providers(&cfg);
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].name, "openai");
+    }
+
+    #[test]
+    fn both_deprecated_fields_together_are_accepted() {
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+    capabilities_source: http
+routes:
+  - name: embeddings
+    vmodel: text-embedding-3-small
+    type: embedding
+    targets:
+      - provider: openai
+        model: text-embedding-3-small
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        let providers = build_providers(&cfg);
+        let routes = build_routes(&cfg, &providers);
+        assert_eq!(providers.len(), 1);
+        assert_eq!(routes.len(), 1);
     }
 }


### PR DESCRIPTION
- Warn on deprecated YAML fields: `capabilities_source` (provider) and `type`/`route_type` (route) are captured and silently ignored; a `tracing::warn` is emitted at startup to guide config migration

- Add integration tests:
  - tests/protocol_gate.rs: documents openai-compat suite expansion (any endpoint-keyed or protocol-keyed OpenAICompatible entry expands to chat-completions + embeddings; no type-gate rejection)
  - tests/protocol_endpoints_normalize.rs: covers normalize_endpoints_json format conversion, endpoints array stripping, duplicate key handling

- Fix stale assertions in yaml_config tests: update canonical ID strings from legacy `openai/chat/v1` to `openai-compat/chat-completions/v1`

- docs/standalone/README.md: remove deprecated `type: embedding` from example YAML config