### PR TITLE
feat(ir): PR-1 IR type reshape — ContentBlock expansion, AiError, CacheControl, ProtocolExt

### DIFF
--- a/crates/nyro-core/src/protocol/ir/cache.rs
+++ b/crates/nyro-core/src/protocol/ir/cache.rs
@@ -1,0 +1,58 @@
+//! Cache control types for prompt caching.
+//!
+//! `CacheControl` is carried on `ContentBlock` variants that support it.
+//! The egress encoder translates it into the wire format expected by the target
+//! protocol (Anthropic per-block `cache_control`, OpenAI `prompt_cache_retention`,
+//! or Google `cachedContent` resource reference).
+
+use serde::{Deserialize, Serialize};
+
+/// Cache time-to-live hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheTtl {
+    /// 5-minute ephemeral cache (Anthropic default for `type = "ephemeral"`).
+    Ephemeral5m,
+    /// 1-hour extended ephemeral cache (Anthropic `ttl = "1h"`).
+    Ephemeral1h,
+}
+
+impl Default for CacheTtl {
+    fn default() -> Self {
+        Self::Ephemeral5m
+    }
+}
+
+/// Per-block cache control breakpoint.
+///
+/// Placed on a `ContentBlock` by the ingress decoder when the client explicitly
+/// requests a cache breakpoint at that position (e.g. Anthropic `cache_control`
+/// field).  The encoder decides how to translate this into the wire format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheControl {
+    pub ttl: CacheTtl,
+    /// Priority for multi-breakpoint injection ordering (0 = lowest / injected last).
+    pub breakpoint_priority: u8,
+}
+
+impl Default for CacheControl {
+    fn default() -> Self {
+        Self {
+            ttl: CacheTtl::default(),
+            breakpoint_priority: 0,
+        }
+    }
+}
+
+impl CacheControl {
+    pub fn ephemeral() -> Self {
+        Self::default()
+    }
+
+    pub fn ephemeral_1h() -> Self {
+        Self {
+            ttl: CacheTtl::Ephemeral1h,
+            breakpoint_priority: 0,
+        }
+    }
+}

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -216,15 +216,24 @@ fn block_to_old(b: ContentBlock) -> Option<OldContentBlock> {
             }),
             _ => None,
         },
