### PR TITLE
feat(ir/pr5): full dispatcher, provider adapter, and cache switch to new IR

### DIFF
--- a/crates/nyro-core/src/cache/entry.rs
+++ b/crates/nyro-core/src/cache/entry.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::protocol::types::{InternalResponse, TokenUsage};
+use crate::protocol::ir::AiResponse;
+use crate::protocol::types::TokenUsage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheEntry {
@@ -13,5 +14,5 @@ pub struct CacheEntry {
     pub usage: TokenUsage,
     pub created_at_epoch_ms: i64,
     #[serde(default)]
-    pub internal_response: Option<InternalResponse>,
+    pub internal_response: Option<AiResponse>,
 }

--- a/crates/nyro-core/src/cache/key.rs
+++ b/crates/nyro-core/src/cache/key.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest, Sha256};
 
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{ContentBlock, InternalRequest, MessageContent};
+use crate::protocol::ir::{AiRequest, ContentBlock, MessageContent};
 
 /// Bump this constant whenever the codec field mapping changes in a way that
 /// could cause a cached response to be returned in the wrong format.
@@ -11,7 +11,8 @@ use crate::protocol::types::{ContentBlock, InternalRequest, MessageContent};
 /// be evicted by TTL / LRU), but they will no longer be served.
 /// Bump when: IR mapping changes, codec field mapping changes, or cache key format changes.
 /// v1 → v2: dispatch_pipeline now carries RawEnvelope + AiRequest; ingress included in key.
-pub const CODEC_SCHEMA_VERSION: u32 = 2;
+/// v3: PR-5 full switch to AiRequest; GenerationConfig fields used directly.
+pub const CODEC_SCHEMA_VERSION: u32 = 3;
 
 /// Build a deterministic cache key for an exact-match or semantic-cache
 /// lookup.
@@ -22,29 +23,29 @@ pub const CODEC_SCHEMA_VERSION: u32 = 2;
 ///   formatted for the ingress protocol; the same body from different ingress
 ///   protocols must produce different cache entries.
 /// - A SHA-256 hash of the semantically-relevant request fields.
