### PR TITLE
fix(openai-responses): preserve input_tokens across streaming usage deltas

### DIFF
--- a/crates/nyro-core/src/protocol/codec/openai_responses/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/stream.rs
@@ -399,7 +399,21 @@ impl StreamFormatter for ResponsesStreamFormatter {
                     }
                 }
                 StreamDelta::Usage(u) => {
-                    self.usage = u.clone();
+                    if u.input_tokens > 0 {
+                        self.usage.input_tokens = u.input_tokens;
+                    }
+                    if u.output_tokens > 0 {
+                        self.usage.output_tokens = u.output_tokens;
+                    }
+                    if u.cache_read_input_tokens.is_some() {
+                        self.usage.cache_read_input_tokens = u.cache_read_input_tokens;
+                    }
+                    if u.cache_creation_input_tokens.is_some() {
+                        self.usage.cache_creation_input_tokens = u.cache_creation_input_tokens;
+                    }
+                    if u.server_tool_use.is_some() {
+                        self.usage.server_tool_use = u.server_tool_use.clone();
+                    }
                 }
                 StreamDelta::RawEvent { .. } => {}
                 StreamDelta::Done { .. } => {


### PR DESCRIPTION
## Summary

Streamed `openai/responses` ingress → `anthropic/messages` egress requests were landing in `request_logs` with `input_tokens = 0` while `output_tokens` was correct. Verified on a dev instance: all 3803 streamed rows on this protocol pair had `input_tokens = 0`; non-streamed rows on the same pair were fine.

## Root cause

`ResponsesStreamFormatter` in `crates/nyro-core/src/protocol/codec/openai_responses/stream.rs` was assigning `self.usage = u.clone()` on every `StreamDelta::Usage`, wholesale-overwriting whatever was already there.

Anthropic SSE reports usage in two separate events:
- `message_start.usage` carries the real `input_tokens` (and cache fields).
- `message_delta.usage` carries the final `output_tokens`, with `input_tokens: 0`.

So the later delta clobbered the earlier one and the formatter ended with `input_tokens = 0`. The dispatcher fallback at `proxy/dispatcher/mod.rs:1546` only kicks in when **both** `input_tokens` and `output_tokens` are 0, which is exactly the case this bug doesn't produce — so it never recovered.

## Fix

Mirror the selective-merge already used by `AnthropicStreamFormatter` (`crates/nyro-core/src/protocol/codec/anthropic_messages/stream.rs:574-589`): only assign each `Usage` field when the incoming value is non-zero / non-None. One file, +15/-1.

## Test plan

- [x] Built and deployed to a dev instance.
- [x] Issued a streamed `POST /v1/responses` against a route whose target speaks `anthropic/messages` upstream.
- [x] Confirmed the final SSE `response.completed` event reports `usage.input_tokens > 0`.
- [x] Confirmed `request_logs` row for the same request has `input_tokens > 0, output_tokens > 0, is_stream = 1`.
- [ ] Reviewer: consider whether to add a unit test in `openai_responses/stream.rs` that feeds the two-step Anthropic usage sequence and asserts merged result. (Did not include here to keep the patch minimal — happy to add if preferred.)

Historical rows already in `request_logs` cannot be back-filled; this fix is forward-only.