-        ContentBlock::Thinking { thinking, signature } => {
-            Some(OldContentBlock::Reasoning { text: thinking, signature })
-        }
-        ContentBlock::ToolUse { id, name, input, .. } => {
-            Some(OldContentBlock::ToolUse { id, name, input })
-        }
-        ContentBlock::ToolResult { tool_use_id, content, .. } => {
-            Some(OldContentBlock::ToolResult { tool_use_id, content })
-        }
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => Some(OldContentBlock::Reasoning {
+            text: thinking,
+            signature,
+        }),
+        ContentBlock::ToolUse {
+            id, name, input, ..
+        } => Some(OldContentBlock::ToolUse { id, name, input }),
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            ..
+        } => Some(OldContentBlock::ToolResult {
+            tool_use_id,
+            content,
+        }),
         // New variants not representable in old IR are dropped.
         _ => None,
     }

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -9,8 +9,8 @@
 //! lossless for all fields present in `InternalRequest`.
 
 use crate::protocol::ir::request::{
-    AiRequest, ContentBlock, GenerationConfig, Message, MessageContent, Role, StreamConfig,
-    ToolCall, ToolSpec,
+    AiRequest, ContentBlock, GenerationConfig, MediaSource, Message, MessageContent, Role,
+    StreamConfig, ToolCall, ToolSpec,
 };
 use crate::protocol::ir::response::AiResponse;
 use crate::protocol::types::{
@@ -87,21 +87,35 @@ fn content_from_old(c: OldMessageContent) -> MessageContent {
 
 fn block_from_old(b: OldContentBlock) -> ContentBlock {
     match b {
-        OldContentBlock::Text { text } => ContentBlock::Text { text },
-        OldContentBlock::Image { source } => ContentBlock::Image {
-            media_type: source.media_type,
-            data: source.data,
+        OldContentBlock::Text { text } => ContentBlock::Text {
+            text,
+            cache_control: None,
         },
-        OldContentBlock::Reasoning { text, signature } => {
-            ContentBlock::Reasoning { text, signature }
-        }
-        OldContentBlock::ToolUse { id, name, input } => ContentBlock::ToolUse { id, name, input },
+        OldContentBlock::Image { source } => ContentBlock::Image {
+            source: MediaSource::Base64 {
+                media_type: source.media_type,
+                data: source.data,
+            },
+            cache_control: None,
+        },
+        OldContentBlock::Reasoning { text, signature } => ContentBlock::Thinking {
+            thinking: text,
+            signature,
+        },
+        OldContentBlock::ToolUse { id, name, input } => ContentBlock::ToolUse {
+            id,
+            name,
+            input,
+            cache_control: None,
+        },
         OldContentBlock::ToolResult {
             tool_use_id,
             content,
         } => ContentBlock::ToolResult {
             tool_use_id,
             content,
+            is_error: None,
+            cache_control: None,
         },
     }
 }
@@ -119,6 +133,8 @@ fn tool_spec_from_old(td: ToolDef) -> ToolSpec {
         name: td.name,
         description: td.description,
         parameters: td.parameters,
+        strict: None,
+        cache_control: None,
         meta: None,
     }
 }
@@ -193,24 +209,24 @@ fn content_to_old(c: MessageContent) -> OldMessageContent {
 
 fn block_to_old(b: ContentBlock) -> Option<OldContentBlock> {
     match b {
-        ContentBlock::Text { text } => Some(OldContentBlock::Text { text }),
-        ContentBlock::Image { media_type, data } => Some(OldContentBlock::Image {
-            source: crate::protocol::types::ImageSource { media_type, data },
-        }),
-        ContentBlock::Reasoning { text, signature } => {
-            Some(OldContentBlock::Reasoning { text, signature })
+        ContentBlock::Text { text, .. } => Some(OldContentBlock::Text { text }),
+        ContentBlock::Image { source, .. } => match source {
+            MediaSource::Base64 { media_type, data } => Some(OldContentBlock::Image {
+                source: crate::protocol::types::ImageSource { media_type, data },
+            }),
+            _ => None,
+        },
+        ContentBlock::Thinking { thinking, signature } => {
+            Some(OldContentBlock::Reasoning { text: thinking, signature })
         }
-        ContentBlock::ToolUse { id, name, input } => {
+        ContentBlock::ToolUse { id, name, input, .. } => {
             Some(OldContentBlock::ToolUse { id, name, input })
         }
-        ContentBlock::ToolResult {
-            tool_use_id,
-            content,
-        } => Some(OldContentBlock::ToolResult {
-            tool_use_id,
-            content,
-        }),
-        ContentBlock::Unknown { .. } => None,
+        ContentBlock::ToolResult { tool_use_id, content, .. } => {
+            Some(OldContentBlock::ToolResult { tool_use_id, content })
+        }
+        // New variants not representable in old IR are dropped.
+        _ => None,
     }
 }
 
@@ -273,7 +289,7 @@ impl From<AiResponse> for InternalResponse {
                     crate::protocol::ir::response::ResponseItem::OutputText { text } => {
                         Some(crate::protocol::types::ResponseItem::Message { text })
                     }
-                    crate::protocol::ir::response::ResponseItem::Reasoning { text } => {
+                    crate::protocol::ir::response::ResponseItem::Thinking { text } => {
                         Some(crate::protocol::types::ResponseItem::Reasoning { text })
                     }
                     crate::protocol::ir::response::ResponseItem::FunctionCall {

--- a/crates/nyro-core/src/protocol/ir/error.rs
+++ b/crates/nyro-core/src/protocol/ir/error.rs
@@ -1,0 +1,158 @@
+//! `AiError` / `AiErrorKind` — unified cross-protocol error IR.
+//!
+//! All codec parsers and the dispatcher normalize upstream errors to `AiError`.
+//! The `AiErrorKind::is_retryable()` method drives retry and circuit-breaker
+//! decisions in the dispatcher (PR-5).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt;
+
+/// Normalized error classification across all supported LLM protocols.
+///
+/// Use `is_retryable()` to determine whether the gateway may automatically
+/// retry a request after receiving this error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiErrorKind {
+    /// 401 — invalid API key or expired token.
+    AuthenticationError,
+    /// 403 — account lacks permission for the requested operation.
+    AuthorizationError,
+    /// 404 — model or resource not found.
+    NotFoundError,
+    /// 429 (rate-limit) — requests-per-minute or tokens-per-minute exceeded.
+    RateLimitError,
+    /// 429 (quota) / 529 — spend or usage quota exhausted; not retryable.
+    QuotaExceeded,
+    /// 400 — malformed request body, unsupported parameters, or schema error.
+    InvalidRequest,
+    /// 500 — provider-side internal error.
+    ServerError,
+    /// 503 — provider temporarily unavailable.
+    ServiceUnavailable,
+    /// 408 / 504 — upstream timed out.
+    Timeout,
+    /// 200 — response was blocked by content filtering
+    /// (`promptFeedback.blockReason` for Google, `content_filter` for OpenAI).
+    ContentFiltered,
+    /// 400 — request exceeds the model's context window.
+    ContextLengthExceeded,
+    /// 404 / 503 — model is temporarily unavailable; may be retried.
+    ModelNotAvailable,
+    /// Mid-stream SSE error detected by the stream parser.
+    StreamMidError,
+    /// Stream was truncated (no `[DONE]` sentinel received).
+    UnexpectedEof,
+    /// Any other error that could not be classified.
+    Unknown,
+}
+
+impl AiErrorKind {
+    /// Returns `true` if the gateway *may* automatically retry after this error.
+    ///
+    /// Retryable errors are transient by nature; non-retryable errors indicate
+    /// a permanent failure for this particular request.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::RateLimitError
+                | Self::ServerError
+                | Self::ServiceUnavailable
+                | Self::Timeout
+                | Self::ModelNotAvailable
+                | Self::UnexpectedEof
+                | Self::StreamMidError
+        )
+    }
+}
+
+impl fmt::Display for AiErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::AuthenticationError => "authentication_error",
+            Self::AuthorizationError => "authorization_error",
+            Self::NotFoundError => "not_found_error",
+            Self::RateLimitError => "rate_limit_error",
+            Self::QuotaExceeded => "quota_exceeded",
+            Self::InvalidRequest => "invalid_request",
+            Self::ServerError => "server_error",
+            Self::ServiceUnavailable => "service_unavailable",
+            Self::Timeout => "timeout",
+            Self::ContentFiltered => "content_filtered",
+            Self::ContextLengthExceeded => "context_length_exceeded",
+            Self::ModelNotAvailable => "model_not_available",
+            Self::StreamMidError => "stream_mid_error",
+            Self::UnexpectedEof => "unexpected_eof",
+            Self::Unknown => "unknown",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Cross-protocol normalized AI error.
+///
+/// Produced by codec parsers and the dispatcher when an upstream call fails.
+/// Always carries a `kind` for retry / circuit-breaker decisions.  The `raw`
+/// field preserves the original vendor error body for logging and passthrough.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiError {
+    pub kind: AiErrorKind,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+    /// Original vendor error body, preserved verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<Value>,
+}
+
+impl AiError {
+    pub fn new(kind: AiErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            status_code: None,
+            raw: None,
+        }
+    }
+
+    pub fn with_status(mut self, status: u16) -> Self {
+        self.status_code = Some(status);
+        self
+    }
+
+    pub fn with_raw(mut self, raw: Value) -> Self {
+        self.raw = Some(raw);
+        self
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+
+    /// Construct an `AiError` from an HTTP status code.
+    ///
+    /// The caller should override the `kind` if the response body provides more
+    /// specific information (e.g. OpenAI `error.type = "context_length_exceeded"`).
+    pub fn from_status(status: u16, message: impl Into<String>) -> Self {
+        let kind = match status {
+            401 => AiErrorKind::AuthenticationError,
+            403 => AiErrorKind::AuthorizationError,
+            404 => AiErrorKind::NotFoundError,
+            408 | 504 => AiErrorKind::Timeout,
+            429 => AiErrorKind::RateLimitError,
+            500 => AiErrorKind::ServerError,
+            503 | 529 => AiErrorKind::ServiceUnavailable,
+            _ => AiErrorKind::Unknown,
+        };
+        Self::new(kind, message).with_status(status)
+    }
+}
+
+impl fmt::Display for AiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.kind, self.message)
+    }
+}
+
+impl std::error::Error for AiError {}

--- a/crates/nyro-core/src/protocol/ir/ext.rs
+++ b/crates/nyro-core/src/protocol/ir/ext.rs
@@ -1,0 +1,177 @@
+//! Protocol-domain strong-typed extensions (`ProtocolExt`).
+//!
+//! Each variant holds fields that are specific to one protocol family and
+//! influence codec behaviour but are **not** consumed by gateway infrastructure
+//! (router, quota, cache-key, dispatcher).  Fields in this module are only
+//! read by the matching protocol encoder or stream formatter.
+//!
+//! ## Design
+//!
+//! Using a concrete enum (rather than `Box<dyn Any>`) keeps downcasting
+//! ergonomic and avoids allocations for the common case where no extension is
+//! needed.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Protocol-specific request extension.
+///
+/// Populated by the ingress codec decoder; consumed by the egress encoder.
+/// When Nyro translates between protocols (e.g. Anthropic → OpenAI), the
+/// source `ProtocolExt` is discarded and the encoder relies solely on the
+/// core `AiRequest` fields.
+#[derive(Debug, Clone)]
+pub enum ProtocolExt {
+    OpenAiChat(OpenAIChatExt),
+    OpenAiResponses(OpenAIResponsesExt),
+    Anthropic(AnthropicExt),
+    Google(GoogleExt),
+}
+
+// ── OpenAI Chat Completions ────────────────────────────────────────────────
+
+/// Extension fields for `POST /v1/chat/completions`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OpenAIChatExt {
+    /// Audio output configuration (`audio.voice`, `audio.format`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio: Option<Value>,
+    /// Token logit biases (map from token ID to bias value −100..100).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logit_bias: Option<HashMap<String, f64>>,
+    /// Whether to return log-probabilities of output tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<bool>,
+    /// Number of top log-probabilities per token position (requires `logprobs = true`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_logprobs: Option<u32>,
+    /// Output modalities (`["text"]`, `["text", "audio"]`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<Vec<String>>,
+    /// Number of candidate completions to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n: Option<u32>,
+    /// Speculative decoding prediction content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prediction: Option<Value>,
+    /// Extended prompt-cache retention (`"in_memory"` | `"24h"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<String>,
+    /// Streaming options (e.g. `include_usage`, `include_obfuscation`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<Value>,
+    /// Response verbosity hint (`"low"` | `"medium"` | `"high"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<String>,
+    /// Web search tool options.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search_options: Option<Value>,
+}
+
+// ── OpenAI Responses API ──────────────────────────────────────────────────
+
+/// Extension fields for `POST /v1/responses`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OpenAIResponsesExt {
+    /// Run the model in background mode (fire-and-forget).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    /// Context management configuration (compression strategies).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_management: Option<Value>,
+    /// Conversation the response belongs to (stateful multi-turn).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation: Option<Value>,
+    /// Additional output data to include in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include: Option<Vec<String>>,
+    /// Previous response ID for multi-turn stateless conversations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_response_id: Option<String>,
+    /// Prompt template reference and variable bindings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<Value>,
+    /// Extended prompt-cache retention (`"in_memory"` | `"24h"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<String>,
+    /// Streaming options.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<Value>,
+    /// Top log-probabilities per token position.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_logprobs: Option<u32>,
+    /// Context truncation strategy (`"auto"` | `"disabled"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<String>,
+    /// Protocol-specific `tool_choice` variants not representable in the core IR
+    /// (e.g. `allowed_tools`, MCP tool choice).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice_ext: Option<Value>,
+}
+
+// ── Anthropic Messages ────────────────────────────────────────────────────
+
+/// Extension fields for `POST /v1/messages`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AnthropicExt {
+    /// Top-k nucleus sampling (Anthropic-specific).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Code execution container configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container: Option<Value>,
+    /// Inference geo-routing preference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_geo: Option<String>,
+    /// Output configuration (`effort` + `format: json_schema`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<Value>,
+    /// Anthropic service tier (different enum space from OAI).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+    /// Server-side tool specifications (bash, code_execution, web_search, etc.).
+    /// Encoded verbatim into the `tools` array alongside user-defined tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_tools: Option<Vec<Value>>,
+}
+
+// ── Google GenAI ──────────────────────────────────────────────────────────
+
+/// Extension fields for `POST /v1beta/{model}:generateContent`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoogleExt {
+    /// Top-k token sampling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Number of candidate responses to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_count: Option<u32>,
+    /// Whether to include token log-probabilities in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_logprobs: Option<bool>,
+    /// Number of top log-probabilities per token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<u32>,
+    /// Output MIME type (`"text/plain"` | `"application/json"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_mime_type: Option<String>,
+    /// JSON Schema alternative to `response_format` (full JSON Schema standard).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_json_schema: Option<Value>,
+    /// Function calling mode configuration (`toolConfig`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_config: Option<Value>,
+    /// Server-side cached content resource name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_content: Option<String>,
+    /// Requested response modalities (`["TEXT"]`, `["IMAGE"]`, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_modalities: Option<Vec<String>>,
+    /// Thinking / reasoning budget configuration (`thinkingBudget`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_config: Option<Value>,
+    /// Image generation configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_config: Option<Value>,
+}