-pub fn build_cache_key(request: &InternalRequest, ingress: ProtocolId) -> String {
+pub fn build_cache_key(request: &AiRequest, ingress: ProtocolId) -> String {
     let mut source = String::new();
     source.push_str("model:");
     source.push_str(request.model.trim());
     source.push('|');
     source.push_str("temperature:");
-    if let Some(temperature) = request.temperature {
+    if let Some(temperature) = request.generation.temperature {
         source.push_str(&temperature.to_string());
     }
     source.push('|');
     source.push_str("max_tokens:");
-    if let Some(max_tokens) = request.max_tokens {
+    if let Some(max_tokens) = request.generation.max_tokens {
         source.push_str(&max_tokens.to_string());
     }
     source.push('|');
     source.push_str("top_p:");
-    if let Some(top_p) = request.top_p {
+    if let Some(top_p) = request.generation.top_p {
         source.push_str(&top_p.to_string());
     }
     source.push('|');
     source.push_str("tool_choice:");
     if let Some(tool_choice) = &request.tool_choice {
-        source.push_str(&tool_choice.to_string());
+        source.push_str(&serde_json::to_string(tool_choice).unwrap_or_default());
     }
     source.push('|');
     source.push_str("tools:");
@@ -60,8 +61,10 @@ pub fn build_cache_key(request: &InternalRequest, ingress: ProtocolId) -> String
             MessageContent::Blocks(blocks) => {
                 for block in blocks {
                     match block {
-                        ContentBlock::Text { text } => source.push_str(text),
-                        ContentBlock::ToolUse { id, name, input } => {
+                        ContentBlock::Text { text, .. } => source.push_str(text),
+                        ContentBlock::ToolUse {
+                            id, name, input, ..
+                        } => {
                             source.push_str(id);
                             source.push_str(name);
                             source.push_str(&input.to_string());
@@ -69,19 +72,24 @@ pub fn build_cache_key(request: &InternalRequest, ingress: ProtocolId) -> String
                         ContentBlock::ToolResult {
                             tool_use_id,
                             content,
+                            ..
                         } => {
                             source.push_str(tool_use_id);
                             source.push_str(&content.to_string());
                         }
                         ContentBlock::Image { .. } => source.push_str("[image]"),
-                        ContentBlock::Reasoning { text, signature } => {
+                        ContentBlock::Thinking {
+                            thinking,
+                            signature,
+                        } => {
                             source.push_str("[thinking]");
-                            source.push_str(text);
+                            source.push_str(thinking);
                             if let Some(sig) = signature {
                                 source.push_str("[sig]");
                                 source.push_str(sig);
                             }
                         }
+                        _ => {}
                     }
                 }
             }

--- a/crates/nyro-core/src/integrations/hooks.rs
+++ b/crates/nyro-core/src/integrations/hooks.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 
 use crate::error::GatewayError;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 
 // ── HookContext ───────────────────────────────────────────────────────────────
 
@@ -37,11 +37,7 @@ pub trait RequestHook: Send + Sync + 'static {
     /// Short stable name used in log messages (e.g. `"content-moderation"`).
     fn name(&self) -> &'static str;
 
-    async fn on_request(
-        &self,
-        ctx: &HookContext,
-        req: &mut InternalRequest,
-    ) -> Result<(), GatewayError>;
+    async fn on_request(&self, ctx: &HookContext, req: &mut AiRequest) -> Result<(), GatewayError>;
 }
 
 /// `inventory` registration record for a [`RequestHook`].
@@ -54,7 +50,7 @@ inventory::collect!(RequestHookRegistration);
 // ── ResponseHook ──────────────────────────────────────────────────────────────
 
 /// Called after a successful upstream response has been parsed into
-/// [`InternalResponse`], before it is formatted and returned to the client.
+/// [`AiResponse`], before it is formatted and returned to the client.
 ///
 /// Errors returned by `on_response` are **logged and ignored** — the response
 /// is still delivered to the client. This is intentional: response hooks must
@@ -66,7 +62,7 @@ inventory::collect!(RequestHookRegistration);
 pub trait ResponseHook: Send + Sync + 'static {
     fn name(&self) -> &'static str;
 
-    async fn on_response(&self, ctx: &HookContext, resp: &mut InternalResponse, latency_ms: u64);
+    async fn on_response(&self, ctx: &HookContext, resp: &mut AiResponse, latency_ms: u64);
 }
 
 /// `inventory` registration record for a [`ResponseHook`].

--- a/crates/nyro-core/src/protocol/ir/response.rs
+++ b/crates/nyro-core/src/protocol/ir/response.rs
@@ -38,7 +38,7 @@ pub enum ResponseItem {
 // ── AiResponse ────────────────────────────────────────────────────────────────
 
 /// Unified egress IR produced by all codec response parsers and the accumulator.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiResponse {
     /// The unique response ID assigned by the provider.
     pub id: String,

--- a/crates/nyro-core/src/protocol/ir/vendor_ext.rs
+++ b/crates/nyro-core/src/protocol/ir/vendor_ext.rs
@@ -19,10 +19,11 @@
 //!   in PR-07) will reject requests with non-empty `passthrough_safe` entries
 //!   unless `allow_passthrough` is set on the route.
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct VendorExtensions {
     /// Extra fields from the ingress body (client side).
     pub ingress: HashMap<String, Value>,

--- a/crates/nyro-core/src/provider/anthropic/mod.rs
+++ b/crates/nyro-core/src/provider/anthropic/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::pipeline;
 use crate::provider::inbound::InboundResponse;
 use crate::provider::metadata::{
@@ -120,7 +120,7 @@ impl Vendor for AnthropicVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -129,7 +129,7 @@ impl Vendor for AnthropicVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -30,7 +30,7 @@ use crate::provider::vendor::Vendor;
 ///  post_encode → auth_headers → build_url`.
 pub async fn build_request<V>(
     vendor: &V,
-    req: &mut crate::protocol::types::InternalRequest,
+    req: &mut crate::protocol::ir::AiRequest,
     ctx: &crate::provider::vendor::ProviderCtx<'_>,
 ) -> Result<crate::provider::outbound::OutboundRequest, GatewayError>
 where
@@ -46,8 +46,13 @@ where
         .await
         .map_err(GatewayError::internal)?;
 
-    // 2. normalize tool results
-    crate::protocol::codec::tool_correlation::normalize_request_tool_results(req);
+    // 2. normalize tool results (convert round-trip via compat for legacy helper)
+    {
+        let mut old_req: crate::protocol::types::InternalRequest = req.clone().into();
+        crate::protocol::codec::tool_correlation::normalize_request_tool_results(&mut old_req);
+        // Merge normalized messages back (tool correlation only touches messages)
+        req.messages = crate::protocol::ir::AiRequest::from(old_req).messages;
+    }
 
     // 3. pre_encode hook
     vendor
@@ -58,9 +63,8 @@ where
     // 4. codec encode
     let egress_handler = ctx.protocol.handler();
     let encoder = egress_handler.make_encoder();
-    let ai_req: crate::protocol::ir::AiRequest = req.clone().into();
     let (mut body, mut extra_headers) = encoder
-        .encode_request(&ai_req)
+        .encode_request(req)
         .map_err(GatewayError::internal)?;
 
     // 5. post_encode hook
@@ -105,7 +109,7 @@ where
     headers.extend(extra_headers);
 
     // 7. build URL
-    let egress_path = encoder.egress_path(ctx.actual_model, req.stream);
+    let egress_path = encoder.egress_path(ctx.actual_model, req.stream.enabled);
     let url = vendor.build_url(&vendor_ctx, ctx.egress_base_url, &egress_path);
 
     Ok(crate::provider::outbound::OutboundRequest { url, headers, body })
@@ -117,7 +121,7 @@ pub async fn parse_response<V>(
     vendor: &V,
     resp: crate::provider::inbound::InboundResponse,
     ctx: &crate::provider::vendor::ProviderCtx<'_>,
-) -> Result<crate::protocol::types::InternalResponse, GatewayError>
+) -> Result<crate::protocol::ir::AiResponse, GatewayError>
 where
     V: crate::provider::vendor::Vendor,
 {
@@ -133,21 +137,25 @@ where
     // 2. codec parse
     let egress_handler = ctx.protocol.handler();
     let parser = egress_handler.make_response_parser();
-    let ai_resp = parser
+    let mut ai_resp = parser
         .parse_response(body)
         .map_err(GatewayError::internal)?;
-    let mut internal_resp: crate::protocol::types::InternalResponse = ai_resp.into();
 
-    // 3. reasoning normalization
-    crate::protocol::codec::reasoning::normalize_response_reasoning(&mut internal_resp);
+    // 3. reasoning normalization (via compat round-trip)
+    {
+        let mut old = crate::protocol::types::InternalResponse::from(ai_resp.clone());
+        crate::protocol::codec::reasoning::normalize_response_reasoning(&mut old);
+        ai_resp.reasoning_content = old.reasoning_content;
+        ai_resp.reasoning_signature = old.reasoning_signature;
+    }
 
     // 4. post_parse hook
     vendor
-        .post_parse(&vendor_ctx, &mut internal_resp)
+        .post_parse(&vendor_ctx, &mut ai_resp)
         .await
         .map_err(GatewayError::internal)?;
 
-    Ok(internal_resp)
+    Ok(ai_resp)
 }
 
 /// Standard `stream_parser` factory: wraps the codec's stream parser in a
@@ -235,9 +243,7 @@ mod tests {
     use crate::protocol::ids::{
         ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1, ProtocolId,
     };
-    use crate::protocol::types::{
-        InternalMessage, InternalRequest, InternalResponse, MessageContent, Role,
-    };
+    use crate::protocol::ir::{AiRequest, AiResponse};
     use crate::provider::inbound::InboundResponse;
     use crate::provider::outbound::OutboundRequest;
     use crate::provider::registry::VendorScope;
@@ -247,7 +253,6 @@ mod tests {
     use async_trait::async_trait;
     use reqwest::header::HeaderMap as ExtHeaderMap;
     use serde_json::Value;
-    use std::collections::HashMap;
     use std::path::PathBuf;
     use uuid::Uuid;
 
@@ -280,7 +285,7 @@ mod tests {
         }
         async fn build_request(
             &self,
-            _req: &mut InternalRequest,
+            _req: &mut AiRequest,
             _ctx: &ProviderCtx<'_>,
         ) -> Result<OutboundRequest, GatewayError> {
             unreachable!()
@@ -289,7 +294,7 @@ mod tests {
             &self,
             _resp: InboundResponse,
             _ctx: &ProviderCtx<'_>,
-        ) -> Result<InternalResponse, GatewayError> {
+        ) -> Result<AiResponse, GatewayError> {
             unreachable!()
         }
         fn stream_parser(&self, _ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {
@@ -330,7 +335,7 @@ mod tests {
         }
         async fn build_request(
             &self,
-            _req: &mut InternalRequest,
+            _req: &mut AiRequest,
             _ctx: &ProviderCtx<'_>,
         ) -> Result<OutboundRequest, GatewayError> {
             unreachable!()
@@ -339,7 +344,7 @@ mod tests {
             &self,
             _resp: InboundResponse,
             _ctx: &ProviderCtx<'_>,
-        ) -> Result<InternalResponse, GatewayError> {
+        ) -> Result<AiResponse, GatewayError> {
             unreachable!()
         }
         fn stream_parser(&self, _ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {
@@ -374,25 +379,18 @@ mod tests {
         }
     }
 
-    fn minimal_chat_request() -> InternalRequest {
-        InternalRequest {
-            messages: vec![InternalMessage {
-                role: Role::User,
-                content: MessageContent::Text("ping".into()),
-                tool_calls: None,
-                tool_call_id: None,
-                extra: Default::default(),
-            }],
-            model: "ignored-by-actual-model".into(),
-            stream: false,
-            temperature: None,
-            max_tokens: None,
-            top_p: None,
-            tools: None,
-            tool_choice: None,
-            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
-            extra: HashMap::new(),
-        }
+    fn minimal_chat_request() -> AiRequest {
+        use crate::protocol::ir::{Message, MessageContent, Role};
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Text("ping".into()),
+            tool_calls: None,
+            tool_call_id: None,
+            meta: None,
+        }];
+        let mut req = AiRequest::new("ignored-by-actual-model", messages);
+        req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+        req
     }
 
     async fn build_test_gateway() -> Gateway {

--- a/crates/nyro-core/src/provider/custom/mod.rs
+++ b/crates/nyro-core/src/provider/custom/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{GenericOpenAICompatibleAdapter, openai_map_error};
 use crate::provider::common::pipeline;
 use crate::provider::inbound::InboundResponse;
@@ -75,7 +75,7 @@ impl Vendor for CustomVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -84,7 +84,7 @@ impl Vendor for CustomVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/deepseek/mod.rs
+++ b/crates/nyro-core/src/provider/deepseek/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -88,7 +88,7 @@ impl Vendor for DeepseekVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -97,7 +97,7 @@ impl Vendor for DeepseekVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/google/mod.rs
+++ b/crates/nyro-core/src/provider/google/mod.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::pipeline;
 use crate::provider::inbound::InboundResponse;
 use crate::provider::metadata::{
@@ -86,7 +86,7 @@ impl Vendor for GoogleVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -95,7 +95,7 @@ impl Vendor for GoogleVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/minimax/mod.rs
+++ b/crates/nyro-core/src/provider/minimax/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -114,7 +114,7 @@ impl Vendor for MinimaxVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -123,7 +123,7 @@ impl Vendor for MinimaxVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/moonshotai/mod.rs
+++ b/crates/nyro-core/src/provider/moonshotai/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -114,7 +114,7 @@ impl Vendor for MoonshotaiVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -123,7 +123,7 @@ impl Vendor for MoonshotaiVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/nvidia/mod.rs
+++ b/crates/nyro-core/src/provider/nvidia/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -82,7 +82,7 @@ impl Vendor for NvidiaVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -91,7 +91,7 @@ impl Vendor for NvidiaVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/ollama/mod.rs
+++ b/crates/nyro-core/src/provider/ollama/mod.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use crate::Gateway;
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -81,7 +81,7 @@ impl Vendor for OllamaVendor {
     async fn pre_request(
         &self,
         ctx: &VendorCtx<'_>,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         gw: &Gateway,
     ) -> anyhow::Result<()> {
         if req.tools.is_none() && req.tool_choice.is_none() {
@@ -104,8 +104,8 @@ impl Vendor for OllamaVendor {
             );
             req.tools = None;
             req.tool_choice = None;
-            req.extra.remove("tools");
-            req.extra.remove("tool_choice");
+            req.meta.vendor.ingress.remove("tools");
+            req.meta.vendor.ingress.remove("tool_choice");
         }
         Ok(())
     }
@@ -119,7 +119,7 @@ impl Vendor for OllamaVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -128,7 +128,7 @@ impl Vendor for OllamaVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/openai/mod.rs
+++ b/crates/nyro-core/src/provider/openai/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -122,7 +122,7 @@ impl Vendor for OpenAiVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -131,7 +131,7 @@ impl Vendor for OpenAiVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/openrouter/mod.rs
+++ b/crates/nyro-core/src/provider/openrouter/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -88,7 +88,7 @@ impl Vendor for OpenrouterVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -97,7 +97,7 @@ impl Vendor for OpenrouterVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/vendor.rs
+++ b/crates/nyro-core/src/provider/vendor.rs
@@ -72,7 +72,7 @@ use crate::auth::types::StoredCredential;
 use crate::db::models::Provider;
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta};
+use crate::protocol::ir::{AiRequest, AiResponse, AiStreamDelta};
 use crate::provider::inbound::InboundResponse;
 use crate::provider::metadata::VendorMetadata;
 use crate::provider::outbound::OutboundRequest;
@@ -142,11 +142,7 @@ pub trait Vendor: Send + Sync + 'static {
         format!("{}{}", base_url.trim_end_matches('/'), path)
     }
 
-    async fn pre_encode(
-        &self,
-        _ctx: &VendorCtx<'_>,
-        _req: &mut InternalRequest,
-    ) -> anyhow::Result<()> {
+    async fn pre_encode(&self, _ctx: &VendorCtx<'_>, _req: &mut AiRequest) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -163,11 +159,7 @@ pub trait Vendor: Send + Sync + 'static {
         Ok(())
     }
 
-    async fn post_parse(
-        &self,
-        _ctx: &VendorCtx<'_>,
-        _resp: &mut InternalResponse,
-    ) -> anyhow::Result<()> {
+    async fn post_parse(&self, _ctx: &VendorCtx<'_>, _resp: &mut AiResponse) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -182,7 +174,7 @@ pub trait Vendor: Send + Sync + 'static {
     async fn on_stream_delta(
         &self,
         _ctx: &VendorCtx<'_>,
-        _delta: &mut StreamDelta,
+        _delta: &mut AiStreamDelta,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -190,7 +182,7 @@ pub trait Vendor: Send + Sync + 'static {
     async fn pre_request(
         &self,
         _ctx: &VendorCtx<'_>,
-        _req: &mut InternalRequest,
+        _req: &mut AiRequest,
         _gw: &Gateway,
     ) -> anyhow::Result<()> {
         Ok(())
@@ -207,7 +199,7 @@ pub trait Vendor: Send + Sync + 'static {
     /// Build the outbound request via the standard 7-step pipeline.
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError>;
 
@@ -216,7 +208,7 @@ pub trait Vendor: Send + Sync + 'static {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError>;
+    ) -> Result<AiResponse, GatewayError>;
 
     /// Return a stream parser for SSE responses.
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send>;

--- a/crates/nyro-core/src/provider/vendor_ext.rs
+++ b/crates/nyro-core/src/provider/vendor_ext.rs
@@ -21,7 +21,7 @@ use crate::Gateway;
 use crate::auth::types::StoredCredential;
 use crate::db::models::Provider;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta};
+use crate::protocol::ir::{AiRequest, AiResponse, AiStreamDelta};
 use crate::provider::registry::VendorScope;
 
 /// Runtime context handed to every `VendorExtension` hook.
@@ -55,11 +55,7 @@ pub trait VendorExtension: Send + Sync + 'static {
         format!("{}{}", base_url.trim_end_matches('/'), path)
     }
 
-    async fn pre_encode(
-        &self,
-        _ctx: &VendorCtx<'_>,
-        _req: &mut InternalRequest,
-    ) -> anyhow::Result<()> {
+    async fn pre_encode(&self, _ctx: &VendorCtx<'_>, _req: &mut AiRequest) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -76,11 +72,7 @@ pub trait VendorExtension: Send + Sync + 'static {
         Ok(())
     }
 
-    async fn post_parse(
-        &self,
-        _ctx: &VendorCtx<'_>,
-        _resp: &mut InternalResponse,
-    ) -> anyhow::Result<()> {
+    async fn post_parse(&self, _ctx: &VendorCtx<'_>, _resp: &mut AiResponse) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -95,7 +87,7 @@ pub trait VendorExtension: Send + Sync + 'static {
     async fn on_stream_delta(
         &self,
         _ctx: &VendorCtx<'_>,
-        _delta: &mut StreamDelta,
+        _delta: &mut AiStreamDelta,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -105,7 +97,7 @@ pub trait VendorExtension: Send + Sync + 'static {
     async fn pre_request(
         &self,
         _ctx: &VendorCtx<'_>,
-        _req: &mut InternalRequest,
+        _req: &mut AiRequest,
         _gw: &Gateway,
     ) -> anyhow::Result<()> {
         Ok(())
@@ -131,11 +123,7 @@ impl<T: crate::provider::vendor::Vendor> VendorExtension for T {
     fn build_url(&self, ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
         crate::provider::vendor::Vendor::build_url(self, ctx, base_url, path)
     }
-    async fn pre_encode(
-        &self,
-        ctx: &VendorCtx<'_>,
-        req: &mut InternalRequest,
-    ) -> anyhow::Result<()> {
+    async fn pre_encode(&self, ctx: &VendorCtx<'_>, req: &mut AiRequest) -> anyhow::Result<()> {
         crate::provider::vendor::Vendor::pre_encode(self, ctx, req).await
     }
     async fn post_encode(
@@ -153,11 +141,7 @@ impl<T: crate::provider::vendor::Vendor> VendorExtension for T {
     ) -> anyhow::Result<()> {
         crate::provider::vendor::Vendor::pre_parse(self, ctx, resp).await
     }
-    async fn post_parse(
-        &self,
-        ctx: &VendorCtx<'_>,
-        resp: &mut InternalResponse,
-    ) -> anyhow::Result<()> {
+    async fn post_parse(&self, ctx: &VendorCtx<'_>, resp: &mut AiResponse) -> anyhow::Result<()> {
         crate::provider::vendor::Vendor::post_parse(self, ctx, resp).await
     }
     async fn on_stream_raw_chunk(
@@ -170,14 +154,14 @@ impl<T: crate::provider::vendor::Vendor> VendorExtension for T {
     async fn on_stream_delta(
         &self,
         ctx: &VendorCtx<'_>,
-        delta: &mut StreamDelta,
+        delta: &mut AiStreamDelta,
     ) -> anyhow::Result<()> {
         crate::provider::vendor::Vendor::on_stream_delta(self, ctx, delta).await
     }
     async fn pre_request(
         &self,
         ctx: &VendorCtx<'_>,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         gw: &Gateway,
     ) -> anyhow::Result<()> {
         crate::provider::vendor::Vendor::pre_request(self, ctx, req, gw).await

--- a/crates/nyro-core/src/provider/xai/mod.rs
+++ b/crates/nyro-core/src/provider/xai/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -80,7 +80,7 @@ impl Vendor for XaiVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -89,7 +89,7 @@ impl Vendor for XaiVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/zai/mod.rs
+++ b/crates/nyro-core/src/provider/zai/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -112,7 +112,7 @@ impl Vendor for ZaiVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -121,7 +121,7 @@ impl Vendor for ZaiVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/provider/zhipuai/mod.rs
+++ b/crates/nyro-core/src/provider/zhipuai/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::GatewayError;
 use crate::protocol::ids::ProtocolId;
-use crate::protocol::types::{InternalRequest, InternalResponse};
+use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::openai::{
     openai_bearer_auth_headers, openai_build_url, openai_map_error,
 };
@@ -114,7 +114,7 @@ impl Vendor for ZhipuaiVendor {
     }
     async fn build_request(
         &self,
-        req: &mut InternalRequest,
+        req: &mut AiRequest,
         ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         pipeline::build_request(self, req, ctx).await
@@ -123,7 +123,7 @@ impl Vendor for ZhipuaiVendor {
         &self,
         resp: InboundResponse,
         ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         pipeline::parse_response(self, resp, ctx).await
     }
     fn stream_parser(&self, ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/crates/nyro-core/src/proxy/dispatcher/accumulator.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/accumulator.rs
@@ -1,7 +1,9 @@
 //! Stream response accumulator: buffers streaming deltas into a complete
-//! `InternalResponse` for caching and formatted response aggregation.
+//! `AiResponse` for caching and formatted response aggregation.
 
-use crate::protocol::types::{InternalResponse, StreamDelta, TokenUsage, ToolCall};
+use crate::protocol::ir::request::ToolCall;
+use crate::protocol::ir::{AiResponse, AiStreamDelta};
+use crate::protocol::types::TokenUsage;
 
 #[derive(Default)]
 pub(super) struct StreamResponseAccumulator {
@@ -16,15 +18,15 @@ pub(super) struct StreamResponseAccumulator {
 }
 
 impl StreamResponseAccumulator {
-    pub(super) fn apply_all(&mut self, deltas: &[StreamDelta]) {
+    pub(super) fn apply_all(&mut self, deltas: &[AiStreamDelta]) {
         for delta in deltas {
             self.apply(delta);
         }
     }
 
-    pub(super) fn apply(&mut self, delta: &StreamDelta) {
+    pub(super) fn apply(&mut self, delta: &AiStreamDelta) {
         match delta {
-            StreamDelta::MessageStart { id, model } => {
+            AiStreamDelta::MessageStart { id, model } => {
                 if self.id.is_empty() {
                     self.id = id.clone();
                 }
@@ -32,10 +34,10 @@ impl StreamResponseAccumulator {
                     self.model = model.clone();
                 }
             }
-            StreamDelta::ReasoningDelta(text) => self.reasoning_content.push_str(text),
-            StreamDelta::ReasoningSignature(sig) => self.reasoning_signature.push_str(sig),
-            StreamDelta::TextDelta(text) => self.content.push_str(text),
-            StreamDelta::ToolCallStart { index, id, name } => {
+            AiStreamDelta::ThinkingDelta(text) => self.reasoning_content.push_str(text),
+            AiStreamDelta::ThinkingSignature(sig) => self.reasoning_signature.push_str(sig),
+            AiStreamDelta::TextDelta(text) => self.content.push_str(text),
+            AiStreamDelta::ToolCallStart { index, id, name } => {
                 ensure_tool_index(&mut self.tool_calls, *index);
                 self.tool_calls[*index] = Some(ToolCall {
                     id: id.clone(),
@@ -43,7 +45,7 @@ impl StreamResponseAccumulator {
                     arguments: String::new(),
                 });
             }
-            StreamDelta::ToolCallDelta { index, arguments } => {
+            AiStreamDelta::ToolCallDelta { index, arguments } => {
                 ensure_tool_index(&mut self.tool_calls, *index);
                 if let Some(tc) = self.tool_calls[*index].as_mut() {
                     tc.arguments.push_str(arguments);
@@ -55,38 +57,48 @@ impl StreamResponseAccumulator {
                     });
                 }
             }
-            StreamDelta::Usage(usage) => self.usage = usage.clone(),
-            StreamDelta::Done { stop_reason } => self.stop_reason = Some(stop_reason.clone()),
-            StreamDelta::RawEvent { .. } => {}
+            AiStreamDelta::ToolCallComplete { index, tool_call } => {
+                ensure_tool_index(&mut self.tool_calls, *index);
+                self.tool_calls[*index] = Some(tool_call.clone());
+            }
+            AiStreamDelta::Usage(usage) => self.usage = usage.clone(),
+            AiStreamDelta::Done { stop_reason } => self.stop_reason = Some(stop_reason.clone()),
+            AiStreamDelta::StreamError { error } => {
+                self.stop_reason = Some("error".to_string());
+                tracing::warn!(error = ?error, "stream error delta received");
+            }
+            AiStreamDelta::UnexpectedEof => {
+                if self.stop_reason.is_none() {
+                    self.stop_reason = Some("error".to_string());
+                }
+            }
+            AiStreamDelta::Unknown { .. } => {}
         }
     }
 
-    pub(super) fn into_internal_response(self) -> InternalResponse {
+    pub(super) fn into_ai_response(self) -> AiResponse {
         let tool_calls = self
             .tool_calls
             .into_iter()
             .flatten()
             .filter(|tc| !tc.name.is_empty())
             .collect::<Vec<_>>();
-        InternalResponse {
-            id: self.id,
-            model: self.model,
-            content: self.content,
-            reasoning_content: if self.reasoning_content.is_empty() {
-                None
-            } else {
-                Some(self.reasoning_content)
-            },
-            reasoning_signature: if self.reasoning_signature.is_empty() {
-                None
-            } else {
-                Some(self.reasoning_signature)
-            },
-            tool_calls,
-            stop_reason: self.stop_reason,
-            usage: self.usage,
-            response_items: None,
-        }
+        let mut resp = AiResponse::new(self.id, self.model);
+        resp.content = self.content;
+        resp.reasoning_content = if self.reasoning_content.is_empty() {
+            None
+        } else {
+            Some(self.reasoning_content)
+        };
+        resp.reasoning_signature = if self.reasoning_signature.is_empty() {
+            None
+        } else {
+            Some(self.reasoning_signature)
+        };
+        resp.tool_calls = tool_calls;
+        resp.stop_reason = self.stop_reason;
+        resp.usage = self.usage;
+        resp
     }
 }
 

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -51,8 +51,8 @@ use crate::db::models::Provider;
 use crate::error::{AuthFailure, GatewayError};
 use crate::protocol::ProviderProtocols;
 use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, ProtocolId};
-use crate::protocol::ir::{AiRequest, RawEnvelope};
-use crate::protocol::types::{InternalRequest, InternalResponse, StreamDelta, TokenUsage};
+use crate::protocol::ir::{AiRequest, AiResponse, RawEnvelope};
+use crate::protocol::types::TokenUsage;
 use crate::provider::vendor::ProviderCtx;
 use crate::provider::{VendorCtx, VendorRegistry};
 use crate::proxy::client::ProxyClient;
@@ -82,7 +82,7 @@ pub async fn dispatch_pipeline(
     request: AiRequest,
     ingress: ProtocolId,
 ) -> Response {
-    // Derive logging strings from envelope; convert new IR → old IR for backward-compat.
+    // Derive logging strings from envelope.
     let method_owned = envelope.method.clone();
     let path_owned = envelope.path.clone();
     let request_body_str = envelope
@@ -97,10 +97,10 @@ pub async fn dispatch_pipeline(
         headers: request_headers_str.clone(),
         body: request_body_str.clone(),
     };
-    let mut internal: InternalRequest = request.into();
+    let mut request = request;
     let start = Instant::now();
-    let request_model = internal.model.clone();
-    let is_stream = internal.stream;
+    let request_model = request.model.clone();
+    let is_stream = request.stream.enabled;
     let ingress_str = ingress.to_string();
 
     // ── Route lookup ─────────────────────────────────────────────────────────
@@ -147,7 +147,7 @@ pub async fn dispatch_pipeline(
     let cache_backend = (**gw.cache_backend.load()).clone();
     let vector_store = (**gw.vector_store.load()).clone();
     let route_cache = resolve_route_cache(&route);
-    let request_has_image = request_has_image_input(&internal);
+    let request_has_image = request_has_image_input(&request);
     let exact_enabled_for_route = cache_config.exact.enabled
         && cache_backend.is_some()
         && route_cache.exact.is_some()
@@ -156,9 +156,9 @@ pub async fn dispatch_pipeline(
         && vector_store.is_some()
         && route_cache.semantic.is_some()
         && !request_has_image;
-    let semantic_write_temp_allowed = internal.temperature.unwrap_or(0.0) <= 0.0;
+    let semantic_write_temp_allowed = request.generation.temperature.unwrap_or(0.0) <= 0.0;
     let request_cache_key = if exact_enabled_for_route || semantic_enabled_for_route {
-        Some(build_cache_key(&internal, ingress))
+        Some(build_cache_key(&request, ingress))
     } else {
         None
     };
@@ -169,11 +169,11 @@ pub async fn dispatch_pipeline(
         route_semantic_threshold(&route_cache, cache_config.semantic.similarity_threshold);
     let semantic_entry_key = request_cache_key
         .clone()
-        .unwrap_or_else(|| build_cache_key(&internal, ingress));
-    let semantic_embedding = extract_semantic_embedding_input(&internal);
+        .unwrap_or_else(|| build_cache_key(&request, ingress));
+    let semantic_embedding = extract_semantic_embedding_input(&request);
     let semantic_partition = semantic_embedding
         .as_ref()
-        .map(|(system_prompt, _)| build_semantic_partition(&internal.model, system_prompt));
+        .map(|(system_prompt, _)| build_semantic_partition(&request.model, system_prompt));
 
     // ── Exact cache read ──────────────────────────────────────────────────────
 
@@ -353,11 +353,11 @@ pub async fn dispatch_pipeline(
         let hook_ctx = crate::integrations::HookContext {
             route_id: route.id.clone(),
             provider_name: String::new(),
-            model: internal.model.clone(),
+            model: request.model.clone(),
             api_key_id: auth_key.id.clone(),
         };
         for hook in hook_registry.request_hooks() {
-            if let Err(e) = hook.on_request(&hook_ctx, &mut internal).await {
+            if let Err(e) = hook.on_request(&hook_ctx, &mut request).await {
                 tracing::warn!(hook = hook.name(), error = %e, "request hook rejected request");
                 LogBuilder::from_dispatch(
                     &gw,
@@ -430,7 +430,7 @@ pub async fn dispatch_pipeline(
             target.model.clone()
         };
 
-        let mut internal_for_target = internal.clone();
+        let mut request_for_target = request.clone();
 
         let provider_runtime = match gw.admin().resolve_provider_runtime(&provider).await {
             Ok(runtime) => runtime,
@@ -514,7 +514,7 @@ pub async fn dispatch_pipeline(
                 }
             }
         } else {
-            match adapter.build_request(&mut internal_for_target, &ctx).await {
+            match adapter.build_request(&mut request_for_target, &ctx).await {
                 Ok(o) => o,
                 Err(e) => {
                     last_response = Some(e.render(None));
@@ -987,7 +987,7 @@ fn cached_entry_to_response(
 
 fn replay_cached_stream(
     ingress: ProtocolId,
-    internal: &InternalResponse,
+    ai_resp: &AiResponse,
     cache_key: Option<&str>,
     cache_status: &str,
     score: Option<f64>,
@@ -995,16 +995,12 @@ fn replay_cached_stream(
     expose_headers: bool,
 ) -> Response {
     let mut formatter = ingress.handler().make_stream_formatter();
-    let old_deltas = internal_response_to_deltas(internal);
-    let old_deltas = if stream_replay_tps > 0 {
-        split_text_deltas(old_deltas, 4)
+    let ai_deltas = ai_response_to_deltas(ai_resp);
+    let ai_deltas = if stream_replay_tps > 0 {
+        split_text_deltas(ai_deltas, 4)
     } else {
-        old_deltas
+        ai_deltas
     };
-    let ai_deltas: Vec<crate::protocol::ir::AiStreamDelta> = old_deltas
-        .iter()
-        .map(crate::protocol::ir::compat::old_stream_delta_to_new)
-        .collect();
     let mut payloads: Vec<String> = formatter
         .format_deltas(&ai_deltas)
         .into_iter()
@@ -1057,46 +1053,43 @@ fn replay_cached_stream(
     response
 }
 
-fn internal_response_to_deltas(internal: &InternalResponse) -> Vec<StreamDelta> {
-    let mut deltas = vec![StreamDelta::MessageStart {
-        id: if internal.id.is_empty() {
+fn ai_response_to_deltas(resp: &AiResponse) -> Vec<crate::protocol::ir::AiStreamDelta> {
+    use crate::protocol::ir::AiStreamDelta;
+    let mut deltas = vec![AiStreamDelta::MessageStart {
+        id: if resp.id.is_empty() {
             format!("chatcmpl-{}", uuid::Uuid::new_v4().simple())
         } else {
-            internal.id.clone()
+            resp.id.clone()
         },
-        model: internal.model.clone(),
+        model: resp.model.clone(),
     }];
-    if let Some(reasoning) = &internal.reasoning_content
+    if let Some(reasoning) = &resp.reasoning_content
         && !reasoning.is_empty()
     {
-        deltas.push(StreamDelta::ReasoningDelta(reasoning.clone()));
-        if let Some(sig) = internal
-            .reasoning_signature
-            .as_ref()
-            .filter(|s| !s.is_empty())
-        {
-            deltas.push(StreamDelta::ReasoningSignature(sig.clone()));
+        deltas.push(AiStreamDelta::ThinkingDelta(reasoning.clone()));
+        if let Some(sig) = resp.reasoning_signature.as_ref().filter(|s| !s.is_empty()) {
+            deltas.push(AiStreamDelta::ThinkingSignature(sig.clone()));
         }
     }
-    if !internal.content.is_empty() {
-        deltas.push(StreamDelta::TextDelta(internal.content.clone()));
+    if !resp.content.is_empty() {
+        deltas.push(AiStreamDelta::TextDelta(resp.content.clone()));
     }
-    for (index, tool_call) in internal.tool_calls.iter().enumerate() {
-        deltas.push(StreamDelta::ToolCallStart {
+    for (index, tool_call) in resp.tool_calls.iter().enumerate() {
+        deltas.push(AiStreamDelta::ToolCallStart {
             index,
             id: tool_call.id.clone(),
             name: tool_call.name.clone(),
         });
         if !tool_call.arguments.is_empty() {
-            deltas.push(StreamDelta::ToolCallDelta {
+            deltas.push(AiStreamDelta::ToolCallDelta {
                 index,
                 arguments: tool_call.arguments.clone(),
             });
         }
     }
-    deltas.push(StreamDelta::Usage(internal.usage.clone()));
-    deltas.push(StreamDelta::Done {
-        stop_reason: internal
+    deltas.push(AiStreamDelta::Usage(resp.usage.clone()));
+    deltas.push(AiStreamDelta::Done {
+        stop_reason: resp
             .stop_reason
             .clone()
             .unwrap_or_else(|| "stop".to_string()),
@@ -1104,28 +1097,32 @@ fn internal_response_to_deltas(internal: &InternalResponse) -> Vec<StreamDelta> 
     deltas
 }
 
-fn split_text_deltas(deltas: Vec<StreamDelta>, chunk_chars: usize) -> Vec<StreamDelta> {
+fn split_text_deltas(
+    deltas: Vec<crate::protocol::ir::AiStreamDelta>,
+    chunk_chars: usize,
+) -> Vec<crate::protocol::ir::AiStreamDelta> {
+    use crate::protocol::ir::AiStreamDelta;
     deltas
         .into_iter()
         .flat_map(|d| match d {
-            StreamDelta::TextDelta(text) => {
+            AiStreamDelta::TextDelta(text) => {
                 let chars: Vec<char> = text.chars().collect();
                 if chars.len() <= chunk_chars {
-                    return vec![StreamDelta::TextDelta(text)];
+                    return vec![AiStreamDelta::TextDelta(text)];
                 }
                 chars
                     .chunks(chunk_chars)
-                    .map(|c| StreamDelta::TextDelta(c.iter().collect()))
+                    .map(|c| AiStreamDelta::TextDelta(c.iter().collect()))
                     .collect()
             }
-            StreamDelta::ReasoningDelta(text) => {
+            AiStreamDelta::ThinkingDelta(text) => {
                 let chars: Vec<char> = text.chars().collect();
                 if chars.len() <= chunk_chars {
-                    return vec![StreamDelta::ReasoningDelta(text)];
+                    return vec![AiStreamDelta::ThinkingDelta(text)];
                 }
                 chars
                     .chunks(chunk_chars)
-                    .map(|c| StreamDelta::ReasoningDelta(c.iter().collect()))
+                    .map(|c| AiStreamDelta::ThinkingDelta(c.iter().collect()))
                     .collect()
             }
             other => vec![other],

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -13,9 +13,6 @@ use serde_json::Value;
 
 use crate::cache::entry::CacheEntry;
 use crate::integrations::{HookContext, HookRegistry};
-use crate::protocol::ir::AiResponse;
-use crate::protocol::ir::compat::ai_stream_delta_to_old;
-use crate::protocol::types::StreamDelta;
 use crate::provider::inbound::InboundResponse;
 use crate::provider::vendor::ProviderCtx;
 use crate::proxy::client::ProxyClient;
@@ -130,7 +127,7 @@ pub(super) async fn handle_non_stream(
 
     // Parse response via ProviderAdapter.
     let inbound = InboundResponse { status, body: resp };
-    let mut internal_resp = match adapter.parse_response(inbound, ctx).await {
+    let mut ai_resp = match adapter.parse_response(inbound, ctx).await {
         Ok(r) => r,
         Err(e) => {
             log.status(500)
@@ -146,8 +143,8 @@ pub(super) async fn handle_non_stream(
     };
 
     // Ensure actual_model is set in the response.
-    if internal_resp.model.is_empty() {
-        internal_resp.model = actual_model.to_string();
+    if ai_resp.model.is_empty() {
+        ai_resp.model = actual_model.to_string();
     }
 
     // ── Response hooks ──────────────────────────────────────────────────────
@@ -157,19 +154,18 @@ pub(super) async fn handle_non_stream(
         let hook_ctx = HookContext {
             route_id: call_ctx.route_id.to_string(),
             provider_name: call_ctx.provider.name.clone(),
-            model: internal_resp.model.clone(),
+            model: ai_resp.model.clone(),
             api_key_id: call_ctx.api_key_id.map(str::to_string),
         };
         for hook in hook_registry.response_hooks() {
-            hook.on_response(&hook_ctx, &mut internal_resp, latency_ms)
-                .await;
+            hook.on_response(&hook_ctx, &mut ai_resp, latency_ms).await;
         }
     }
 
-    let is_tool = !internal_resp.tool_calls.is_empty();
-    let usage = internal_resp.usage.clone();
+    let is_tool = !ai_resp.tool_calls.is_empty();
+    let usage = ai_resp.usage.clone();
     let formatter = ingress.handler().make_response_formatter();
-    let output = formatter.format_response(&AiResponse::from(internal_resp.clone()));
+    let output = formatter.format_response(&ai_resp);
 
     let response_body_full = serde_json::to_string(&output).ok();
     let response_preview = response_body_full
@@ -198,7 +194,7 @@ pub(super) async fn handle_non_stream(
             actual_model: Some(actual_model.to_string()),
             usage,
             created_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-            internal_response: Some(internal_resp),
+            internal_response: Some(ai_resp),
         };
         if let Ok(bytes) = serde_json::to_vec(&entry) {
             if allow_exact_store {
@@ -296,32 +292,29 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
         };
         let text = String::from_utf8_lossy(&bytes);
         if let Ok(ai_deltas) = stream_parser.parse_chunk(&text) {
-            let old: Vec<StreamDelta> = ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-            accumulator.apply_all(&old);
+            accumulator.apply_all(&ai_deltas);
         }
     }
 
     if let Ok(ai_deltas) = stream_parser.finish() {
-        let old: Vec<StreamDelta> = ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-        accumulator.apply_all(&old);
+        accumulator.apply_all(&ai_deltas);
     }
 
-    let mut internal_resp = accumulator.into_internal_response();
-    if internal_resp.id.is_empty() {
-        internal_resp.id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
+    let mut ai_resp = accumulator.into_ai_response();
+    if ai_resp.id.is_empty() {
+        ai_resp.id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
     }
-    if internal_resp.model.is_empty() {
-        internal_resp.model = actual_model.to_string();
+    if ai_resp.model.is_empty() {
+        ai_resp.model = actual_model.to_string();
     }
-    if internal_resp.stop_reason.is_none() {
-        internal_resp.stop_reason = Some("stop".to_string());
+    if ai_resp.stop_reason.is_none() {
+        ai_resp.stop_reason = Some("stop".to_string());
     }
-    crate::protocol::codec::reasoning::normalize_response_reasoning(&mut internal_resp);
 
-    let is_tool = !internal_resp.tool_calls.is_empty();
-    let usage = internal_resp.usage.clone();
+    let is_tool = !ai_resp.tool_calls.is_empty();
+    let usage = ai_resp.usage.clone();
     let formatter = ingress.handler().make_response_formatter();
-    let output = formatter.format_response(&AiResponse::from(internal_resp.clone()));
+    let output = formatter.format_response(&ai_resp);
 
     let response_preview = serde_json::to_string(&output)
         .ok()
@@ -349,7 +342,7 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
             actual_model: Some(actual_model.to_string()),
             usage,
             created_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-            internal_response: Some(internal_resp),
+            internal_response: Some(ai_resp),
         };
         if let Ok(bytes) = serde_json::to_vec(&entry) {
             if allow_exact_store {

--- a/crates/nyro-core/src/proxy/dispatcher/stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/stream.rs
@@ -19,9 +19,7 @@ use tokio::sync::broadcast;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::cache::entry::CacheEntry;
-use crate::protocol::ir::compat::ai_stream_delta_to_old;
-use crate::protocol::ir::{AiResponse, AiStreamDelta};
-use crate::protocol::types::StreamDelta;
+use crate::protocol::ir::AiStreamDelta;
 use crate::proxy::client::ProxyClient;
 use crate::proxy::observability::headers_to_json;
 
@@ -141,32 +139,28 @@ pub(super) async fn handle_stream(
             let mut log_parser = egress.handler().make_stream_parser();
             let mut accumulator = StreamResponseAccumulator::default();
             if let Ok(ai_deltas) = log_parser.parse_chunk(&log_text) {
-                let old: Vec<StreamDelta> = ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-                accumulator.apply_all(&old);
+                accumulator.apply_all(&ai_deltas);
             }
             if let Ok(ai_deltas) = log_parser.finish() {
-                let old: Vec<StreamDelta> = ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-                accumulator.apply_all(&old);
+                accumulator.apply_all(&ai_deltas);
             }
 
-            let mut internal = accumulator.into_internal_response();
-            if internal.id.is_empty() {
-                internal.id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+            let mut ai_resp = accumulator.into_ai_response();
+            if ai_resp.id.is_empty() {
+                ai_resp.id = format!("msg_{}", uuid::Uuid::new_v4().simple());
             }
-            if internal.model.is_empty() {
-                // actual_model is embedded inside log_pt
-                internal.model = log_pt.actual_model.clone();
+            if ai_resp.model.is_empty() {
+                ai_resp.model = log_pt.actual_model.clone();
             }
 
             let aggregated_formatter = ingress.handler().make_response_formatter();
-            let aggregated_output =
-                aggregated_formatter.format_response(&AiResponse::from(internal.clone()));
+            let aggregated_output = aggregated_formatter.format_response(&ai_resp);
             let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
 
             log_pt
                 .status(200)
-                .usage(internal.usage.clone())
-                .maybe_tool(!internal.tool_calls.is_empty())
+                .usage(ai_resp.usage.clone())
+                .maybe_tool(!ai_resp.tool_calls.is_empty())
                 .maybe_error(stream_error)
                 .resp_headers(upstream_hdrs_pt)
                 .resp_body(aggregated_body_str)
@@ -232,9 +226,7 @@ pub(super) async fn handle_stream(
             };
             let text = String::from_utf8_lossy(&bytes);
             if let Ok(ai_deltas) = stream_parser.parse_chunk(&text) {
-                let old_deltas: Vec<StreamDelta> =
-                    ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-                accumulator.apply_all(&old_deltas);
+                accumulator.apply_all(&ai_deltas);
                 let events = stream_formatter.format_deltas(&ai_deltas);
                 for ev in events {
                     if tx.send(Ok(ev.to_sse_string())).await.is_err() {
@@ -245,9 +237,7 @@ pub(super) async fn handle_stream(
         }
 
         if let Ok(ai_deltas) = stream_parser.finish() {
-            let old_deltas: Vec<StreamDelta> =
-                ai_deltas.iter().map(ai_stream_delta_to_old).collect();
-            accumulator.apply_all(&old_deltas);
+            accumulator.apply_all(&ai_deltas);
             let events = stream_formatter.format_deltas(&ai_deltas);
             for ev in events {
                 let _ = tx.send(Ok(ev.to_sse_string())).await;
@@ -260,48 +250,47 @@ pub(super) async fn handle_stream(
         }
 
         let usage = stream_formatter.usage();
-        let mut internal = accumulator.into_internal_response();
-        if internal.usage.input_tokens == 0 && internal.usage.output_tokens == 0 {
-            internal.usage = usage.clone();
+        let mut ai_resp = accumulator.into_ai_response();
+        if ai_resp.usage.input_tokens == 0 && ai_resp.usage.output_tokens == 0 {
+            ai_resp.usage = usage.clone();
         }
-        if internal.id.is_empty() {
-            internal.id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
+        if ai_resp.id.is_empty() {
+            ai_resp.id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
         }
-        if internal.model.is_empty() {
-            internal.model = act_model_ir.clone();
+        if ai_resp.model.is_empty() {
+            ai_resp.model = act_model_ir.clone();
         }
-        if internal.stop_reason.is_none() {
-            internal.stop_reason = Some("stop".to_string());
+        if ai_resp.stop_reason.is_none() {
+            ai_resp.stop_reason = Some("stop".to_string());
         }
 
         let aggregated_formatter = ingress.handler().make_response_formatter();
-        let aggregated_output =
-            aggregated_formatter.format_response(&AiResponse::from(internal.clone()));
+        let aggregated_output = aggregated_formatter.format_response(&ai_resp);
         let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
         log_ir
             .status(200)
-            .usage(internal.usage.clone())
-            .maybe_tool(!internal.tool_calls.is_empty())
+            .usage(ai_resp.usage.clone())
+            .maybe_tool(!ai_resp.tool_calls.is_empty())
             .resp_headers(upstream_hdrs_owned)
             .resp_body(aggregated_body_str)
             .emit();
 
         let mut singleflight_payload: Option<Vec<u8>> = None;
-        if allow_exact_store && internal.tool_calls.is_empty() {
+        if allow_exact_store && ai_resp.tool_calls.is_empty() {
             let cache_backend = (**gw_ir.cache_backend.load()).clone();
             if let (Some(cache_backend), Some(cache_key)) =
                 (cache_backend.as_ref(), cache_key_owned.as_deref())
             {
                 let formatter = ingress.handler().make_response_formatter();
-                let payload = formatter.format_response(&AiResponse::from(internal.clone()));
+                let payload = formatter.format_response(&ai_resp);
                 let entry = CacheEntry {
                     payload,
                     status_code: 200,
                     provider_name: provider_name_ir.clone(),
                     actual_model: Some(act_model_ir.clone()),
-                    usage: internal.usage.clone(),
+                    usage: ai_resp.usage.clone(),
                     created_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-                    internal_response: Some(internal.clone()),
+                    internal_response: Some(ai_resp.clone()),
                 };
                 if let Ok(bytes) = serde_json::to_vec(&entry) {
                     let _ = cache_backend
@@ -325,21 +314,21 @@ pub(super) async fn handle_stream(
                     }
                 }
             }
-        } else if internal.tool_calls.is_empty() {
+        } else if ai_resp.tool_calls.is_empty() {
             let vector_store = (**gw_ir.vector_store.load()).clone();
             if let (Some(vector_store), Some(ctx)) =
                 (vector_store.as_ref(), semantic_write_ctx_owned.as_ref())
             {
                 let formatter = ingress.handler().make_response_formatter();
-                let payload = formatter.format_response(&AiResponse::from(internal.clone()));
+                let payload = formatter.format_response(&ai_resp);
                 let entry = CacheEntry {
                     payload,
                     status_code: 200,
                     provider_name: provider_name_ir.clone(),
                     actual_model: Some(act_model_ir.clone()),
-                    usage: internal.usage.clone(),
+                    usage: ai_resp.usage.clone(),
                     created_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-                    internal_response: Some(internal.clone()),
+                    internal_response: Some(ai_resp.clone()),
                 };
                 if let Ok(bytes) = serde_json::to_vec(&entry) {
                     let vector = if let Some(existing) = ctx.query_vector.clone() {

--- a/crates/nyro-core/src/proxy/dispatcher/util.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/util.rs
@@ -12,7 +12,7 @@ use crate::cache::entry::CacheEntry;
 use crate::db::models::{
     Route, RouteCacheConfig, RouteExactCacheConfig, RouteSemanticCacheConfig, RouteTarget,
 };
-use crate::protocol::types::{ContentBlock, InternalRequest, MessageContent, Role};
+use crate::protocol::ir::{AiRequest, ContentBlock, MessageContent, Role};
 
 // ── Semantic write context ─────────────────────────────────────────────────────
 
@@ -122,7 +122,7 @@ pub(super) fn is_semantic_entry_expired(entry: &CacheEntry, ttl: Duration) -> bo
 
 // ── Request introspection ─────────────────────────────────────────────────────
 
-pub(super) fn request_has_image_input(request: &InternalRequest) -> bool {
+pub(super) fn request_has_image_input(request: &AiRequest) -> bool {
     for message in &request.messages {
         if let MessageContent::Blocks(blocks) = &message.content
             && blocks
@@ -135,14 +135,12 @@ pub(super) fn request_has_image_input(request: &InternalRequest) -> bool {
     false
 }
 
-pub(super) fn extract_semantic_embedding_input(
-    request: &InternalRequest,
-) -> Option<(String, String)> {
+pub(super) fn extract_semantic_embedding_input(request: &AiRequest) -> Option<(String, String)> {
     let system_prompt = request
         .messages
         .iter()
         .filter(|m| matches!(m.role, Role::System))
-        .map(|m| m.content.as_text())
+        .map(|m| m.content.to_text())
         .filter(|t| !t.trim().is_empty())
         .collect::<Vec<_>>()
         .join("\n");
@@ -152,7 +150,7 @@ pub(super) fn extract_semantic_embedding_input(
         .iter()
         .rev()
         .find(|m| matches!(m.role, Role::User))
-        .map(|m| m.content.as_text())
+        .map(|m| m.content.to_text())
         .filter(|t| !t.trim().is_empty())?;
 
     let combined = if system_prompt.is_empty() {

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -29,7 +29,7 @@ use nyro_core::protocol::ids::{
     ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1, ProtocolId,
 };
-use nyro_core::protocol::types::{InternalRequest, InternalResponse};
+use nyro_core::protocol::ir::{AiRequest, AiResponse};
 use nyro_core::provider::inbound::InboundResponse;
 use nyro_core::provider::outbound::OutboundRequest;
 use nyro_core::provider::registry::VendorScope;
@@ -136,7 +136,7 @@ impl Vendor for BearerVendor {
     }
     async fn build_request(
         &self,
-        _req: &mut InternalRequest,
+        _req: &mut AiRequest,
         _ctx: &ProviderCtx<'_>,
     ) -> Result<OutboundRequest, GatewayError> {
         unreachable!()
@@ -145,7 +145,7 @@ impl Vendor for BearerVendor {
         &self,
         _resp: InboundResponse,
         _ctx: &ProviderCtx<'_>,
-    ) -> Result<InternalResponse, GatewayError> {
+    ) -> Result<AiResponse, GatewayError> {
         unreachable!()
     }
     fn stream_parser(&self, _ctx: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {
@@ -467,7 +467,7 @@ fn vendor_declared_mutations_defaults_are_conservative() {
         }
         async fn build_request(
             &self,
-            _: &mut InternalRequest,
+            _: &mut AiRequest,
             _: &ProviderCtx<'_>,
         ) -> Result<OutboundRequest, GatewayError> {
             unreachable!()
@@ -476,7 +476,7 @@ fn vendor_declared_mutations_defaults_are_conservative() {
             &self,
             _: InboundResponse,
             _: &ProviderCtx<'_>,
-        ) -> Result<InternalResponse, GatewayError> {
+        ) -> Result<AiResponse, GatewayError> {
             unreachable!()
         }
         fn stream_parser(&self, _: &ProviderCtx<'_>) -> Box<dyn ProviderStreamParser + Send> {

--- a/docs/design/ir/CHANGELOG.md
+++ b/docs/design/ir/CHANGELOG.md
@@ -6,6 +6,58 @@
 
 ---
 
+## [PR-5] Dispatcher / Provider Adapter / Cache 全切到新 IR — 2026-05-15
+
+### 变更
+
+**`CacheEntry`** (`cache/entry.rs`)
+- `internal_response: Option<InternalResponse>` → `Option<AiResponse>`
+
+**`cache/key.rs`**
+- `build_cache_key` 参数 `&InternalRequest` → `&AiRequest`
+- `CODEC_SCHEMA_VERSION` v2 → v3（字段映射变更，清空旧缓存）
+
+**Integration Hooks** (`integrations/hooks.rs`)
+- `RequestHook::on_request`: `&mut InternalRequest` → `&mut AiRequest`
+- `ResponseHook::on_response`: `&mut InternalResponse` → `&mut AiResponse`
+
+**Vendor 层**
+- `Vendor::build_request`: `&mut InternalRequest` → `&mut AiRequest`
+- `Vendor::parse_response`: return `InternalResponse` → `AiResponse`
+- Hook 方法 (`pre_encode`, `post_parse`, `pre_request`, `on_stream_delta`) 全部切换新类型
+- `VendorExtension` 及其 blanket impl 同步更新
+- Ollama `pre_request`：`req.extra.remove(...)` 改为 `req.meta.vendor.ingress.remove(...)`
+
+**`pipeline.rs`**
+- `build_request` 参数 `&mut InternalRequest` → `&mut AiRequest`；移除 `ai_req = req.clone().into()` 中转
+- `parse_response` 返回 `AiResponse`；移除 `ai_resp.into()` 中转
+- `egress_path` 传参 `req.stream` → `req.stream.enabled`
+
+**11 个 vendor mod.rs（批量）**
+- `build_request` / `parse_response` 签名同步切换
+
+**`StreamResponseAccumulator`** (`dispatcher/accumulator.rs`)
+- 全面切换 `AiStreamDelta`；`into_internal_response()` 改为 `into_ai_response()` 返回 `AiResponse`
+
+**Dispatcher** (`dispatcher/mod.rs`)
+- 移除 `let mut internal: InternalRequest = request.into()`；全程直接使用 `request: AiRequest`
+- `replay_cached_stream` / `split_text_deltas` / 新增 `ai_response_to_deltas` 切换为 `AiStreamDelta`
+
+**`dispatcher/non_stream.rs` + `stream.rs`**
+- 移除所有 `AiResponse::from(...)` 和 `ai_stream_delta_to_old(...)` 包装
+- Accumulator 直接调用 `.apply_all(&ai_deltas)` / `.into_ai_response()`
+- Cache entry `internal_response` 直接存 `AiResponse`
+
+**`dispatcher/util.rs`**
+- `request_has_image_input` / `extract_semantic_embedding_input` 改为 `&AiRequest`
+
+### 不变
+- `compat.rs` 本体保留（供测试和外部使用）
+- 老 `InternalRequest`/`InternalResponse` 类型仍在 `types.rs`（PR-6 删除）
+- Parser/Formatter/StreamParser/StreamFormatter 已在 PR-3/PR-4 完成切换
+
+---
+
 ## [PR-4] Codec Parser + Formatter 全切换到 AiResponse / AiStreamDelta — 2026-05-15
 
 ### 变更


### PR DESCRIPTION
- Dispatcher/mod.rs: remove InternalRequest.into() conversion; AiRequest used end-to-end
- accumulator.rs: rewritten for AiStreamDelta → AiResponse (into_ai_response)
- non_stream.rs + stream.rs: remove all AiResponse::from() and ai_stream_delta_to_old() wrappers
- cache/entry.rs: internal_response field changed to Option<AiResponse>
- cache/key.rs: build_cache_key accepts &AiRequest; CODEC_SCHEMA_VERSION bumped to v3
- Vendor trait + VendorExtension: build_request/parse_response and all hooks use AiRequest/AiResponse
- pipeline.rs: encode_request and parse_response use AiRequest/AiResponse directly
- 11 vendor mod.rs + ollama: signatures updated; extra.remove → vendor.ingress.remove
- hooks.rs: RequestHook/ResponseHook use AiRequest/AiResponse
- VendorExtensions + AiResponse: added Serialize/Deserialize derives
- passthrough_fidelity.rs: test vendors updated to new Vendor trait signatures