### PR TITLE
feat(ir): PR-2 — switch all ingress decoders to emit AiRequest directly

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
@@ -1,22 +1,35 @@
+//! Anthropic Messages ingress decoder — produces `AiRequest` directly.
+//!
+//! Cache-control and exotic blocks (Document, InputAudio) are now carried
+//! natively in `ContentBlock`. Raw wire values are also preserved in
+//! `meta.vendor.ingress` so the old Anthropic encoder (pre-PR-3) can still
+//! round-trip them.
+
 use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
 use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
-use crate::protocol::types::*;
+use crate::protocol::ir::DocumentSource as IrDocumentSource;
+use crate::protocol::ir::{
+    AiRequest, AnthropicExt, CacheTtl, ContentBlock, GenerationConfig, MediaSource, Message,
+    MessageContent, ProtocolExt, ReasoningConfig, Role, StreamConfig, ToolCall, ToolChoice,
+    ToolSpec,
+};
 
-use super::types::*;
+use super::types::{
+    AnthropicContent, AnthropicContentBlock, AnthropicImageSource, AnthropicMessage,
+    AnthropicRequest, AnthropicSystem, CacheControl as WireCacheControl,
+    DocumentSource as WireDocumentSource,
+};
 
 pub struct AnthropicDecoder;
 
 impl IngressDecoder for AnthropicDecoder {
-    fn decode_request(&self, body: Value) -> Result<InternalRequest> {
+    fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let req: AnthropicRequest = serde_json::from_value(body)?;
 
-        // ── Cache-control / exotic-block detection ────────────────────────────
-        // If any message contains cache_control or non-standard blocks
-        // (Document, InputAudio), preserve the original wire-format so the
-        // encoder can round-trip them faithfully.
+        // ── Cache-control / exotic-block detection (for raw preservation) ──────
         let needs_raw_msgs = req.messages.iter().any(|m| {
             if let AnthropicContent::Blocks(blocks) = &m.content {
                 blocks
@@ -40,7 +53,7 @@ impl IngressDecoder for AnthropicDecoder {
             .map(|ts| ts.iter().any(|t| t.cache_control.is_some()))
             .unwrap_or(false);
 
-        // Snapshot raw anthropic wire values before consuming req.
+        // Snapshot raw wire values before consuming req.
         let raw_messages: Option<Value> = if needs_raw_msgs {
             serde_json::to_value(&req.messages).ok()
         } else {
@@ -61,8 +74,9 @@ impl IngressDecoder for AnthropicDecoder {
             None
         };
 
-        // ── Decode messages ───────────────────────────────────────────────────
-        let mut messages = Vec::new();
+        // ── System prompt ─────────────────────────────────────────────────────
+        // Extracted as the leading system message (backward compat with old encoders).
+        let mut messages: Vec<Message> = Vec::new();
 
         if let Some(system) = &req.system {
             let text = match system {
@@ -80,12 +94,12 @@ impl IngressDecoder for AnthropicDecoder {
                     .join("\n"),
             };
             if !text.is_empty() {
-                messages.push(InternalMessage {
+                messages.push(Message {
                     role: Role::System,
                     content: MessageContent::Text(text),
                     tool_calls: None,
                     tool_call_id: None,
-                    extra: Default::default(),
+                    meta: None,
                 });
             }
         }
@@ -94,90 +108,146 @@ impl IngressDecoder for AnthropicDecoder {
             messages.extend(decode_message(msg)?);
         }
 
-        // ── Decode tools ──────────────────────────────────────────────────────
-        let tools = req.tools.map(|tools| {
-            tools
-                .into_iter()
-                .filter_map(|t| {
-                    // Built-in tools (computer_use, text_editor, bash) have no
-                    // input_schema; represent them with a sentinel name so the
-                    // encoder can reconstruct them.
-                    if let Some(tool_type) = &t.tool_type {
-                        return Some(ToolDef {
-                            name: format!("__builtin__{}", tool_type),
-                            description: t.description,
-                            parameters: t.input_schema.unwrap_or(Value::Object(Default::default())),
-                        });
+        // ── Tools ─────────────────────────────────────────────────────────────
+        let mut user_tools: Vec<ToolSpec> = Vec::new();
+        let mut server_tools: Vec<Value> = Vec::new();
+
+        if let Some(tools) = req.tools {
+            for t in tools {
+                if let Some(ref tool_type) = t.tool_type {
+                    // Built-in / server tool — preserve as raw Value in AnthropicExt.
+                    let mut raw = serde_json::Map::new();
+                    raw.insert("type".to_string(), Value::String(tool_type.clone()));
+                    if let Some(d) = &t.description {
+                        raw.insert("description".to_string(), Value::String(d.clone()));
                     }
-                    t.input_schema.map(|schema| ToolDef {
+                    if let Some(s) = &t.input_schema {
+                        raw.insert("input_schema".to_string(), s.clone());
+                    }
+                    server_tools.push(Value::Object(raw));
+                    // Also keep sentinel ToolSpec so dispatcher knows about it.
+                    user_tools.push(ToolSpec {
+                        name: format!("__builtin__{}", tool_type),
+                        description: t.description,
+                        parameters: t.input_schema.unwrap_or(Value::Object(Default::default())),
+                        strict: None,
+                        cache_control: t.cache_control.as_ref().map(map_cache_control),
+                        meta: None,
+                    });
+                } else if let Some(schema) = t.input_schema {
+                    user_tools.push(ToolSpec {
                         name: t.name,
                         description: t.description,
                         parameters: schema,
-                    })
-                })
-                .collect()
-        });
+                        strict: None,
+                        cache_control: t.cache_control.as_ref().map(map_cache_control),
+                        meta: None,
+                    });
+                }
+            }
+        }
 
-        // ── Build extra map ───────────────────────────────────────────────────
-        let mut extra: std::collections::HashMap<String, Value> = Default::default();
+        // ── tool_choice ───────────────────────────────────────────────────────
+        let tool_choice = req.tool_choice.map(parse_tool_choice);
+
+        // ── Reasoning config ──────────────────────────────────────────────────
+        let reasoning = if let Some(ref thinking) = req.thinking {
+            let enabled = thinking.kind == "enabled";
+            ReasoningConfig {
+                enabled,
+                budget_tokens: thinking.budget_tokens,
+                ..Default::default()
+            }
+        } else {
+            ReasoningConfig::default()
+        };
+
+        // ── AnthropicExt ──────────────────────────────────────────────────────
+        let ant_ext = AnthropicExt {
+            top_k: req.top_k,
+            container: req.container.as_ref().map(|c| Value::String(c.clone())),
+            service_tier: req.service_tier.clone(),
+            server_tools: if server_tools.is_empty() {
+                None
+            } else {
+                Some(server_tools)
+            },
+            ..Default::default()
+        };
+
+        // ── Vendor ingress bag — backward compat for old Anthropic encoder ────
+        let mut ingress = std::collections::HashMap::new();
 
         if let Some(v) = raw_messages {
-            extra.insert("__anthropic_raw_messages".into(), v);
+            ingress.insert("__anthropic_raw_messages".into(), v);
         }
         if let Some(v) = raw_system {
-            extra.insert("__anthropic_raw_system".into(), v);
+            ingress.insert("__anthropic_raw_system".into(), v);
         }
         if let Some(v) = raw_tools {
-            extra.insert("__anthropic_raw_tools".into(), v);
+            ingress.insert("__anthropic_raw_tools".into(), v);
         }
-
-        // PR-10 named extra fields ─────────────────────────────────────────────
-        if let Some(thinking) = req.thinking
-            && let Ok(v) = serde_json::to_value(&thinking)
+        if let Some(ref thinking) = req.thinking
+            && let Ok(v) = serde_json::to_value(thinking)
         {
-            extra.insert("__anthropic_thinking".into(), v);
+            ingress.insert("__anthropic_thinking".into(), v);
         }
-        if let Some(cm) = req.context_management
-            && let Ok(v) = serde_json::to_value(&cm)
+        if let Some(ref cm) = req.context_management
+            && let Ok(v) = serde_json::to_value(cm)
         {
-            extra.insert("__anthropic_context_management".into(), v);
+            ingress.insert("__anthropic_context_management".into(), v);
         }
-        if let Some(c) = req.container {
-            extra.insert("__anthropic_container".into(), Value::String(c));
+        if let Some(ref c) = req.container {
+            ingress.insert("__anthropic_container".into(), Value::String(c.clone()));
         }
-        if let Some(st) = req.service_tier {
-            extra.insert("__anthropic_service_tier".into(), Value::String(st));
+        if let Some(ref st) = req.service_tier {
+            ingress.insert("__anthropic_service_tier".into(), Value::String(st.clone()));
         }
-        if let Some(meta) = req.metadata {
-            extra.insert("__anthropic_metadata".into(), meta);
+        if let Some(ref meta) = req.metadata {
+            ingress.insert("__anthropic_metadata".into(), meta.clone());
         }
-        if let Some(stops) = req.stop_sequences
-            && let Ok(v) = serde_json::to_value(&stops)
+        if let Some(ref stops) = req.stop_sequences
+            && let Ok(v) = serde_json::to_value(stops)
         {
-            extra.insert("__anthropic_stop_sequences".into(), v);
+            ingress.insert("__anthropic_stop_sequences".into(), v);
         }
         if let Some(k) = req.top_k {
-            extra.insert("__anthropic_top_k".into(), Value::Number(k.into()));
+            ingress.insert("__anthropic_top_k".into(), Value::Number(k.into()));
         }
 
-        Ok(InternalRequest {
-            messages,
-            model: req.model,
-            stream: req.stream,
+        // ── Build AiRequest ───────────────────────────────────────────────────
+        let tools_opt = if user_tools.is_empty() {
+            None
+        } else {
+            Some(user_tools)
+        };
+
+        let mut ai_req = AiRequest::new(req.model, messages);
+        ai_req.generation = GenerationConfig {
             temperature: req.temperature,
             max_tokens: Some(req.max_tokens),
             top_p: req.top_p,
-            tools,
-            tool_choice: req.tool_choice,
-            source_protocol: ANTHROPIC_MESSAGES_2023_06_01,
-            extra,
-        })
+            stop: req.stop_sequences,
+            ..Default::default()
+        };
+        ai_req.stream = StreamConfig {
+            enabled: req.stream,
+            include_usage: false,
+        };
+        ai_req.tools = tools_opt;
+        ai_req.tool_choice = tool_choice;
+        ai_req.reasoning = reasoning;
+        ai_req.ext = Some(ProtocolExt::Anthropic(ant_ext));
+        ai_req.meta.source_protocol = Some(ANTHROPIC_MESSAGES_2023_06_01);
+        ai_req.meta.vendor.ingress = ingress;
+
+        Ok(ai_req)
     }
 }
 
 // ── Message decoding helpers ──────────────────────────────────────────────────
 
-fn decode_message(msg: AnthropicMessage) -> Result<Vec<InternalMessage>> {
+fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
     let role = match msg.role.as_str() {
         "user" => Role::User,
         "assistant" => Role::Assistant,
@@ -193,62 +263,95 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<InternalMessage>> {
     let (content, tool_calls, tool_call_id) = match msg.content {
         AnthropicContent::Text(t) => (MessageContent::Text(t), None, None),
         AnthropicContent::Blocks(blocks) => {
-            let mut content_blocks = Vec::new();
-            let mut tcs = Vec::new();
-            let mut tc_id = None;
+            let mut content_blocks: Vec<ContentBlock> = Vec::new();
+            let mut tcs: Vec<ToolCall> = Vec::new();
+            let mut tc_id: Option<String> = None;
 
             for block in blocks {
                 match block {
-                    AnthropicContentBlock::Text { text, .. } => {
-                        content_blocks.push(ContentBlock::Text { text });
+                    AnthropicContentBlock::Text {
+                        text,
+                        cache_control,
+                        ..
+                    } => {
+                        content_blocks.push(ContentBlock::Text {
+                            text,
+                            cache_control: cache_control.as_ref().map(map_cache_control),
+                        });
                     }
                     AnthropicContentBlock::Thinking {
                         thinking,
                         signature,
                         ..
                     } => {
-                        content_blocks.push(ContentBlock::Reasoning {
-                            text: thinking,
+                        content_blocks.push(ContentBlock::Thinking {
+                            thinking,
                             signature,
                         });
                     }
-                    AnthropicContentBlock::Image { source, .. } => {
+                    AnthropicContentBlock::Image {
+                        source,
+                        cache_control,
+                        ..
+                    } => {
                         content_blocks.push(ContentBlock::Image {
-                            source: ImageSource {
-                                media_type: source.media_type.unwrap_or_default(),
-                                data: source.data.unwrap_or_default(),
-                            },
+                            source: map_image_source(source),
+                            cache_control: cache_control.as_ref().map(map_cache_control),
                         });
                     }
                     AnthropicContentBlock::ToolUse {
-                        id, name, input, ..
+                        id,
+                        name,
+                        input,
+                        cache_control,
+                        ..
                     } => {
                         tcs.push(ToolCall {
                             id: id.clone(),
                             name: name.clone(),
                             arguments: input.to_string(),
                         });
-                        content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                        content_blocks.push(ContentBlock::ToolUse {
+                            id,
+                            name,
+                            input,
+                            cache_control: cache_control.as_ref().map(map_cache_control),
+                        });
                     }
                     AnthropicContentBlock::ToolResult {
                         tool_use_id,
                         content,
+                        cache_control,
                         ..
                     } => {
                         tc_id = Some(tool_use_id.clone());
                         content_blocks.push(ContentBlock::ToolResult {
                             tool_use_id,
                             content: content.unwrap_or(Value::Null),
+                            is_error: None,
+                            cache_control: cache_control.as_ref().map(map_cache_control),
                         });
                     }
-                    AnthropicContentBlock::Document { title, .. } => {
-                        // Best-effort IR representation; encoder uses raw bytes.
-                        let text = title.unwrap_or_else(|| "[document]".to_string());
-                        content_blocks.push(ContentBlock::Text { text });
+                    AnthropicContentBlock::Document {
+                        source,
+                        title,
+                        context,
+                        cache_control,
+                        ..
+                    } => {
+                        content_blocks.push(ContentBlock::Document {
+                            source: map_doc_source(source),
+                            title,
+                            context,
+                            cache_control: cache_control.as_ref().map(map_cache_control),
+                        });
                     }
-                    AnthropicContentBlock::InputAudio { .. } => {
-                        content_blocks.push(ContentBlock::Text {
-                            text: "[audio]".to_string(),
+                    AnthropicContentBlock::InputAudio { source, .. } => {
+                        content_blocks.push(ContentBlock::Audio {
+                            source: MediaSource::Base64 {
+                                media_type: source.media_type,
+                                data: source.data,
+                            },
                         });
                     }
                 }
@@ -257,14 +360,14 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<InternalMessage>> {
             let tool_calls_opt = if tcs.is_empty() { None } else { Some(tcs) };
 
             if content_blocks.len() == 1
-                && let ContentBlock::Text { text } = &content_blocks[0]
+                && let ContentBlock::Text { text, .. } = &content_blocks[0]
             {
-                return Ok(vec![InternalMessage {
+                return Ok(vec![Message {
                     role,
                     content: MessageContent::Text(text.clone()),
                     tool_calls: tool_calls_opt,
                     tool_call_id: tc_id,
-                    extra: Default::default(),
+                    meta: None,
                 }]);
             }
 
@@ -276,17 +379,17 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<InternalMessage>> {
         }
     };
 
-    Ok(vec![InternalMessage {
+    Ok(vec![Message {
         role,
         content,
         tool_calls,
         tool_call_id,
-        extra: Default::default(),
+        meta: None,
     }])
 }
 
-fn decode_user_blocks(blocks: Vec<AnthropicContentBlock>) -> Result<Vec<InternalMessage>> {
-    let mut messages: Vec<InternalMessage> = Vec::new();
+fn decode_user_blocks(blocks: Vec<AnthropicContentBlock>) -> Result<Vec<Message>> {
+    let mut messages: Vec<Message> = Vec::new();
     let mut user_blocks: Vec<ContentBlock> = Vec::new();
 
     for block in blocks {
@@ -301,64 +404,162 @@ fn decode_user_blocks(blocks: Vec<AnthropicContentBlock>) -> Result<Vec<Internal
                     Value::Null => String::new(),
                     other => other.to_string(),
                 };
-                messages.push(InternalMessage {
+                messages.push(Message {
                     role: Role::Tool,
                     content: MessageContent::Text(tool_text),
                     tool_calls: None,
                     tool_call_id: Some(tool_use_id),
-                    extra: Default::default(),
+                    meta: None,
                 });
             }
-            AnthropicContentBlock::Text { text, .. } => {
-                user_blocks.push(ContentBlock::Text { text })
+            AnthropicContentBlock::Text {
+                text,
+                cache_control,
+                ..
+            } => {
+                user_blocks.push(ContentBlock::Text {
+                    text,
+                    cache_control: cache_control.as_ref().map(map_cache_control),
+                });
             }
             AnthropicContentBlock::Thinking {
                 thinking,
                 signature,
                 ..
-            } => user_blocks.push(ContentBlock::Reasoning {
-                text: thinking,
-                signature,
-            }),
-            AnthropicContentBlock::Image { source, .. } => user_blocks.push(ContentBlock::Image {
-                source: ImageSource {
-                    media_type: source.media_type.unwrap_or_default(),
-                    data: source.data.unwrap_or_default(),
-                },
-            }),
+            } => {
+                user_blocks.push(ContentBlock::Thinking {
+                    thinking,
+                    signature,
+                });
+            }
+            AnthropicContentBlock::Image {
+                source,
+                cache_control,
+                ..
+            } => {
+                user_blocks.push(ContentBlock::Image {
+                    source: map_image_source(source),
+                    cache_control: cache_control.as_ref().map(map_cache_control),
+                });
+            }
             AnthropicContentBlock::ToolUse {
-                id, name, input, ..
-            } => user_blocks.push(ContentBlock::ToolUse { id, name, input }),
-            AnthropicContentBlock::Document { title, .. } => user_blocks.push(ContentBlock::Text {
-                text: title.unwrap_or_else(|| "[document]".to_string()),
-            }),
-            AnthropicContentBlock::InputAudio { .. } => user_blocks.push(ContentBlock::Text {
-                text: "[audio]".to_string(),
-            }),
+                id,
+                name,
+                input,
+                cache_control,
+                ..
+            } => {
+                user_blocks.push(ContentBlock::ToolUse {
+                    id,
+                    name,
+                    input,
+                    cache_control: cache_control.as_ref().map(map_cache_control),
+                });
+            }
+            AnthropicContentBlock::Document {
+                source,
+                title,
+                context,
+                cache_control,
+                ..
+            } => {
+                user_blocks.push(ContentBlock::Document {
+                    source: map_doc_source(source),
+                    title,
+                    context,
+                    cache_control: cache_control.as_ref().map(map_cache_control),
+                });
+            }
+            AnthropicContentBlock::InputAudio { source, .. } => {
+                user_blocks.push(ContentBlock::Audio {
+                    source: MediaSource::Base64 {
+                        media_type: source.media_type,
+                        data: source.data,
+                    },
+                });
+            }
         }
     }
 
     if !user_blocks.is_empty() {
-        let content = if user_blocks.len() == 1 {
-            if let ContentBlock::Text { text } = &user_blocks[0] {
-                MessageContent::Text(text.clone())
-            } else {
-                MessageContent::Blocks(user_blocks)
-            }
+        let content = if user_blocks.len() == 1
+            && let ContentBlock::Text { text, .. } = &user_blocks[0]
+        {
+            MessageContent::Text(text.clone())
         } else {
             MessageContent::Blocks(user_blocks)
         };
         messages.insert(
             0,
-            InternalMessage {
+            Message {
                 role: Role::User,
                 content,
                 tool_calls: None,
                 tool_call_id: None,
-                extra: Default::default(),
+                meta: None,
             },
         );
     }
 
     Ok(messages)
+}
+
+// ── Type-mapping helpers ──────────────────────────────────────────────────────
+
+fn map_cache_control(_cc: &WireCacheControl) -> crate::protocol::ir::CacheControl {
+    // Anthropic only has "ephemeral" TTL.
+    crate::protocol::ir::CacheControl {
+        ttl: CacheTtl::Ephemeral5m,
+        breakpoint_priority: 0,
+    }
+}
+
+fn map_image_source(src: AnthropicImageSource) -> MediaSource {
+    match src.source_type.as_str() {
+        "base64" => MediaSource::Base64 {
+            media_type: src.media_type.unwrap_or_default(),
+            data: src.data.unwrap_or_default(),
+        },
+        "url" => MediaSource::Url(src.url.unwrap_or_default()),
+        _ => MediaSource::Base64 {
+            media_type: src.media_type.unwrap_or_default(),
+            data: src.data.unwrap_or_default(),
+        },
+    }
+}
+
+fn map_doc_source(src: WireDocumentSource) -> IrDocumentSource {
+    match src.kind.as_str() {
+        "base64" => IrDocumentSource::Base64Pdf {
+            data: src.data.unwrap_or_default(),
+        },
+        "text" => IrDocumentSource::PlainText {
+            data: src.data.unwrap_or_default(),
+        },
+        "url" => IrDocumentSource::Url(src.url.unwrap_or_default()),
+        "content" => IrDocumentSource::Blocks {
+            content: Vec::new(), // encoder uses raw JSON; best-effort stub
+        },
+        _ => IrDocumentSource::PlainText {
+            data: src.data.unwrap_or_default(),
+        },
+    }
+}
+
+fn parse_tool_choice(v: Value) -> ToolChoice {
+    match v.get("type").and_then(|t| t.as_str()) {
+        Some("auto") => ToolChoice::Auto,
+        Some("any") => ToolChoice::Required,
+        Some("none") => ToolChoice::None,
+        Some("tool") => {
+            if let Some(name) = v.get("name").and_then(|n| n.as_str()) {
+                ToolChoice::Named {
+                    name: name.to_string(),
+                }
+            } else {
+                ToolChoice::Raw(v)
+            }
+        }
+        _ => ToolChoice::Raw(v),
+    }
 }

--- a/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
@@ -1,25 +1,28 @@
+//! Google Generative AI ingress decoder — produces `AiRequest` directly.
+//!
+//! `decode_with_model` accepts the model and stream flag extracted from the URL
+//! path by the ingress shell handler, since Google embeds the model in the path
+//! rather than the request body.
+
 use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
 use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
-use crate::protocol::types::*;
+use crate::protocol::ir::{
+    AiRequest, ContentBlock, GenerationConfig, GoogleExt, MediaSource, Message, MessageContent,
+    ProtocolExt, ReasoningConfig, Role, SafetySettings, StreamConfig, ToolCall, ToolSpec,
+};
 
 use super::types::*;
 
 pub struct GoogleDecoder;
 
 impl GoogleDecoder {
-    pub fn decode_with_model(
-        &self,
-        body: Value,
-        model: &str,
-        stream: bool,
-    ) -> Result<InternalRequest> {
+    pub fn decode_with_model(&self, body: Value, model: &str, stream: bool) -> Result<AiRequest> {
         let req: GoogleRequest = serde_json::from_value(body)?;
 
         // ── System instruction ────────────────────────────────────────────────
-        // If the system instruction has non-text parts, preserve raw value.
         let needs_raw_system = req.system_instruction.as_ref().is_some_and(|si| {
             si.parts.len() > 1
                 || si
@@ -27,7 +30,6 @@ impl GoogleDecoder {
                     .iter()
                     .any(|p| !matches!(p, GooglePart::Text { .. }))
         });
-
         let raw_system: Option<Value> = if needs_raw_system {
             req.system_instruction
                 .as_ref()
@@ -44,7 +46,6 @@ impl GoogleDecoder {
                     || t.google_search_retrieval.is_some()
             })
         });
-
         let raw_tools: Option<Value> = if has_builtin_tools {
             req.tools
                 .as_ref()
@@ -53,7 +54,8 @@ impl GoogleDecoder {
             None
         };
 
-        let mut messages = Vec::new();
+        // ── Messages ──────────────────────────────────────────────────────────
+        let mut messages: Vec<Message> = Vec::new();
 
         // System message from system_instruction
         if let Some(si) = &req.system_instruction {
@@ -67,12 +69,12 @@ impl GoogleDecoder {
                 .collect::<Vec<_>>()
                 .join("\n");
             if !text.is_empty() {
-                messages.push(InternalMessage {
+                messages.push(Message {
                     role: Role::System,
                     content: MessageContent::Text(text),
                     tool_calls: None,
                     tool_call_id: None,
-                    extra: Default::default(),
+                    meta: None,
                 });
             }
         }
@@ -81,104 +83,172 @@ impl GoogleDecoder {
             messages.push(decode_content(content)?);
         }
 
-        // ── Tools: function declarations + sentinel built-ins ─────────────────
+        // ── Tools ─────────────────────────────────────────────────────────────
         let tools = req.tools.as_ref().map(|entries| {
-            let mut defs: Vec<ToolDef> = Vec::new();
+            let mut defs: Vec<ToolSpec> = Vec::new();
             for entry in entries {
                 if let Some(decls) = &entry.function_declarations {
                     for fd in decls {
-                        defs.push(ToolDef {
+                        defs.push(ToolSpec {
                             name: fd.name.clone(),
                             description: fd.description.clone(),
                             parameters: fd
                                 .parameters
                                 .clone()
                                 .unwrap_or(Value::Object(Default::default())),
+                            strict: None,
+                            cache_control: None,
+                            meta: None,
                         });
                     }
                 }
                 if entry.google_search.is_some() {
-                    defs.push(ToolDef {
+                    defs.push(ToolSpec {
                         name: "__builtin__google_search".into(),
                         description: None,
                         parameters: Value::Object(Default::default()),
+                        strict: None,
+                        cache_control: None,
+                        meta: None,
                     });
                 }
                 if entry.code_execution.is_some() {
-                    defs.push(ToolDef {
+                    defs.push(ToolSpec {
                         name: "__builtin__code_execution".into(),
                         description: None,
                         parameters: Value::Object(Default::default()),
+                        strict: None,
+                        cache_control: None,
+                        meta: None,
                     });
                 }
                 if entry.google_search_retrieval.is_some() {
-                    defs.push(ToolDef {
+                    defs.push(ToolSpec {
                         name: "__builtin__google_search_retrieval".into(),
                         description: None,
                         parameters: Value::Object(Default::default()),
+                        strict: None,
+                        cache_control: None,
+                        meta: None,
                     });
                 }
             }
             defs
         });
 
-        // ── generationConfig → InternalRequest fields + extra ─────────────────
+        // ── generationConfig → IR fields + GoogleExt ──────────────────────────
         let gc = req.generation_config.as_ref();
         let max_tokens = gc.and_then(|c| c.max_output_tokens);
         let temperature = gc.and_then(|c| c.temperature);
         let top_p = gc.and_then(|c| c.top_p);
+        let stop = gc.and_then(|c| c.stop_sequences.clone());
+        let seed = gc.and_then(|c| c.seed.map(|s| s as i64));
+        let frequency_penalty = gc.and_then(|c| c.frequency_penalty);
+        let presence_penalty = gc.and_then(|c| c.presence_penalty);
 
-        let mut extra: std::collections::HashMap<String, Value> = Default::default();
+        // Reasoning from thinkingConfig
+        let reasoning = if let Some(tc) = gc.and_then(|c| c.thinking_config.as_ref()) {
+            let budget = tc
+                .get("thinkingBudget")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            ReasoningConfig {
+                enabled: budget.map(|b| b > 0).unwrap_or(false),
+                budget_tokens: budget,
+                ..Default::default()
+            }
+        } else {
+            ReasoningConfig::default()
+        };
 
-        // Preserve full generationConfig so encoder can re-emit extended fields.
-        if let Some(gen_cfg) = &req.generation_config
+        // Safety settings
+        let safety_settings = req.safety_settings.as_ref().map(|ss| {
+            ss.iter()
+                .map(|s| SafetySettings {
+                    category: s.category.clone(),
+                    threshold: s.threshold.clone(),
+                })
+                .collect()
+        });
+
+        // GoogleExt
+        let google_ext = GoogleExt {
+            top_k: gc.and_then(|c| c.top_k.map(|v| v as u32)),
+            candidate_count: gc.and_then(|c| c.candidate_count),
+            response_logprobs: gc.and_then(|c| c.response_logprobs),
+            logprobs: gc.and_then(|c| c.logprobs.map(|v| v as u32)),
+            response_mime_type: gc.and_then(|c| c.response_mime_type.clone()),
+            response_json_schema: gc.and_then(|c| c.response_schema.clone()),
+            tool_config: req.tool_config.clone(),
+            cached_content: req.cached_content.clone(),
+            thinking_config: gc.and_then(|c| c.thinking_config.clone()),
+            ..Default::default()
+        };
+
+        // ── Vendor ingress bag — backward compat for old Google encoder ────────
+        let mut ingress = std::collections::HashMap::new();
+
+        if let Some(ref gen_cfg) = req.generation_config
             && let Ok(v) = serde_json::to_value(gen_cfg)
         {
-            extra.insert("__google_generation_config".into(), v);
+            ingress.insert("__google_generation_config".into(), v);
         }
-
         if let Some(v) = raw_system {
-            extra.insert("__google_raw_system_instruction".into(), v);
+            ingress.insert("__google_raw_system_instruction".into(), v);
         }
         if let Some(v) = raw_tools {
-            extra.insert("__google_raw_tools".into(), v);
+            ingress.insert("__google_raw_tools".into(), v);
         }
         if let Some(ref ss) = req.safety_settings
             && let Ok(v) = serde_json::to_value(ss)
         {
-            extra.insert("__google_safety_settings".into(), v);
+            ingress.insert("__google_safety_settings".into(), v);
         }
         if let Some(ref tc) = req.tool_config {
-            extra.insert("__google_tool_config".into(), tc.clone());
+            ingress.insert("__google_tool_config".into(), tc.clone());
         }
         if let Some(ref cc) = req.cached_content {
-            extra.insert("__google_cached_content".into(), Value::String(cc.clone()));
+            ingress.insert("__google_cached_content".into(), Value::String(cc.clone()));
         }
 
-        Ok(InternalRequest {
-            messages,
-            model: model.to_string(),
-            stream,
+        // ── Build AiRequest ───────────────────────────────────────────────────
+        let tools_opt = tools.filter(|t| !t.is_empty());
+
+        let mut ai_req = AiRequest::new(model.to_string(), messages);
+        ai_req.generation = GenerationConfig {
             temperature,
             max_tokens,
             top_p,
-            tools,
-            tool_choice: None,
-            source_protocol: GOOGLE_GENERATE_CONTENT_V1BETA,
-            extra,
-        })
+            seed,
+            stop,
+            frequency_penalty,
+            presence_penalty,
+            ..Default::default()
+        };
+        ai_req.stream = StreamConfig {
+            enabled: stream,
+            include_usage: false,
+        };
+        ai_req.tools = tools_opt;
+        ai_req.reasoning = reasoning;
+        ai_req.safety_settings = safety_settings;
+        ai_req.ext = Some(ProtocolExt::Google(google_ext));
+        ai_req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+        ai_req.meta.vendor.ingress = ingress;
+
+        Ok(ai_req)
     }
 }
 
 impl IngressDecoder for GoogleDecoder {
-    fn decode_request(&self, body: Value) -> Result<InternalRequest> {
+    fn decode_request(&self, body: Value) -> Result<AiRequest> {
         self.decode_with_model(body, "gemini-2.0-flash", false)
     }
 }
 
 // ── Content decoding ──────────────────────────────────────────────────────────
 
-fn decode_content(content: GoogleContent) -> Result<InternalMessage> {
+fn decode_content(content: GoogleContent) -> Result<Message> {
     let mut role = match content.role.as_deref() {
         Some("user") | None => Role::User,
         Some("model") => Role::Assistant,
@@ -194,24 +264,28 @@ fn decode_content(content: GoogleContent) -> Result<InternalMessage> {
         match part {
             GooglePart::Text { text } => {
                 text_parts.push(text.clone());
-                blocks.push(ContentBlock::Text { text });
+                blocks.push(ContentBlock::Text {
+                    text,
+                    cache_control: None,
+                });
             }
             GooglePart::InlineData { inline_data } => {
                 blocks.push(ContentBlock::Image {
-                    source: ImageSource {
+                    source: MediaSource::Base64 {
                         media_type: inline_data.mime_type,
                         data: inline_data.data,
                     },
+                    cache_control: None,
                 });
             }
             GooglePart::FileData { file_data } => {
-                // Represent file references as Image with URI as data.
-                blocks.push(ContentBlock::Image {
-                    source: ImageSource {
-                        media_type: file_data.mime_type.unwrap_or_default(),
-                        data: file_data.file_uri,
-                    },
-                });
+                let mime = file_data.mime_type.unwrap_or_default();
+                let source = if mime.starts_with("image/") || mime.is_empty() {
+                    MediaSource::Url(file_data.file_uri)
+                } else {
+                    MediaSource::Url(file_data.file_uri)
+                };
+                blocks.push(ContentBlock::File { source });
             }
             GooglePart::FunctionCall { function_call } => {
                 let id = format!("call_{}", uuid::Uuid::new_v4().simple());
@@ -224,6 +298,7 @@ fn decode_content(content: GoogleContent) -> Result<InternalMessage> {
                     id,
                     name: function_call.name,
                     input: function_call.args,
+                    cache_control: None,
                 });
             }
             GooglePart::FunctionResponse { function_response } => {
@@ -231,25 +306,46 @@ fn decode_content(content: GoogleContent) -> Result<InternalMessage> {
                 blocks.push(ContentBlock::ToolResult {
                     tool_use_id: function_response.name,
                     content: function_response.response,
+                    is_error: None,
+                    cache_control: None,
                 });
             }
             GooglePart::ExecutableCode { executable_code } => {
-                blocks.push(ContentBlock::Text {
-                    text: executable_code.code,
+                blocks.push(ContentBlock::ExecutableCode {
+                    code: executable_code.code,
+                    language: executable_code.language,
+                    id: None,
                 });
             }
             GooglePart::CodeExecutionResult {
                 code_execution_result,
             } => {
                 let output = code_execution_result.output.unwrap_or_default();
-                blocks.push(ContentBlock::Text { text: output });
+                blocks.push(ContentBlock::CodeExecutionResult {
+                    return_code: 0,
+                    stdout: output,
+                    stderr: String::new(),
+                    id: None,
+                });
             }
             GooglePart::Other(v) => {
-                // Thought parts or future types: surface text if available.
-                if let Some(text) = v.get("text").and_then(|t| t.as_str()) {
+                // Detect thought parts (Gemini 2.5 extended thinking).
+                let is_thought = v.get("thought").and_then(|t| t.as_bool()).unwrap_or(false);
+                if is_thought {
+                    let thinking = v
+                        .get("text")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    blocks.push(ContentBlock::Thinking {
+                        thinking,
+                        signature: None,
+                    });
+                } else if let Some(text) = v.get("text").and_then(|t| t.as_str()) {
                     text_parts.push(text.to_string());
                     blocks.push(ContentBlock::Text {
                         text: text.to_string(),
+                        cache_control: None,
                     });
                 }
             }
@@ -271,11 +367,11 @@ fn decode_content(content: GoogleContent) -> Result<InternalMessage> {
         role = Role::Tool;
     }
 
-    Ok(InternalMessage {
+    Ok(Message {
         role,
         content: msg_content,
         tool_calls: tool_calls_opt,
         tool_call_id: None,
-        extra: Default::default(),
+        meta: None,
     })
 }

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
@@ -1,27 +1,26 @@
-//! OpenAI Chat Completions ingress decoder (PR-08).
+//! OpenAI Chat Completions ingress decoder — produces `AiRequest` directly.
 //!
-//! Decodes a client `POST /v1/chat/completions` body into `InternalRequest`.
-//!
-//! Fields added in PR-08 that don't have a first-class slot in the old IR are
-//! preserved in `InternalRequest.extra` under their original JSON key names.
-//! They will migrate to `AiRequest` proper when the codec is updated to emit
-//! `AiRequest` directly (post-PR-06 migration).
-//!
-//! Zero-cost for fields the client did not send (all `Option`).
+//! Protocol-specific fields that don't belong in the IR core are stored in:
+//! - `AiRequest.ext = Some(ProtocolExt::OpenAiChat(OpenAIChatExt { … }))` — typed Ext
+//! - `AiRequest.meta.vendor.ingress` — backward-compat bag for old encoders (PR-3 will clean up)
 
 use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
 use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-use crate::protocol::types::*;
+use crate::protocol::ir::{
+    AiRequest, ContentBlock, GenerationConfig, MediaSource, Message, MessageContent, OpenAIChatExt,
+    ProtocolExt, ReasoningConfig, ReasoningEffort, ResponseFormat, Role, StreamConfig, ToolCall,
+    ToolChoice, ToolSpec,
+};
 
 use super::types::*;
 
 pub struct OpenAIDecoder;
 
 impl IngressDecoder for OpenAIDecoder {
-    fn decode_request(&self, body: Value) -> Result<InternalRequest> {
+    fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let req: OpenAIRequest = serde_json::from_value(body)?;
 
         let messages = req
@@ -35,7 +34,7 @@ impl IngressDecoder for OpenAIDecoder {
                 .iter()
                 .filter_map(|t| {
                     let func = t.get("function")?;
-                    Some(ToolDef {
+                    Some(ToolSpec {
                         name: func.get("name")?.as_str()?.to_string(),
                         description: func
                             .get("description")
@@ -45,113 +44,178 @@ impl IngressDecoder for OpenAIDecoder {
                             .get("parameters")
                             .cloned()
                             .unwrap_or(Value::Object(Default::default())),
+                        strict: func.get("strict").and_then(|v| v.as_bool()),
+                        cache_control: None,
+                        meta: None,
                     })
                 })
                 .collect()
         });
 
-        // ── Extra fields (PR-08) ──────────────────────────────────────────────
-        let mut extra = req.extra;
+        let tool_choice = req.tool_choice.map(parse_tool_choice);
 
-        // Prefer max_completion_tokens (o-models); fall back to max_tokens.
+        // Prefer max_completion_tokens (o-models), fall back to max_tokens.
         let effective_max_tokens = req.max_completion_tokens.or(req.max_tokens);
 
-        // Carry PR-08 fields as first-class extras for downstream encoding.
-        if let Some(v) = req.stream_options {
-            extra
-                .entry("stream_options".to_string())
-                .or_insert_with(|| serde_json::to_value(v).unwrap_or(Value::Null));
+        let reasoning = match &req.reasoning_effort {
+            Some(s) => ReasoningConfig {
+                enabled: true,
+                effort: Some(parse_reasoning_effort(s)),
+                ..Default::default()
+            },
+            None => ReasoningConfig::default(),
+        };
+
+        let include_usage = req
+            .stream_options
+            .as_ref()
+            .map(|s| s.include_usage)
+            .unwrap_or(false);
+
+        // ── ProtocolExt ───────────────────────────────────────────────────────
+        let oai_ext = OpenAIChatExt {
+            audio: req
+                .audio
+                .as_ref()
+                .and_then(|a| serde_json::to_value(a).ok()),
+            logit_bias: req.logit_bias.clone(),
+            modalities: req.modalities.clone(),
+            n: req.n,
+            prediction: req
+                .prediction
+                .as_ref()
+                .and_then(|p| serde_json::to_value(p).ok()),
+            stream_options: req
+                .stream_options
+                .as_ref()
+                .and_then(|s| serde_json::to_value(s).ok()),
+            ..Default::default()
+        };
+
+        // ── Vendor ingress bag — backward compat for old encoders (pre-PR-3) ──
+        // Old OpenAI encoder reads these keys from InternalRequest.extra, which
+        // is populated from meta.vendor.ingress via compat.rs.
+        let mut ingress = req.extra.clone(); // unknown flatten'd fields
+        macro_rules! put_opt_value {
+            ($key:expr, $val:expr) => {
+                if let Some(v) = $val {
+                    ingress
+                        .entry($key.to_string())
+                        .or_insert_with(|| serde_json::to_value(v).unwrap_or(Value::Null));
+                }
+            };
         }
-        if let Some(v) = req.parallel_tool_calls {
-            extra
-                .entry("parallel_tool_calls".to_string())
-                .or_insert_with(|| Value::Bool(v));
+        macro_rules! put_bool {
+            ($key:expr, $val:expr) => {
+                if let Some(v) = $val {
+                    ingress
+                        .entry($key.to_string())
+                        .or_insert_with(|| Value::Bool(v));
+                }
+            };
         }
-        if let Some(v) = req.prediction {
-            extra
-                .entry("prediction".to_string())
-                .or_insert_with(|| serde_json::to_value(v).unwrap_or(Value::Null));
+        macro_rules! put_str {
+            ($key:expr, $val:expr) => {
+                if let Some(v) = $val {
+                    ingress
+                        .entry($key.to_string())
+                        .or_insert_with(|| Value::String(v.clone()));
+                }
+            };
         }
-        if let Some(v) = req.modalities {
-            extra
+        put_opt_value!("stream_options", req.stream_options.as_ref());
+        put_bool!("parallel_tool_calls", req.parallel_tool_calls);
+        put_opt_value!("prediction", req.prediction.as_ref());
+        if let Some(ref v) = req.modalities {
+            ingress
                 .entry("modalities".to_string())
-                .or_insert_with(|| Value::Array(v.into_iter().map(Value::String).collect()));
+                .or_insert_with(|| Value::Array(v.iter().cloned().map(Value::String).collect()));
         }
-        if let Some(v) = req.audio {
-            extra
-                .entry("audio".to_string())
-                .or_insert_with(|| serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(v) = req.response_format {
-            extra
+        put_opt_value!("audio", req.audio.as_ref());
+        if let Some(ref v) = req.response_format {
+            ingress
                 .entry("response_format".to_string())
                 .or_insert_with(|| serde_json::to_value(v).unwrap_or(Value::Null));
         }
         if let Some(v) = req.seed {
-            extra
+            ingress
                 .entry("seed".to_string())
                 .or_insert_with(|| Value::from(v));
         }
-        if let Some(v) = req.stop {
-            extra.entry("stop".to_string()).or_insert_with(|| match v {
-                StopToken::Single(s) => Value::String(s),
-                StopToken::Multiple(vs) => {
-                    Value::Array(vs.into_iter().map(Value::String).collect())
-                }
+        if let Some(ref v) = req.stop {
+            ingress
+                .entry("stop".to_string())
+                .or_insert_with(|| match v {
+                    StopToken::Single(s) => Value::String(s.clone()),
+                    StopToken::Multiple(vs) => {
+                        Value::Array(vs.iter().cloned().map(Value::String).collect())
+                    }
+                });
+        }
+        if let Some(ref v) = req.logit_bias {
+            ingress.entry("logit_bias".to_string()).or_insert_with(|| {
+                Value::Object(
+                    v.iter()
+                        .map(|(k, f)| (k.clone(), Value::from(*f)))
+                        .collect(),
+                )
             });
         }
-        if let Some(v) = req.logit_bias {
-            extra.entry("logit_bias".to_string()).or_insert_with(|| {
-                Value::Object(v.into_iter().map(|(k, f)| (k, Value::from(f))).collect())
-            });
-        }
-        if let Some(v) = req.service_tier {
-            extra
-                .entry("service_tier".to_string())
-                .or_insert_with(|| Value::String(v));
-        }
-        if let Some(v) = req.reasoning_effort {
-            extra
-                .entry("reasoning_effort".to_string())
-                .or_insert_with(|| Value::String(v));
-        }
+        put_str!("service_tier", req.service_tier.as_ref());
+        put_str!("reasoning_effort", req.reasoning_effort.as_ref());
         if let Some(v) = req.frequency_penalty {
-            extra
+            ingress
                 .entry("frequency_penalty".to_string())
                 .or_insert_with(|| Value::from(v));
         }
         if let Some(v) = req.presence_penalty {
-            extra
+            ingress
                 .entry("presence_penalty".to_string())
                 .or_insert_with(|| Value::from(v));
         }
         if let Some(v) = req.n {
-            extra
+            ingress
                 .entry("n".to_string())
                 .or_insert_with(|| Value::from(v));
         }
-        if let Some(v) = req.user {
-            extra
-                .entry("user".to_string())
-                .or_insert_with(|| Value::String(v));
-        }
+        put_str!("user", req.user.as_ref());
 
-        Ok(InternalRequest {
-            messages,
-            model: req.model,
-            stream: req.stream,
+        // Consume stop and response_format AFTER ingress bag is built.
+        let stop = req.stop.map(StopToken::into_vec);
+        let response_format = req.response_format.map(parse_response_format);
+
+        // ── Build AiRequest ───────────────────────────────────────────────────
+        let mut ai_req = AiRequest::new(req.model, messages);
+        ai_req.generation = GenerationConfig {
             temperature: req.temperature,
             max_tokens: effective_max_tokens,
             top_p: req.top_p,
-            tools,
-            tool_choice: req.tool_choice,
-            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
-            extra,
-        })
+            seed: req.seed,
+            stop,
+            frequency_penalty: req.frequency_penalty,
+            presence_penalty: req.presence_penalty,
+            ..Default::default()
+        };
+        ai_req.stream = StreamConfig {
+            enabled: req.stream,
+            include_usage,
+        };
+        ai_req.tools = tools;
+        ai_req.tool_choice = tool_choice;
+        ai_req.parallel_tool_calls = req.parallel_tool_calls;
+        ai_req.reasoning = reasoning;
+        ai_req.response_format = response_format;
+        ai_req.ext = Some(ProtocolExt::OpenAiChat(oai_ext));
+        ai_req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+        ai_req.meta.vendor.ingress = ingress;
+
+        Ok(ai_req)
     }
 }
 
-fn decode_message(msg: OpenAIMessage) -> Result<InternalMessage> {
+// ── Message decoding ──────────────────────────────────────────────────────────
+
+fn decode_message(msg: OpenAIMessage) -> Result<Message> {
     let role = match msg.role.as_str() {
         "system" | "developer" => Role::System,
         "user" => Role::User,
@@ -166,20 +230,26 @@ fn decode_message(msg: OpenAIMessage) -> Result<InternalMessage> {
             let blocks = parts
                 .into_iter()
                 .map(|p| match p {
-                    OpenAIContentPart::Text { text } => ContentBlock::Text { text },
-                    OpenAIContentPart::ImageUrl { image_url } => ContentBlock::Image {
-                        source: ImageSource {
-                            media_type: "image/url".to_string(),
-                            data: image_url.url,
-                        },
+                    OpenAIContentPart::Text { text } => ContentBlock::Text {
+                        text,
+                        cache_control: None,
                     },
-                    // InputAudio: pass as text; will be handled by audio-aware encoders.
-                    OpenAIContentPart::InputAudio { input_audio } => ContentBlock::Text {
-                        text: format!(
-                            "[audio:{}:{}]",
-                            input_audio.format,
-                            &input_audio.data[..input_audio.data.len().min(16)]
-                        ),
+                    OpenAIContentPart::ImageUrl { image_url } => {
+                        let source = if image_url.url.starts_with("data:") {
+                            parse_data_url_source(image_url.url)
+                        } else {
+                            MediaSource::Url(image_url.url)
+                        };
+                        ContentBlock::Image {
+                            source,
+                            cache_control: None,
+                        }
+                    }
+                    OpenAIContentPart::InputAudio { input_audio } => ContentBlock::Audio {
+                        source: MediaSource::Base64 {
+                            media_type: format!("audio/{}", input_audio.format),
+                            data: input_audio.data,
+                        },
                     },
                 })
                 .collect();
@@ -198,11 +268,91 @@ fn decode_message(msg: OpenAIMessage) -> Result<InternalMessage> {
             .collect()
     });
 
-    Ok(InternalMessage {
+    // Put any per-message extra fields + refusal into meta.
+    let mut meta_obj = serde_json::Map::new();
+    for (k, v) in msg.extra {
+        meta_obj.insert(k, v);
+    }
+    if let Some(ref r) = msg.refusal {
+        meta_obj.insert("refusal".to_string(), Value::String(r.clone()));
+    }
+    let meta = if meta_obj.is_empty() {
+        None
+    } else {
+        Some(Value::Object(meta_obj))
+    };
+
+    Ok(Message {
         role,
         content,
         tool_calls,
         tool_call_id: msg.tool_call_id,
-        extra: msg.extra,
+        meta,
     })
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse_tool_choice(v: Value) -> ToolChoice {
+    match &v {
+        Value::String(s) => match s.as_str() {
+            "none" => ToolChoice::None,
+            "auto" => ToolChoice::Auto,
+            "required" => ToolChoice::Required,
+            _ => ToolChoice::Raw(v),
+        },
+        Value::Object(obj) => {
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function") {
+                if let Some(name) = obj
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                {
+                    return ToolChoice::Named {
+                        name: name.to_string(),
+                    };
+                }
+            }
+            ToolChoice::Raw(v)
+        }
+        _ => ToolChoice::Raw(v),
+    }
+}
+
+fn parse_reasoning_effort(s: &str) -> ReasoningEffort {
+    match s {
+        "low" => ReasoningEffort::Low,
+        "high" => ReasoningEffort::High,
+        _ => ReasoningEffort::Medium,
+    }
+}
+
+fn parse_response_format(f: ResponseFormatWire) -> ResponseFormat {
+    match f {
+        ResponseFormatWire::Text => ResponseFormat::Text,
+        ResponseFormatWire::JsonObject => ResponseFormat::JsonObject,
+        ResponseFormatWire::JsonSchema { json_schema } => ResponseFormat::JsonSchema {
+            name: json_schema.name,
+            schema: json_schema.schema,
+            strict: json_schema.strict,
+        },
+    }
+}
+
+/// Parse a `data:<media_type>;base64,<data>` URL into a `MediaSource::Base64`.
+/// Falls back to `MediaSource::Url` if the format is not recognised.
+fn parse_data_url_source(url: String) -> MediaSource {
+    if let Some(rest) = url.strip_prefix("data:") {
+        if let Some(semi) = rest.find(';') {
+            let media_type = rest[..semi].to_string();
+            let after = &rest[semi + 1..];
+            if let Some(data) = after.strip_prefix("base64,") {
+                return MediaSource::Base64 {
+                    media_type,
+                    data: data.to_string(),
+                };
+            }
+        }
+    }
+    MediaSource::Url(url)
 }

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
@@ -33,6 +33,7 @@ use serde_json::Value;
 
 use crate::protocol::SseEvent;
 use crate::protocol::ids::{EndpointCapabilities, OPENAI_EMBEDDINGS_V1, ProtocolEndpoint};
+use crate::protocol::ir::{AiRequest, GenerationConfig, Message, StreamConfig};
 use crate::protocol::registry::EndpointRegistration;
 use crate::protocol::traits::*;
 use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta, TokenUsage};
@@ -102,7 +103,7 @@ inventory::submit! {
 struct EmbeddingsDecoder;
 
 impl IngressDecoder for EmbeddingsDecoder {
-    fn decode_request(&self, body: Value) -> anyhow::Result<InternalRequest> {
+    fn decode_request(&self, body: Value) -> anyhow::Result<AiRequest> {
         let obj = body
             .as_object()
             .ok_or_else(|| anyhow::anyhow!("embeddings request must be a JSON object"))?;
@@ -115,30 +116,26 @@ impl IngressDecoder for EmbeddingsDecoder {
             .map(ToString::to_string)
             .ok_or_else(|| anyhow::anyhow!("model is required for embeddings"))?;
 
-        let mut extra: HashMap<String, Value> = HashMap::new();
+        // ── Vendor ingress bag (backward compat for EmbeddingsEncoder) ─────────
+        let mut ingress: HashMap<String, Value> = HashMap::new();
 
         // Keep the original body so `embeddings_proxy` can forward it.
-        extra.insert(EMBEDDINGS_BODY_KEY.to_string(), body.clone());
+        ingress.insert(EMBEDDINGS_BODY_KEY.to_string(), body.clone());
 
-        // ── Parse known fields ────────────────────────────────────────────────
-        // `input` can be: string | string[] | integer[] | integer[][]
         if let Some(input) = obj.get("input") {
-            extra.insert("__emb_input".into(), input.clone());
+            ingress.insert("__emb_input".into(), input.clone());
         }
         if let Some(dims) = obj.get("dimensions") {
-            extra.insert("__emb_dimensions".into(), dims.clone());
+            ingress.insert("__emb_dimensions".into(), dims.clone());
         }
         if let Some(ef) = obj.get("encoding_format") {
-            extra.insert("__emb_encoding_format".into(), ef.clone());
+            ingress.insert("__emb_encoding_format".into(), ef.clone());
         }
         if let Some(user) = obj.get("user") {
-            extra.insert("__emb_user".into(), user.clone());
+            ingress.insert("__emb_user".into(), user.clone());
         }
 
-        // ── Vendor extensions – ingress segment ───────────────────────────────
         // Collect unknown fields into __vendor_ingress.
-        // Policy is VendorFieldPolicy::Drop, so the encoder will not forward
-        // them unless the policy is relaxed per-provider in the future.
         let mut vendor_ingress = serde_json::Map::new();
         for (k, v) in obj {
             if !KNOWN_EMBEDDINGS_FIELDS.contains(&k.as_str()) {
@@ -146,21 +143,19 @@ impl IngressDecoder for EmbeddingsDecoder {
             }
         }
         if !vendor_ingress.is_empty() {
-            extra.insert("__vendor_ingress".into(), Value::Object(vendor_ingress));
+            ingress.insert("__vendor_ingress".into(), Value::Object(vendor_ingress));
         }
 
-        Ok(InternalRequest {
-            messages: Vec::new(),
-            model,
-            stream: false,
-            temperature: None,
-            max_tokens: None,
-            top_p: None,
-            tools: None,
-            tool_choice: None,
-            source_protocol: OPENAI_EMBEDDINGS_V1,
-            extra,
-        })
+        let mut ai_req = AiRequest::new(model, Vec::<Message>::new());
+        ai_req.generation = GenerationConfig::default();
+        ai_req.stream = StreamConfig {
+            enabled: false,
+            include_usage: false,
+        };
+        ai_req.meta.source_protocol = Some(OPENAI_EMBEDDINGS_V1);
+        ai_req.meta.vendor.ingress = ingress;
+
+        Ok(ai_req)
     }
 }
 

--- a/crates/nyro-core/src/protocol/codec/openai_responses/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/decoder.rs
@@ -1,14 +1,4 @@
-//! OpenAI Responses API ingress decoder (PR-09).
-//!
-//! Added in PR-09:
-//! - `background` (bool) — run in background
-//! - `previous_response_id` — link to prior response (multi-turn stateful)
-//! - Built-in tools: `web_search_preview`, `file_search`, `computer_use_preview`
-//! - `store` — whether to store in conversation history
-//! - `include` — list of fields to include in the response
-//! - `truncation` — input truncation strategy
-//! - `metadata` / `text` / `temperature` / `top_p` (pre-existing, now explicit)
-//! - Full reasoning item handling (passed through as extra, skip silently)
+//! OpenAI Responses API ingress decoder — produces `AiRequest` directly.
 
 use std::collections::HashMap;
 
@@ -17,11 +7,14 @@ use serde_json::Value;
 
 use crate::protocol::IngressDecoder;
 use crate::protocol::ids::OPENAI_RESPONSES_V1;
-use crate::protocol::types::*;
+use crate::protocol::ir::{
+    AiRequest, GenerationConfig, Message, MessageContent, OpenAIResponsesExt, ProtocolExt,
+    ReasoningConfig, Role, StreamConfig, ToolCall, ToolChoice, ToolSpec,
+};
 
 pub struct ResponsesDecoder;
 
-// Fields decoded into named IR fields (not extra).
+// Fields decoded into named IR fields (not ingress bag).
 const KNOWN_FIELDS: &[&str] = &[
     "model",
     "input",
@@ -32,7 +25,6 @@ const KNOWN_FIELDS: &[&str] = &[
     "top_p",
     "tools",
     "tool_choice",
-    // PR-09
     "background",
     "previous_response_id",
     "store",
@@ -47,7 +39,7 @@ const KNOWN_FIELDS: &[&str] = &[
 ];
 
 impl IngressDecoder for ResponsesDecoder {
-    fn decode_request(&self, body: Value) -> Result<InternalRequest> {
+    fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let obj = body
             .as_object()
             .ok_or_else(|| anyhow::anyhow!("request body must be a JSON object"))?;
@@ -65,45 +57,41 @@ impl IngressDecoder for ResponsesDecoder {
             .and_then(|v| v.as_u64())
             .map(|v| v as u32);
         let top_p = obj.get("top_p").and_then(|v| v.as_f64());
+        let parallel_tool_calls = obj.get("parallel_tool_calls").and_then(|v| v.as_bool());
 
-        let mut messages = Vec::new();
-        let tools = parse_tools(obj.get("tools"))?;
-        let tool_choice = obj.get("tool_choice").cloned();
+        // ── System (instructions) ─────────────────────────────────────────────
+        let mut messages: Vec<Message> = Vec::new();
 
         if let Some(inst) = obj.get("instructions").and_then(|v| v.as_str())
             && !inst.is_empty()
         {
-            messages.push(InternalMessage {
+            messages.push(Message {
                 role: Role::System,
                 content: MessageContent::Text(inst.to_string()),
                 tool_calls: None,
                 tool_call_id: None,
-                extra: HashMap::new(),
+                meta: None,
             });
         }
 
+        // ── Input items ───────────────────────────────────────────────────────
         let input = obj
             .get("input")
             .ok_or_else(|| anyhow::anyhow!("missing 'input' field"))?;
 
         match input {
             Value::String(text) => {
-                messages.push(InternalMessage {
+                messages.push(Message {
                     role: Role::User,
                     content: MessageContent::Text(text.clone()),
                     tool_calls: None,
                     tool_call_id: None,
-                    extra: HashMap::new(),
+                    meta: None,
                 });
             }
             Value::Array(items) => {
                 let mut pending_reasoning: Option<String> = None;
                 for item in items {
-                    // Preserve reasoning_content from Responses API "reasoning" items.
-                    // DeepSeek requires that reasoning_content be passed back on the
-                    // assistant message that produced it. Codex represents reasoning as
-                    // a separate "reasoning" item in the input array; we attach it to the
-                    // next assistant message via the `extra` field.
                     if item
                         .get("type")
                         .and_then(|v| v.as_str())
@@ -125,57 +113,47 @@ impl IngressDecoder for ResponsesDecoder {
                     match decode_input_item(item)? {
                         Some(mut msg) => {
                             if msg.role == Role::Assistant {
-                                // Clone reasoning to EACH consecutive assistant message.
-                                // Parallel function_calls produce multiple assistant messages
-                                // that all belong to the same reasoning turn; each must carry
-                                // reasoning_content. Tool results interleaved between
-                                // function_calls are NOT turn boundaries — keep reasoning alive.
                                 if let Some(ref reasoning) = pending_reasoning {
-                                    msg.extra.insert(
+                                    let mut obj = match msg.meta.take() {
+                                        Some(Value::Object(m)) => m,
+                                        _ => serde_json::Map::new(),
+                                    };
+                                    obj.insert(
                                         "reasoning_content".to_string(),
                                         Value::String(reasoning.clone()),
                                     );
+                                    msg.meta = Some(Value::Object(obj));
                                 }
                             } else if msg.role == Role::User || msg.role == Role::System {
-                                // User/System messages are true conversation turn boundaries.
-                                // If pending reasoning was never attached to an assistant
-                                // message, emit it as a standalone assistant now.
                                 if let Some(reasoning) = pending_reasoning.take() {
-                                    let mut extra = HashMap::new();
+                                    let mut extra = serde_json::Map::new();
                                     extra.insert(
                                         "reasoning_content".to_string(),
                                         Value::String(reasoning),
                                     );
-                                    messages.push(InternalMessage {
+                                    messages.push(Message {
                                         role: Role::Assistant,
                                         content: MessageContent::Text(String::new()),
                                         tool_calls: None,
                                         tool_call_id: None,
-                                        extra,
+                                        meta: Some(Value::Object(extra)),
                                     });
                                 }
                             }
-                            // Tool outputs and other non-assistant types: leave
-                            // pending_reasoning intact — they sit between calls of the
-                            // same reasoning turn and do not end the turn.
                             messages.push(msg);
                         }
-                        None => {
-                            // If the item produced no message (e.g., an ignored type)
-                            // but we have pending reasoning, keep it for the next one.
-                        }
+                        None => {}
                     }
                 }
-                // Flush any remaining pending reasoning at end of input
                 if let Some(reasoning) = pending_reasoning.take() {
-                    let mut extra = HashMap::new();
+                    let mut extra = serde_json::Map::new();
                     extra.insert("reasoning_content".to_string(), Value::String(reasoning));
-                    messages.push(InternalMessage {
+                    messages.push(Message {
                         role: Role::Assistant,
                         content: MessageContent::Text(String::new()),
                         tool_calls: None,
                         tool_call_id: None,
-                        extra,
+                        meta: Some(Value::Object(extra)),
                     });
                 }
             }
@@ -186,14 +164,50 @@ impl IngressDecoder for ResponsesDecoder {
             anyhow::bail!("no messages found in input");
         }
 
-        // ── Build extra from unknown + PR-09 named fields ─────────────────────
-        let mut extra: HashMap<String, Value> = obj
+        // ── Tools ─────────────────────────────────────────────────────────────
+        let tools = parse_tools(obj.get("tools"))?;
+        let tool_choice = obj.get("tool_choice").cloned().map(parse_tool_choice);
+
+        // ── Reasoning ─────────────────────────────────────────────────────────
+        let reasoning = if let Some(r) = obj.get("reasoning") {
+            let effort_str = r.get("effort").and_then(|e| e.as_str());
+            let summary = r.get("summary").and_then(|s| s.as_str()).map(String::from);
+            ReasoningConfig {
+                enabled: true,
+                effort: effort_str.map(parse_reasoning_effort),
+                display: summary,
+                ..Default::default()
+            }
+        } else {
+            ReasoningConfig::default()
+        };
+
+        // ── ProtocolExt ───────────────────────────────────────────────────────
+        let resp_ext = OpenAIResponsesExt {
+            background: obj.get("background").and_then(|v| v.as_bool()),
+            previous_response_id: obj
+                .get("previous_response_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            truncation: obj
+                .get("truncation")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            include: obj.get("include").and_then(|v| v.as_array()).map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str().map(String::from))
+                    .collect()
+            }),
+            ..Default::default()
+        };
+
+        // ── Vendor ingress bag — backward compat for old encoders (pre-PR-3) ──
+        let mut ingress: HashMap<String, Value> = obj
             .iter()
             .filter(|(k, _)| !KNOWN_FIELDS.contains(&k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
-        // Carry PR-09 named fields explicitly so the encoder can forward them.
         for key in &[
             "background",
             "previous_response_id",
@@ -208,26 +222,37 @@ impl IngressDecoder for ResponsesDecoder {
             "user",
         ] {
             if let Some(v) = obj.get(*key) {
-                extra.entry(key.to_string()).or_insert_with(|| v.clone());
+                ingress.entry(key.to_string()).or_insert_with(|| v.clone());
             }
         }
 
-        Ok(InternalRequest {
-            messages,
-            model,
-            stream,
+        // ── Build AiRequest ───────────────────────────────────────────────────
+        let mut ai_req = AiRequest::new(model, messages);
+        ai_req.generation = GenerationConfig {
             temperature,
             max_tokens,
             top_p,
-            tools,
-            tool_choice,
-            source_protocol: OPENAI_RESPONSES_V1,
-            extra,
-        })
+            ..Default::default()
+        };
+        ai_req.stream = StreamConfig {
+            enabled: stream,
+            include_usage: false,
+        };
+        ai_req.tools = tools;
+        ai_req.tool_choice = tool_choice;
+        ai_req.parallel_tool_calls = parallel_tool_calls;
+        ai_req.reasoning = reasoning;
+        ai_req.ext = Some(ProtocolExt::OpenAiResponses(resp_ext));
+        ai_req.meta.source_protocol = Some(OPENAI_RESPONSES_V1);
+        ai_req.meta.vendor.ingress = ingress;
+
+        Ok(ai_req)
     }
 }
 
-fn decode_input_item(item: &Value) -> Result<Option<InternalMessage>> {
+// ── Input item decoding ───────────────────────────────────────────────────────
+
+fn decode_input_item(item: &Value) -> Result<Option<Message>> {
     let item_type = item
         .get("type")
         .and_then(|v| v.as_str())
@@ -250,12 +275,12 @@ fn decode_input_item(item: &Value) -> Result<Option<InternalMessage>> {
                 Value::Null => String::new(),
                 other => other.to_string(),
             };
-            Ok(Some(InternalMessage {
+            Ok(Some(Message {
                 role: Role::Tool,
                 content: MessageContent::Text(output_text),
                 tool_calls: None,
                 tool_call_id: Some(call_id),
-                extra: HashMap::new(),
+                meta: None,
             }))
         }
 
@@ -279,7 +304,7 @@ fn decode_input_item(item: &Value) -> Result<Option<InternalMessage>> {
             if call_id.trim().is_empty() || name.trim().is_empty() {
                 anyhow::bail!("function_call item missing call_id or name");
             }
-            Ok(Some(InternalMessage {
+            Ok(Some(Message {
                 role: Role::Assistant,
                 content: MessageContent::Text(String::new()),
                 tool_calls: Some(vec![ToolCall {
@@ -288,12 +313,10 @@ fn decode_input_item(item: &Value) -> Result<Option<InternalMessage>> {
                     arguments,
                 }]),
                 tool_call_id: None,
-                extra: HashMap::new(),
+                meta: None,
             }))
         }
 
-        // PR-09: web_search_call, file_search_call, computer_call — pass through
-        // silently; their results are provided via `function_call_output`.
         "web_search_call" | "file_search_call" | "computer_call" | "reasoning" => Ok(None),
 
         "message" => decode_message_item(item),
@@ -302,7 +325,7 @@ fn decode_input_item(item: &Value) -> Result<Option<InternalMessage>> {
     }
 }
 
-fn decode_message_item(item: &Value) -> Result<Option<InternalMessage>> {
+fn decode_message_item(item: &Value) -> Result<Option<Message>> {
     let role_str = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
     let role = match role_str {
         "system" | "developer" => Role::System,
@@ -324,12 +347,7 @@ fn decode_message_item(item: &Value) -> Result<Option<InternalMessage>> {
                             texts.push(text.to_string());
                         }
                     }
-                    "image_url" => {
-                        // Skip images in text accumulator; they'll be handled by multimodal codecs.
-                    }
-                    _ => {
-                        // Ignore unknown block types (e.g. `input_audio`, `reasoning_summary`).
-                    }
+                    _ => {}
                 }
             }
             let text = texts.join("");
@@ -342,16 +360,18 @@ fn decode_message_item(item: &Value) -> Result<Option<InternalMessage>> {
         None => return Ok(None),
     };
 
-    Ok(Some(InternalMessage {
+    Ok(Some(Message {
         role,
         content,
         tool_calls: None,
         tool_call_id: None,
-        extra: HashMap::new(),
+        meta: None,
     }))
 }
 
-fn parse_tools(raw_tools: Option<&Value>) -> Result<Option<Vec<ToolDef>>> {
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse_tools(raw_tools: Option<&Value>) -> Result<Option<Vec<ToolSpec>>> {
     let Some(Value::Array(items)) = raw_tools else {
         return Ok(None);
     };
@@ -378,24 +398,26 @@ fn parse_tools(raw_tools: Option<&Value>) -> Result<Option<Vec<ToolDef>>> {
                     .get("parameters")
                     .cloned()
                     .unwrap_or(Value::Object(Default::default()));
-                tools.push(ToolDef {
+                tools.push(ToolSpec {
                     name,
                     description,
                     parameters,
+                    strict: item.get("strict").and_then(|v| v.as_bool()),
+                    cache_control: None,
+                    meta: None,
                 });
             }
-            // PR-09: built-in tools preserved as sentinel ToolDef entries
-            // so the encoder can reconstruct them on the egress side.
             "web_search_preview" | "file_search" | "computer_use_preview" | "code_interpreter" => {
-                tools.push(ToolDef {
+                tools.push(ToolSpec {
                     name: format!("__builtin__{}", tool_type),
                     description: Some(format!("built-in tool: {}", tool_type)),
                     parameters: item.clone(),
+                    strict: None,
+                    cache_control: None,
+                    meta: None,
                 });
             }
-            _ => {
-                // Ignore unknown tool types.
-            }
+            _ => {}
         }
     }
 
@@ -403,5 +425,40 @@ fn parse_tools(raw_tools: Option<&Value>) -> Result<Option<Vec<ToolDef>>> {
         Ok(None)
     } else {
         Ok(Some(tools))
+    }
+}
+
+fn parse_tool_choice(v: Value) -> ToolChoice {
+    match &v {
+        Value::String(s) => match s.as_str() {
+            "none" => ToolChoice::None,
+            "auto" => ToolChoice::Auto,
+            "required" => ToolChoice::Required,
+            _ => ToolChoice::Raw(v),
+        },
+        Value::Object(obj) => {
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function") {
+                if let Some(name) = obj
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                {
+                    return ToolChoice::Named {
+                        name: name.to_string(),
+                    };
+                }
+            }
+            ToolChoice::Raw(v)
+        }
+        _ => ToolChoice::Raw(v),
+    }
+}
+
+fn parse_reasoning_effort(s: &str) -> crate::protocol::ir::ReasoningEffort {
+    use crate::protocol::ir::ReasoningEffort;
+    match s {
+        "low" => ReasoningEffort::Low,
+        "high" => ReasoningEffort::High,
+        _ => ReasoningEffort::Medium,
     }
 }

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -214,7 +214,18 @@ fn block_to_old(b: ContentBlock) -> Option<OldContentBlock> {
             MediaSource::Base64 { media_type, data } => Some(OldContentBlock::Image {
                 source: crate::protocol::types::ImageSource { media_type, data },
             }),
-            _ => None,
+            MediaSource::Url(url) => Some(OldContentBlock::Image {
+                source: crate::protocol::types::ImageSource {
+                    media_type: "image/url".to_string(),
+                    data: url,
+                },
+            }),
+            MediaSource::FileId { file_id, .. } => Some(OldContentBlock::Image {
+                source: crate::protocol::types::ImageSource {
+                    media_type: "image/file_id".to_string(),
+                    data: file_id,
+                },
+            }),
         },
         ContentBlock::Thinking {
             thinking,

--- a/crates/nyro-core/src/protocol/ir/request.rs
+++ b/crates/nyro-core/src/protocol/ir/request.rs
@@ -329,20 +329,6 @@ pub struct GenerationConfig {
     pub presence_penalty: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frequency_penalty: Option<f64>,
-
-    // ── Fields pending migration to ProtocolExt (PR-2) ───────────────────────
-    // These belong in `OpenAIChatExt` / `AnthropicExt` / `GoogleExt` per
-    // FIELD_HOMING.md §3-6.  Kept here temporarily so existing codec encoders
-    // continue to compile.  Remove in PR-2 when decoders are rewritten.
-    /// TODO(PR-2): Move to `OpenAIChatExt.logit_bias`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub logit_bias: Option<std::collections::HashMap<String, f64>>,
-    /// TODO(PR-2): Move to `OpenAIChatExt.n`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub n: Option<u32>,
-    /// TODO(PR-2): Move to `AnthropicExt.top_k` / `GoogleExt.top_k`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_k: Option<u32>,
 }
 
 // ── Reasoning config ──────────────────────────────────────────────────────────

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -45,7 +45,7 @@ use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
 // ── Client → Gateway ──
 
 pub trait IngressDecoder {
-    fn decode_request(&self, body: serde_json::Value) -> anyhow::Result<types::InternalRequest>;
+    fn decode_request(&self, body: serde_json::Value) -> anyhow::Result<ir::AiRequest>;
 }
 
 // ── Gateway → Provider ──

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -677,7 +677,7 @@ pub async fn dispatch(
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, method, path);
 
     let decoder = ingress.handler().make_decoder();
-    let internal = match decoder.decode_request(body) {
+    let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => {
             let ingress_str = ingress.to_string();
@@ -701,7 +701,6 @@ pub async fn dispatch(
         }
     };
 
-    let request: AiRequest = internal.into();
     dispatch_pipeline(gw, headers, envelope, request, ingress).await
 }
 

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
-use crate::protocol::ir::{AiRequest, RawEnvelope};
+use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
@@ -29,11 +29,10 @@ pub async fn handler(
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/messages");
     let decoder = ANTHROPIC_MESSAGES_2023_06_01.handler().make_decoder();
-    let internal = match decoder.decode_request(body) {
+    let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
-    let request: AiRequest = internal.into();
     dispatch_pipeline(
         gw,
         headers,

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use crate::Gateway;
 use crate::protocol::codec::google_generative::decoder::GoogleDecoder;
 use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
-use crate::protocol::ir::{AiRequest, RawEnvelope};
+use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
@@ -36,11 +36,10 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", &path);
-    let internal = match GoogleDecoder.decode_with_model(body, &model, is_stream) {
+    let request = match GoogleDecoder.decode_with_model(body, &model, is_stream) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid Gemini request: {e}")),
     };
-    let request: AiRequest = internal.into();
     dispatch_pipeline(
         gw,
         headers,

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-use crate::protocol::ir::{AiRequest, RawEnvelope};
+use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
@@ -34,10 +34,9 @@ pub async fn handler(
         "/v1/chat/completions",
     );
     let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_decoder();
-    let internal = match decoder.decode_request(body) {
+    let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
-    let request: AiRequest = internal.into();
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_CHAT_COMPLETIONS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
-use crate::protocol::ir::{AiRequest, RawEnvelope};
+use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
@@ -29,10 +29,9 @@ pub async fn handler(
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
     let decoder = OPENAI_EMBEDDINGS_V1.handler().make_decoder();
-    let internal = match decoder.decode_request(body) {
+    let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
-    let request: AiRequest = internal.into();
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_EMBEDDINGS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::ids::OPENAI_RESPONSES_V1;
-use crate::protocol::ir::{AiRequest, RawEnvelope};
+use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
 
@@ -29,10 +29,9 @@ pub async fn handler(
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/responses");
     let decoder = OPENAI_RESPONSES_V1.handler().make_decoder();
-    let internal = match decoder.decode_request(body) {
+    let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),
     };
-    let request: AiRequest = internal.into();
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1).await
 }

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -17,7 +17,9 @@ use nyro_core::protocol::ids::{
     ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1,
 };
-use nyro_core::protocol::ir::AiRequest;
+use nyro_core::protocol::ir::{
+    AiRequest, ContentBlock as IrContentBlock, MessageContent as IrMessageContent, Role as IrRole,
+};
 use nyro_core::protocol::types::{
     ContentBlock, InternalMessage, InternalRequest, InternalResponse, MessageContent, ResponseItem,
     Role, StreamDelta, TokenUsage, ToolCall, ToolDef,
@@ -444,7 +446,7 @@ fn anthropic_tool_result_decodes_to_tool_role() {
         .decode_request(body)
         .expect("decode anthropic request");
     assert_eq!(req.messages.len(), 2);
-    assert_eq!(req.messages[1].role, Role::Tool);
+    assert_eq!(req.messages[1].role, IrRole::Tool);
     assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_abc"));
 }
 
@@ -474,8 +476,8 @@ fn anthropic_multi_tool_result_decodes_to_multiple_tool_messages() {
         .decode_request(body)
         .expect("decode anthropic request");
     assert_eq!(req.messages.len(), 3);
-    assert_eq!(req.messages[1].role, Role::Tool);
-    assert_eq!(req.messages[2].role, Role::Tool);
+    assert_eq!(req.messages[1].role, IrRole::Tool);
+    assert_eq!(req.messages[2].role, IrRole::Tool);
     assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_a"));
     assert_eq!(req.messages[2].tool_call_id.as_deref(), Some("call_b"));
 }
@@ -504,17 +506,18 @@ fn anthropic_thinking_block_round_trips_with_signature() {
     let req = AnthropicDecoder
         .decode_request(body)
         .expect("decode anthropic request");
-    let MessageContent::Blocks(blocks) = &req.messages[0].content else {
+    let IrMessageContent::Blocks(blocks) = &req.messages[0].content else {
         panic!("thinking must remain a structured block");
     };
     assert!(matches!(
         &blocks[0],
-        ContentBlock::Reasoning { text, signature }
-            if text == "review prior tool output" && signature.as_deref() == Some("sig_123")
+        IrContentBlock::Thinking { thinking, signature }
+            if thinking == "review prior tool output" && signature.as_deref() == Some("sig_123")
     ));
 
+    let req_old: InternalRequest = req.into();
     let (encoded, _) = AnthropicEncoder
-        .encode_request(&req)
+        .encode_request(&req_old)
         .expect("encode anthropic request");
     let block = encoded
         .get("messages")
@@ -1061,9 +1064,9 @@ fn responses_decoder_ignores_empty_message_content_item() {
         .decode_request(body)
         .expect("decode request should succeed");
     assert_eq!(req.messages.len(), 1);
-    assert_eq!(req.messages[0].role, Role::User);
+    assert_eq!(req.messages[0].role, IrRole::User);
     assert_eq!(
-        req.messages[0].content.as_text(),
+        req.messages[0].content.to_text(),
         "帮我查看当前目录下有哪些文件"
     );
 }
@@ -1916,7 +1919,7 @@ fn codex_parallel_calls_with_intermediate_text_anthropic_egress() {
         ]
     });
     let internal = ResponsesDecoder.decode_request(body).expect("decode");
-    let mut req: InternalRequest = internal;
+    let mut req: InternalRequest = internal.into();
     normalize_request_tool_results(&mut req);
 
     let (encoded, _) = AnthropicEncoder

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -11,8 +11,9 @@ use nyro_core::protocol::ids::{
     ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
     OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolId,
 };
+use nyro_core::protocol::ir::Role;
 use nyro_core::protocol::registry::ProtocolRegistry;
-use nyro_core::protocol::types::Role;
+use nyro_core::protocol::types::InternalRequest;
 use serde_json::json;
 
 #[test]
@@ -151,7 +152,11 @@ fn decoder_preserves_role_sequence_and_source_protocol() {
             .decode_request(body)
             .unwrap_or_else(|e| panic!("decoder failed for {id}: {e}"));
 
-        assert_eq!(req.source_protocol, id, "source_protocol mismatch for {id}");
+        assert_eq!(
+            req.meta.source_protocol.unwrap(),
+            id,
+            "source_protocol mismatch for {id}"
+        );
         assert!(!req.messages.is_empty(), "messages empty for {id}");
         let _: Vec<Role> = req.messages.iter().map(|m| m.role).collect();
     }
@@ -169,9 +174,10 @@ fn encoder_round_trips_body_for_every_handler() {
         let body = sample_body(id);
         let h = reg.get(&id).unwrap();
         let internal = h.make_decoder().decode_request(body).unwrap();
+        let internal_old: InternalRequest = internal.clone().into();
         let (out_body, headers) = h
             .make_encoder()
-            .encode_request(&internal)
+            .encode_request(&internal_old)
             .unwrap_or_else(|e| panic!("encoder failed for {id}: {e}"));
         assert!(
             out_body.is_object(),
@@ -181,7 +187,7 @@ fn encoder_round_trips_body_for_every_handler() {
 
         let _path = h
             .make_encoder()
-            .egress_path(&internal.model, internal.stream);
+            .egress_path(&internal.model, internal.stream.enabled);
     }
 }
 
@@ -255,13 +261,14 @@ fn embeddings_decoder_round_trips_body() {
         .decode_request(body.clone())
         .unwrap();
     assert_eq!(internal.model, "text-embedding-3-small");
-    assert!(!internal.stream);
+    assert!(!internal.stream.enabled);
 
+    let internal_old: InternalRequest = internal.clone().into();
     let (encoded, _headers) = reg
         .get(&OPENAI_EMBEDDINGS_V1)
         .unwrap()
         .make_encoder()
-        .encode_request(&internal)
+        .encode_request(&internal_old)
         .unwrap();
     assert_eq!(encoded, body, "encoder must round-trip the original body");
 }

--- a/docs/design/ir/CHANGELOG.md
+++ b/docs/design/ir/CHANGELOG.md
@@ -6,6 +6,51 @@
 
 ---
 
+## [PR-2] Codec Decoder 全切换到 AiRequest — 2026-05-15
+
+### 变更
+
+**`IngressDecoder` trait**
+- `decode_request` 返回类型由 `InternalRequest` → `AiRequest`
+
+**`GenerationConfig` 清理**
+- 移除临时字段 `logit_bias`、`n`、`top_k`（已归属 `ProtocolExt`）
+
+**4 大 Decoder 重写**
+- `OpenAIDecoder` — 直出 `AiRequest`；`ProtocolExt::OpenAiChat(OpenAIChatExt)`
+  - `audio / modalities / logit_bias / n / prediction / stream_options` 进 `OpenAIChatExt`
+  - `service_tier / user` 进 `meta.vendor.ingress`（老 encoder 向后兼容）
+  - `reasoning_effort` → `ReasoningConfig`；`stop` → `GenerationConfig.stop`
+- `ResponsesDecoder` — 直出 `AiRequest`；`ProtocolExt::OpenAiResponses(OpenAIResponsesExt)`
+  - `background / previous_response_id / truncation / include` 进 `OpenAIResponsesExt`
+  - `reasoning` 字段 → `ReasoningConfig`；`reasoning_content` 附加到 `Message.meta`
+- `AnthropicDecoder` — 直出 `AiRequest`；`ProtocolExt::Anthropic(AnthropicExt)`
+  - `ContentBlock` 全面升级：`Thinking`、`Document`、`Audio`、`cache_control` 原生支持
+  - 内置工具进 `AnthropicExt.server_tools`；用户工具进 `AiRequest.tools`（带 `cache_control`）
+  - `thinking` → `ReasoningConfig`；`stop_sequences` → `GenerationConfig.stop`
+  - 原始 wire JSON 保留在 `meta.vendor.ingress`（`__anthropic_raw_*`，兼容旧 encoder）
+- `GoogleDecoder` — 直出 `AiRequest`；`ProtocolExt::Google(GoogleExt)`
+  - `decode_with_model` 签名同步更新（model + stream 由 URL 路径注入）
+  - `executableCode / codeExecutionResult` → `ContentBlock::ExecutableCode / CodeExecutionResult`
+  - `thought=true` Part → `ContentBlock::Thinking`
+  - `generationConfig` 扩展字段进 `GoogleExt`；`safety_settings` → `AiRequest.safety_settings`
+  - `__google_*` 原始字段保留在 `meta.vendor.ingress`（兼容旧 encoder）
+
+**`EmbeddingsDecoder` 更新**
+- 返回类型同步改为 `AiRequest`；`__emb_*` 键保留在 `meta.vendor.ingress`
+
+**5 个 Ingress Handler + Dispatcher**
+- 移除 `let request: AiRequest = internal.into()` 一行（decoder 直出 `AiRequest`）
+
+**`compat.rs` 修复**
+- `block_to_old` 补充 `MediaSource::Url` / `MediaSource::FileId` → `OldContentBlock::Image` 映射
+
+### 不变
+- Encoder / Parser / Formatter 均未修改；通过 `AiRequest → InternalRequest`（compat.rs）继续工作
+- `compat.rs` 双向转换逻辑核心不变
+
+---
+
 ## 模板
 
 ```


### PR DESCRIPTION
- Change IngressDecoder::decode_request return type from InternalRequest to AiRequest
- Remove temporary fields logit_bias / n / top_k from GenerationConfig (now in ProtocolExt)
- Rewrite all four decoders to produce AiRequest with typed ProtocolExt:
  OpenAIDecoder        → OpenAIChatExt (audio, modalities, logit_bias, n, prediction, stream_options)
  ResponsesDecoder     → OpenAIResponsesExt (background, previous_response_id, truncation, include)
  AnthropicDecoder     → AnthropicExt (native cache_control, Document, Audio ContentBlocks; server_tools)
  GoogleDecoder        → GoogleExt (ExecutableCode, CodeExecutionResult, Thinking from thought parts)
- Update EmbeddingsDecoder to return AiRequest
- Remove internal.into() from 5 ingress handlers and dispatcher (decoder now emits AiRequest directly)
- Fix compat.rs block_to_old to round-trip MediaSource::Url and MediaSource::Fiserve __anthropic_raw_* and __google_* keys in meta.vendor.ingress for backward
  compatibility with pre-PR-3 encoders that still read from InternalRequest.extra