--- a/crates/nyro-core/src/protocol/ir/mod.rs
+++ b/crates/nyro-core/src/protocol/ir/mod.rs
@@ -2,31 +2,55 @@
 //!
 //! # Design principles
 //!
-//! 1. **No silent drops** — every field from every supported protocol has
-//!    an explicit home: `known field`, `vendor.known_specific`, or
-//!    `vendor.passthrough_safe`.
+//! 1. **No silent drops** — every field from every supported protocol has an
+//!    explicit home: core IR field, `ProtocolExt`, `VendorExtensions`, or DROP.
+//!    See `docs/design/ir/FIELD_HOMING.md` for the authoritative decision table.
 //! 2. **Lossless envelope** — `RawEnvelope` keeps a snapshot of the original
 //!    request body + headers for pass-through and audit.
 //! 3. **Parallel deployment** — old `InternalRequest`/`InternalResponse` in
 //!    `protocol/types.rs` stay as `#[deprecated]` shims via `From` impls in
-//!    `compat.rs`.  No breaking change until all codec PRs (08-12) are done.
+//!    `compat.rs`.  No breaking change until all codec PRs are done.
 //! 4. **Repair, not validate** — `repair.rs` performs single-direction
-//!    mutations (fill missing `tool_call_id`, fix orphaned refs, patch broken
-//!    conversation structure) without rejecting the request.
+//!    mutations (fill missing `tool_call_id`, fix orphaned refs) without
+//!    rejecting the request.
 
+pub mod cache;
 pub mod compat;
 pub mod envelope;
+pub mod error;
+pub mod ext;
 pub mod repair;
 pub mod request;
 pub mod response;
+pub mod schema;
 pub mod stream;
 pub mod vendor_ext;
 
-pub use envelope::RawEnvelope;
+// ── Cache ──────────────────────────────────────────────────────────────────────
+pub use cache::{CacheControl, CacheTtl};
+
+// ── Error ──────────────────────────────────────────────────────────────────────
+pub use error::{AiError, AiErrorKind};
+
+// ── ProtocolExt ───────────────────────────────────────────────────────────────
+pub use ext::{AnthropicExt, GoogleExt, OpenAIChatExt, OpenAIResponsesExt, ProtocolExt};
+
+// ── Request ───────────────────────────────────────────────────────────────────
 pub use request::{
-    AiRequest, GenerationConfig, Message, MessageContent, ReasoningConfig, RequestMetadata,
-    ResponseFormat, Role, SafetySettings, StreamConfig, ToolChoice, ToolSpec,
+    AiRequest, ContentBlock, DocumentSource, GenerationConfig, MediaSource, Message,
+    MessageContent, ReasoningConfig, ReasoningEffort, RequestMetadata, ResponseFormat, Role,
+    SafetySettings, StreamConfig, ToolCall, ToolChoice, ToolSpec,
 };
+
+// ── Response ──────────────────────────────────────────────────────────────────
 pub use response::{AiResponse, ResponseItem};
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+pub use schema::SchemaObject;
+
+// ── Stream ────────────────────────────────────────────────────────────────────
 pub use stream::StreamDelta as AiStreamDelta;
+
+// ── Vendor ────────────────────────────────────────────────────────────────────
+pub use envelope::RawEnvelope;
 pub use vendor_ext::VendorExtensions;

--- a/crates/nyro-core/src/protocol/ir/request.rs
+++ b/crates/nyro-core/src/protocol/ir/request.rs
@@ -1,14 +1,16 @@
-//! `AiRequest` — the new unified ingress IR for all supported protocols.
+//! `AiRequest` — the unified ingress IR for all supported protocols.
 //!
-//! PR-08–12 will update the codec decoders to produce `AiRequest` instead of
-//! the old `InternalRequest`.  Until then, `compat.rs` provides lossless
-//! round-trip `From` conversions.
+//! Codec decoders (PR-2) produce `AiRequest`; codec encoders (PR-3) and the
+//! dispatcher (PR-5) consume it.  Until PR-2 lands, `compat.rs` provides
+//! lossless `From` conversions from/to the old `InternalRequest`.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::protocol::ids::ProtocolId;
+use crate::protocol::ir::cache::CacheControl;
 use crate::protocol::ir::envelope::RawEnvelope;
+use crate::protocol::ir::ext::ProtocolExt;
 use crate::protocol::ir::vendor_ext::VendorExtensions;
 
 // ── Role ─────────────────────────────────────────────────────────────────────
@@ -22,31 +24,186 @@ pub enum Role {
     Tool,
 }
 
+// ── Image source ─────────────────────────────────────────────────────────────
+
+/// The data source for an image or audio content block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MediaSource {
+    /// Inline base64-encoded data.
+    Base64 {
+        media_type: String,
+        data: String,
+    },
+    /// A URL pointing to the media.
+    Url(String),
+    /// A provider-side file reference.
+    FileId {
+        file_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+// ── Document source ───────────────────────────────────────────────────────────
+
+/// Source for a document content block (Anthropic).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DocumentSource {
+    Base64Pdf {
+        data: String,
+    },
+    PlainText {
+        data: String,
+    },
+    Url(String),
+    /// Content already stored as content blocks.
+    Blocks {
+        content: Vec<ContentBlock>,
+    },
+}
+
 // ── Content blocks ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
+    // ── Text ─────────────────────────────────────────────────────────────────
     Text {
         text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
+
+    // ── Multimodal ───────────────────────────────────────────────────────────
     Image {
-        media_type: String,
-        data: String,
+        source: MediaSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
-    Reasoning {
-        text: String,
+    Audio {
+        source: MediaSource,
+    },
+    File {
+        source: MediaSource,
+    },
+
+    // ── Reasoning / thinking ─────────────────────────────────────────────────
+    /// Extended thinking output (Anthropic `ThinkingBlockParam`, Google `thought=true`).
+    Thinking {
+        thinking: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         signature: Option<String>,
     },
+    /// Redacted thinking block (Anthropic `RedactedThinkingBlockParam`).
+    RedactedThinking {
+        data: String,
+    },
+
+    // ── Tool calls ────────────────────────────────────────────────────────────
     ToolUse {
         id: String,
         name: String,
         input: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     ToolResult {
         tool_use_id: String,
         content: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
+
+    // ── Server-side tools (Anthropic) ────────────────────────────────────────
+    /// A server-executed tool call (Anthropic `ServerToolUseBlockParam`,
+    /// Google `Part.toolCall`).
+    ServerToolUse {
+        id: String,
+        /// Tool name (e.g. `"web_search"`, `"code_execution"`).
+        name: String,
+        input: Value,
+        /// Discriminator for the tool type (e.g. `"web_search"`, `"bash"`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    /// Result from a server-executed tool.
+    ServerToolResult {
+        tool_use_id: String,
+        content: Value,
+        /// Discriminator matching the originating `ServerToolUse.server_type`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+
+    // ── Documents / search ────────────────────────────────────────────────────
+    /// A document block (Anthropic `DocumentBlockParam`).
+    Document {
+        source: DocumentSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    /// A search result block (Anthropic `SearchResultBlockParam`).
+    SearchResult {
+        content: Vec<ContentBlock>,
+        source: String,
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+
+    // ── Citations ─────────────────────────────────────────────────────────────
+    /// A citation block (Anthropic citations, OpenAI Responses annotations).
+    Citation {
+        cited_text: String,
+        source: Value,
+    },
+
+    // ── Code execution ───────────────────────────────────────────────────────
+    /// Executable code produced by the model (Google `Part.executableCode`).
+    ExecutableCode {
+        code: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        language: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    /// Code execution result (Google `Part.codeExecutionResult`,
+    /// Anthropic `CodeExecutionResultBlockParam`).
+    CodeExecutionResult {
+        return_code: i32,
+        stdout: String,
+        stderr: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+
+    // ── Container ────────────────────────────────────────────────────────────
+    /// Container file upload (Anthropic `ContainerUploadBlockParam`).
+    ContainerUpload {
+        file_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+
+    // ── Refusal ───────────────────────────────────────────────────────────────
+    /// Model refusal (OpenAI `content_filter` / Anthropic `stop_reason = "refusal"`).
+    Refusal {
+        refusal: String,
+    },
+
+    // ── Fallback ─────────────────────────────────────────────────────────────
     /// A raw JSON block that the codec does not understand.  Preserved for
     /// pass-through and future extension.
     Unknown {
@@ -56,15 +213,23 @@ pub enum ContentBlock {
 
 impl ContentBlock {
     pub fn as_text(&self) -> Option<&str> {
-        if let Self::Text { text } = self {
+        if let Self::Text { text, .. } = self {
             Some(text)
         } else {
             None
         }
     }
+
+    pub fn is_tool_use(&self) -> bool {
+        matches!(self, Self::ToolUse { .. } | Self::ServerToolUse { .. })
+    }
+
+    pub fn is_tool_result(&self) -> bool {
+        matches!(self, Self::ToolResult { .. } | Self::ServerToolResult { .. })
+    }
 }
 
-/// Message content can be a plain string or a list of typed blocks.
+/// Message content — either a plain string or a typed block list.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MessageContent {
@@ -93,12 +258,11 @@ pub struct Message {
     pub content: MessageContent,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
-    /// The `tool_call_id` of the preceding assistant tool call this result
-    /// answers.  Required for `Role::Tool` messages.
+    /// The `tool_call_id` this result answers.  Required for `Role::Tool` messages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
     /// Provider-specific extras for this individual message (e.g. Anthropic
-    /// `cache_control`).
+    /// `cache_control` on `system` array items).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
 }
@@ -117,31 +281,38 @@ pub struct ToolSpec {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// JSON Schema for the tool's input parameters.
     pub parameters: Value,
-    /// Vendor-specific extra fields (e.g. Google `codeExecution`, Anthropic
-    /// `cache_control`).
+    /// Whether to enforce strict JSON Schema validation (OpenAI + Anthropic).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
+    /// Per-tool cache breakpoint (Anthropic).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+    /// Vendor-specific extra fields not covered by the IR.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
 }
 
-/// Flexible `tool_choice` that can be a string sentinel or a named-tool object.
+/// `tool_choice` — how the model selects tools.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(rename_all = "snake_case")]
 pub enum ToolChoice {
-    #[serde(rename = "auto")]
+    /// Model decides whether to call a tool.
     Auto,
-    #[serde(rename = "none")]
+    /// Model must not call any tool.
     None,
-    #[serde(rename = "required")]
+    /// Model must call at least one tool.
     Required,
-    Named {
-        name: String,
-    },
+    /// Force a specific tool by name.
+    Named { name: String },
+    /// Pass-through raw value for protocol-specific options.
     Raw(Value),
 }
 
 // ── Generation config ─────────────────────────────────────────────────────────
 
+/// Core generation parameters shared across all supported protocols.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -151,33 +322,63 @@ pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_k: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub frequency_penalty: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub presence_penalty: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
+
+    // ── Fields pending migration to ProtocolExt (PR-2) ───────────────────────
+    // These belong in `OpenAIChatExt` / `AnthropicExt` / `GoogleExt` per
+    // FIELD_HOMING.md §3-6.  Kept here temporarily so existing codec encoders
+    // continue to compile.  Remove in PR-2 when decoders are rewritten.
+    /// TODO(PR-2): Move to `OpenAIChatExt.logit_bias`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub logit_bias: Option<std::collections::HashMap<String, f64>>,
+    /// TODO(PR-2): Move to `OpenAIChatExt.n`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<u32>,
+    /// TODO(PR-2): Move to `AnthropicExt.top_k` / `GoogleExt.top_k`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
 }
 
 // ── Reasoning config ──────────────────────────────────────────────────────────
 
+/// Effort level for reasoning / thinking models.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    /// Budget in tokens (Anthropic `budget_tokens`).
+    Budget(u32),
+}
+
+/// Reasoning / extended-thinking configuration.
+///
+/// Normalized from:
+/// - OpenAI `reasoning.effort` + `reasoning.summary`
+/// - Anthropic `thinking: { type: "enabled", budget_tokens, display }`
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ReasoningConfig {
-    /// Whether extended reasoning / thinking is enabled.
+    /// Whether extended reasoning / thinking is requested.
     pub enabled: bool,
-    /// Budget in tokens (Anthropic `budget_tokens`, OpenAI `budget_tokens`).
+    /// Token budget for thinking (Anthropic `budget_tokens`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub budget_tokens: Option<u32>,
-    /// Effort level (`"low" / "medium" / "high"`) for OpenAI `o` models.
+    /// Effort level (OpenAI `reasoning.effort`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub effort: Option<String>,
+    pub effort: Option<ReasoningEffort>,
+    /// Display mode for thinking content (Anthropic `display: "summarized" | "omitted"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
 }
 
 // ── Response format ───────────────────────────────────────────────────────────
@@ -190,6 +391,7 @@ pub enum ResponseFormat {
     JsonSchema {
         name: String,
         schema: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
     },
 }
@@ -199,15 +401,13 @@ pub enum ResponseFormat {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct StreamConfig {
     pub enabled: bool,
-    /// Whether the provider should include token usage in the final stream
-    /// chunk (OpenAI `stream_options.include_usage`).
+    /// Whether the provider should include token usage in the final stream chunk.
     pub include_usage: bool,
 }
 
 // ── Safety settings ───────────────────────────────────────────────────────────
 
-/// Google SafetySettings are vendor-specific but important enough to have a
-/// first-class home in the IR.  Other vendors ignore this field.
+/// Google SafetySettings — important enough to have a first-class home in the IR.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafetySettings {
     pub category: String,
@@ -228,45 +428,58 @@ pub struct RequestMetadata {
 
 // ── AiRequest ─────────────────────────────────────────────────────────────────
 
-/// Unified ingress IR.  Consumed by all codec encoders and the `dispatcher`.
+/// Unified ingress IR consumed by all codec encoders and the dispatcher.
 ///
-/// Every field that the old `InternalRequest` had is present here.  Fields
-/// added in PR-08–12 are new (marked with their PR number).
+/// Fields are annotated with the FIELD_HOMING.md category that they belong to:
+/// `[IR]` = core, `[OAIChat]` = OpenAIChatExt, etc.
 #[derive(Debug, Clone)]
 pub struct AiRequest {
     // ── Core ──────────────────────────────────────────────────────────────────
-    /// The model identifier as received from the client.
+    /// [IR] The model identifier as received from the client.
     pub model: String,
-    /// Conversation history.
+    /// [IR] Conversation history.
     pub messages: Vec<Message>,
-    /// System prompt (extracted from a leading `system` message or the
+    /// [IR] System prompt (extracted from a leading `system` message or the
     /// top-level `system` field in Anthropic Messages API).
     pub system: Option<String>,
 
     // ── Generation ────────────────────────────────────────────────────────────
+    /// [IR] Core generation parameters.
     pub generation: GenerationConfig,
 
-    // ── Streaming ────────────────────────────────────────────────────────────
+    // ── Streaming ─────────────────────────────────────────────────────────────
+    /// [IR] Streaming configuration.
     pub stream: StreamConfig,
 
     // ── Tools ─────────────────────────────────────────────────────────────────
+    /// [IR] User-defined tool specifications.
     pub tools: Option<Vec<ToolSpec>>,
+    /// [IR] Tool selection mode.
     pub tool_choice: Option<ToolChoice>,
-    /// Whether the provider should call tools in parallel (OpenAI PR-08).
+    /// [IR] Whether the provider should call tools in parallel.
     pub parallel_tool_calls: Option<bool>,
+    /// [IR] Disable parallel tool use (Anthropic `disable_parallel_tool_use`,
+    /// equivalent to `parallel_tool_calls = false` for OpenAI).
+    pub disable_parallel_tool_calls: Option<bool>,
 
     // ── Reasoning ─────────────────────────────────────────────────────────────
+    /// [IR] Reasoning / extended-thinking configuration.
     pub reasoning: ReasoningConfig,
 
     // ── Output format ─────────────────────────────────────────────────────────
+    /// [IR] Response format constraint.
     pub response_format: Option<ResponseFormat>,
-    /// Modalities to include in the response (OpenAI `modalities` PR-08).
-    pub modalities: Option<Vec<String>>,
 
     // ── Safety ────────────────────────────────────────────────────────────────
+    /// [IR] Google SafetySettings (ignored by other encoders).
     pub safety_settings: Option<Vec<SafetySettings>>,
 
-    // ── Metadata / extensions ─────────────────────────────────────────────────
+    // ── Protocol extensions ───────────────────────────────────────────────────
+    /// Protocol-domain Ext carrying fields specific to the source protocol.
+    /// Populated by the ingress decoder (PR-2); consumed by the egress encoder (PR-3).
+    pub ext: Option<ProtocolExt>,
+
+    // ── Metadata / vendor bag ─────────────────────────────────────────────────
     pub meta: RequestMetadata,
 }
 
@@ -282,11 +495,21 @@ impl AiRequest {
             tools: None,
             tool_choice: None,
             parallel_tool_calls: None,
+            disable_parallel_tool_calls: None,
             reasoning: ReasoningConfig::default(),
             response_format: None,
-            modalities: None,
             safety_settings: None,
+            ext: None,
             meta: RequestMetadata::default(),
+        }
+    }
+
+    /// Return the modalities from `OpenAIChatExt` if present.
+    pub fn modalities(&self) -> Option<&Vec<String>> {
+        if let Some(ProtocolExt::OpenAiChat(ref e)) = self.ext {
+            e.modalities.as_ref()
+        } else {
+            None
         }
     }
 }

--- a/crates/nyro-core/src/protocol/ir/request.rs
+++ b/crates/nyro-core/src/protocol/ir/request.rs
@@ -31,10 +31,7 @@ pub enum Role {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MediaSource {
     /// Inline base64-encoded data.
-    Base64 {
-        media_type: String,
-        data: String,
-    },
+    Base64 { media_type: String, data: String },
     /// A URL pointing to the media.
     Url(String),
     /// A provider-side file reference.
@@ -225,7 +222,10 @@ impl ContentBlock {
     }
 
     pub fn is_tool_result(&self) -> bool {
-        matches!(self, Self::ToolResult { .. } | Self::ServerToolResult { .. })
+        matches!(
+            self,
+            Self::ToolResult { .. } | Self::ServerToolResult { .. }
+        )
     }
 }
 

--- a/crates/nyro-core/src/protocol/ir/response.rs
+++ b/crates/nyro-core/src/protocol/ir/response.rs
@@ -1,8 +1,9 @@
-//! `AiResponse` — the new unified egress IR.
+//! `AiResponse` — the unified egress IR produced by all codec response parsers.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::protocol::ir::error::AiError;
 use crate::protocol::ir::vendor_ext::VendorExtensions;
 use crate::protocol::types::TokenUsage;
 
@@ -14,8 +15,8 @@ use crate::protocol::types::TokenUsage;
 pub enum ResponseItem {
     /// A text output block.
     OutputText { text: String },
-    /// A reasoning / thinking block.
-    Reasoning { text: String },
+    /// A thinking / reasoning block.
+    Thinking { text: String },
     /// A tool call issued by the model.
     FunctionCall {
         call_id: String,
@@ -36,20 +37,20 @@ pub enum ResponseItem {
 
 // ── AiResponse ────────────────────────────────────────────────────────────────
 
-/// Unified egress IR produced by all codec response parsers.
+/// Unified egress IR produced by all codec response parsers and the accumulator.
 #[derive(Debug, Clone)]
 pub struct AiResponse {
     /// The unique response ID assigned by the provider.
     pub id: String,
     /// The model variant that was actually used.
     pub model: String,
-    /// The primary text content.
+    /// The primary text content (convenience field; also present in `content_blocks`).
     pub content: String,
-    /// Extended reasoning / thinking output.
+    /// Extended thinking / reasoning output (convenience field).
     pub reasoning_content: Option<String>,
-    /// Anthropic reasoning signature.
+    /// Thinking signature for multi-turn passback (Anthropic).
     pub reasoning_signature: Option<String>,
-    /// Tool calls issued by the model.
+    /// Tool calls issued by the model (convenience field; also in `content_blocks`).
     pub tool_calls: Vec<crate::protocol::ir::request::ToolCall>,
     /// Item graph (native for OpenAI Responses; synthesized for other protocols).
     pub items: Option<Vec<ResponseItem>>,
@@ -57,6 +58,9 @@ pub struct AiResponse {
     pub stop_reason: Option<String>,
     /// Token usage.
     pub usage: TokenUsage,
+    /// Normalized error — populated when the provider returns an error response
+    /// or the parser detects a mid-stream error.
+    pub error: Option<AiError>,
     /// Vendor-specific extra fields.
     pub vendor: VendorExtensions,
 }
@@ -73,7 +77,12 @@ impl AiResponse {
             items: None,
             stop_reason: None,
             usage: TokenUsage::default(),
+            error: None,
             vendor: VendorExtensions::default(),
         }
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
     }
 }

--- a/crates/nyro-core/src/protocol/ir/schema.rs
+++ b/crates/nyro-core/src/protocol/ir/schema.rs
@@ -1,0 +1,101 @@
+//! `SchemaObject` — unified tool-parameter JSON Schema representation.
+//!
+//! Stores the canonical lowercase-type form of a JSON Schema object.
+//! The Google GenAI encoder is responsible for uppercasing `type` values on
+//! the way out (`"string"` → `"STRING"`); all other encoders use lowercase as-is.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A JSON Schema object for tool parameters, always stored with lowercase
+/// `type` names (JSON Schema canonical form).
+///
+/// Use `to_google_wire()` to get an uppercase-type copy for the Gemini wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaObject(pub Value);
+
+impl SchemaObject {
+    /// Create a new `SchemaObject`, normalizing any `type` values to lowercase.
+    pub fn new(value: Value) -> Self {
+        let mut obj = Self(value);
+        obj.normalize_to_lowercase();
+        obj
+    }
+
+    /// Recursively normalize all `type` string values to lowercase in-place.
+    pub fn normalize_to_lowercase(&mut self) {
+        normalize_type_strings(&mut self.0, |s| s.to_lowercase());
+    }
+
+    /// Return a clone with all `type` string values uppercased (Gemini wire format).
+    pub fn to_google_wire(&self) -> Value {
+        let mut v = self.0.clone();
+        normalize_type_strings(&mut v, |s| s.to_uppercase());
+        v
+    }
+
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+}
+
+impl From<Value> for SchemaObject {
+    fn from(v: Value) -> Self {
+        Self::new(v)
+    }
+}
+
+fn normalize_type_strings(v: &mut Value, f: impl Fn(&str) -> String + Copy) {
+    match v {
+        Value::Object(map) => {
+            if let Some(t) = map.get_mut("type") {
+                if let Value::String(s) = t {
+                    *s = f(s);
+                }
+            }
+            for val in map.values_mut() {
+                normalize_type_strings(val, f);
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr {
+                normalize_type_strings(val, f);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn normalizes_google_uppercase_to_lowercase() {
+        let schema = json!({
+            "type": "OBJECT",
+            "properties": {
+                "name": { "type": "STRING" },
+                "age":  { "type": "INTEGER" }
+            }
+        });
+        let obj = SchemaObject::new(schema);
+        assert_eq!(obj.as_value()["type"], "object");
+        assert_eq!(obj.as_value()["properties"]["name"]["type"], "string");
+        assert_eq!(obj.as_value()["properties"]["age"]["type"], "integer");
+    }
+
+    #[test]
+    fn to_google_wire_uppercases() {
+        let schema = json!({"type": "object", "properties": {"x": {"type": "string"}}});
+        let obj = SchemaObject::new(schema);
+        let wire = obj.to_google_wire();
+        assert_eq!(wire["type"], "OBJECT");
+        assert_eq!(wire["properties"]["x"]["type"], "STRING");
+    }
+}

--- a/crates/nyro-core/src/protocol/ir/stream.rs
+++ b/crates/nyro-core/src/protocol/ir/stream.rs
@@ -11,10 +11,7 @@ use crate::protocol::types::TokenUsage;
 #[derive(Debug, Clone)]
 pub enum StreamDelta {
     /// First chunk — identifies the response and model.
-    MessageStart {
-        id: String,
-        model: String,
-    },
+    MessageStart { id: String, model: String },
     /// Incremental text output.
     TextDelta(String),
     /// Incremental thinking / reasoning output (Anthropic `ThinkingBlockParam`,
@@ -29,30 +26,18 @@ pub enum StreamDelta {
         name: String,
     },
     /// Incremental tool call argument JSON fragment.
-    ToolCallDelta {
-        index: usize,
-        arguments: String,
-    },
+    ToolCallDelta { index: usize, arguments: String },
     /// Tool call arguments are complete.
-    ToolCallComplete {
-        index: usize,
-        tool_call: ToolCall,
-    },
+    ToolCallComplete { index: usize, tool_call: ToolCall },
     /// Final token usage statistics.
     Usage(TokenUsage),
     /// Stream ended normally.
-    Done {
-        stop_reason: String,
-    },
+    Done { stop_reason: String },
     /// A mid-stream error detected by the parser (e.g. OAI `data: {"error":{...}}`,
     /// Anthropic `event: error`, Google `promptFeedback.blockReason` in first chunk).
-    StreamError {
-        error: AiError,
-    },
+    StreamError { error: AiError },
     /// Stream was truncated without a `[DONE]` sentinel.
     UnexpectedEof,
     /// A verbatim SSE event not classified into any other variant.
-    Unknown {
-        raw: String,
-    },
+    Unknown { raw: String },
 }

--- a/crates/nyro-core/src/protocol/ir/stream.rs
+++ b/crates/nyro-core/src/protocol/ir/stream.rs
@@ -1,35 +1,57 @@
 //! Stream deltas for `AiResponse`.
 
+use crate::protocol::ir::error::AiError;
 use crate::protocol::ir::request::ToolCall;
 use crate::protocol::types::TokenUsage;
 
 /// A single parsed delta from a streaming response.
+///
+/// The stream parser emits a sequence of `StreamDelta` values.  The accumulator
+/// (PR-4) coalesces them into a complete `AiResponse`.
 #[derive(Debug, Clone)]
 pub enum StreamDelta {
+    /// First chunk — identifies the response and model.
     MessageStart {
         id: String,
         model: String,
     },
+    /// Incremental text output.
     TextDelta(String),
-    ReasoningDelta(String),
-    ReasoningSignature(String),
+    /// Incremental thinking / reasoning output (Anthropic `ThinkingBlockParam`,
+    /// Google `Part{thought=true}`, OpenAI reasoning items).
+    ThinkingDelta(String),
+    /// Thinking signature for multi-turn passback (Anthropic).
+    ThinkingSignature(String),
+    /// A tool call is starting.
     ToolCallStart {
         index: usize,
         id: String,
         name: String,
     },
+    /// Incremental tool call argument JSON fragment.
     ToolCallDelta {
         index: usize,
         arguments: String,
     },
+    /// Tool call arguments are complete.
     ToolCallComplete {
         index: usize,
         tool_call: ToolCall,
     },
+    /// Final token usage statistics.
     Usage(TokenUsage),
+    /// Stream ended normally.
     Done {
         stop_reason: String,
     },
+    /// A mid-stream error detected by the parser (e.g. OAI `data: {"error":{...}}`,
+    /// Anthropic `event: error`, Google `promptFeedback.blockReason` in first chunk).
+    StreamError {
+        error: AiError,
+    },
+    /// Stream was truncated without a `[DONE]` sentinel.
+    UnexpectedEof,
+    /// A verbatim SSE event not classified into any other variant.
     Unknown {
         raw: String,
     },

--- a/docs/design/ir/CHANGELOG.md
+++ b/docs/design/ir/CHANGELOG.md
@@ -35,4 +35,69 @@
 
 ---
 
-<!-- PR-1 及以后条目在合并后追加于此处 -->
+## [PR-1] IR 类型重塑 + 流式事件分层 + Schema 抽象 — 2026-05-15
+
+### 新增
+
+**新模块**
+- `ir/cache.rs` — `CacheControl { ttl: CacheTtl, breakpoint_priority: u8 }` / `CacheTtl { Ephemeral5m, Ephemeral1h }`
+- `ir/error.rs` — `AiError { kind, message, status_code, raw }` / `AiErrorKind` (15 变体) + `is_retryable()`
+- `ir/ext.rs` — `ProtocolExt` 枚举 + `OpenAIChatExt` / `OpenAIResponsesExt` / `AnthropicExt` / `GoogleExt`
+- `ir/schema.rs` — `SchemaObject` (JSON Schema 归一化，`to_google_wire()` 大写转换)
+
+**ContentBlock 新变体**
+- `ContentBlock::Thinking { thinking, signature? }` ← 重命名自 `Reasoning`（字段 `text` → `thinking`）
+- `ContentBlock::RedactedThinking { data }` — Anthropic redacted thinking
+- `ContentBlock::Audio { source: MediaSource }` — 音频内容块
+- `ContentBlock::File { source: MediaSource }` — 文件内容块
+- `ContentBlock::Document { source, title?, context?, cache_control? }` — Anthropic DocumentBlockParam
+- `ContentBlock::SearchResult { content, source, title, cache_control? }` — Anthropic SearchResultBlockParam
+- `ContentBlock::ServerToolUse { id, name, input, server_type?, cache_control? }` — 服务端工具调用
+- `ContentBlock::ServerToolResult { tool_use_id, content, server_type?, cache_control? }` — 服务端工具结果
+- `ContentBlock::Citation { cited_text, source }` — 引用块
+- `ContentBlock::ExecutableCode { code, language?, id? }` — Google executableCode
+- `ContentBlock::CodeExecutionResult { return_code, stdout, stderr, id? }` — 代码执行结果
+- `ContentBlock::ContainerUpload { file_id, cache_control? }` — Anthropic 容器上传
+- `ContentBlock::Refusal { refusal }` — 模型拒绝
+
+**ContentBlock 已有变体扩展**
+- `ContentBlock::Image`: `media_type/data` → `source: MediaSource` + `cache_control?`
+- `ContentBlock::Text`: 新增 `cache_control?`
+- `ContentBlock::ToolUse`: 新增 `cache_control?`
+- `ContentBlock::ToolResult`: 新增 `is_error?` + `cache_control?`
+
+**新类型**
+- `MediaSource { Base64 { media_type, data }, Url(String), FileId { file_id, detail? } }`
+- `DocumentSource { Base64Pdf, PlainText, Url, Blocks }`
+- `ReasoningEffort { None, Minimal, Low, Medium, High, Xhigh, Budget(u32) }`
+
+**AiRequest 新字段**
+- `disable_parallel_tool_calls: Option<bool>` — 与 ANT `disable_parallel_tool_use` 对应
+- `ext: Option<ProtocolExt>` — 协议域 Ext 载体
+
+**ToolSpec 新字段**
+- `strict: Option<bool>` — OAI + ANT strict schema 校验
+- `cache_control: Option<CacheControl>` — ANT 工具级别缓存断点
+
+**ReasoningConfig 扩展**
+- `effort: Option<ReasoningEffort>` 类型从 `Option<String>` 改为强类型 enum
+- `display: Option<String>` — ANT thinking display 模式
+
+**AiResponse 新字段**
+- `error: Option<AiError>` — 规范化错误（非 2xx 或内容过滤时填充）
+
+**AiStreamDelta 新变体**
+- `StreamDelta::ThinkingDelta(String)` ← 重命名自 `ReasoningDelta`
+- `StreamDelta::ThinkingSignature(String)` ← 重命名自 `ReasoningSignature`
+- `StreamDelta::StreamError { error: AiError }` — 流式中途错误
+- `StreamDelta::UnexpectedEof` — 流被截断
+
+### 变更（语义）
+- `ContentBlock::Reasoning { text, signature }` → `ContentBlock::Thinking { thinking, signature }` — 字段名 `text` 改为 `thinking`；compat.rs 已更新做透明桥接
+- `ResponseItem::Reasoning { text }` → `ResponseItem::Thinking { text }`
+- `GenerationConfig`: 标注 `logit_bias` / `n` / `top_k` 为 TODO(PR-2) 待迁移到 ProtocolExt
+
+### 删除
+- `AiRequest::modalities` 字段 — 已移入 `OpenAIChatExt.modalities`
+
+<!-- PR-2 及以后条目在合并后追加于此处 -->


### PR DESCRIPTION
New modules:
- ir/cache.rs: CacheControl / CacheTtl for per-block prompt caching
- ir/error.rs: AiError / AiErrorKind (15 kinds) with is_retryable()
- ir/ext.rs: ProtocolExt enum + OpenAIChatExt / OpenAIResponsesExt / AnthropicExt / GoogleExt
- ir/schema.rs: SchemaObject with Google uppercase type normalization

ContentBlock: +13 new variants (Thinking, RedactedThinking, Audio, File, Document, SearchResult, ServerToolUse, ServerToolResult, Citation, ExecutableCode, CodeExecutionResult, ContainerUpload, Refusal); existing variants extended with cache_control / is_error fields; Image refactored to MediaSource enum.

AiRequest: + ext: Option<ProtocolExt>, + disable_parallel_tool_calls
AiResponse: + error: Option<AiError>
AiStreamDelta: + StreamError, + UnexpectedEof; Reasoning → Thinking rename

All 6 IR unit tests pass; zero compiler errors.