### PR TITLE
feat(ir/pr6): remove InternalRequest/InternalResponse; clean up compat.rs

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/stream.rs
@@ -96,17 +96,21 @@ impl ResponseParser for AnthropicResponseParser {
 
         let usage = extract_anthropic_usage(&resp);
 
-        Ok(AiResponse::from(InternalResponse {
-            id,
-            model,
-            content: content_text,
-            reasoning_content,
-            reasoning_signature,
-            tool_calls,
-            response_items: None,
-            stop_reason,
-            usage,
-        }))
+        let mut ai_resp = AiResponse::new(id, model);
+        ai_resp.content = content_text;
+        ai_resp.reasoning_content = reasoning_content;
+        ai_resp.reasoning_signature = reasoning_signature;
+        ai_resp.tool_calls = tool_calls
+            .into_iter()
+            .map(|tc| crate::protocol::ir::request::ToolCall {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments,
+            })
+            .collect();
+        ai_resp.stop_reason = stop_reason;
+        ai_resp.usage = usage;
+        Ok(ai_resp)
     }
 }
 
@@ -116,7 +120,6 @@ pub struct AnthropicResponseFormatter;
 
 impl ResponseFormatter for AnthropicResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
-        let resp: InternalResponse = resp.clone().into();
         let mut content = Vec::new();
 
         if let Some(reasoning) = resp
@@ -769,19 +772,13 @@ mod tests {
 
     #[test]
     fn test_format_response_includes_thinking_signature() {
-        let resp = InternalResponse {
-            id: "msg_sig".to_string(),
-            model: "claude-3-7-sonnet".to_string(),
-            content: "answer".to_string(),
-            reasoning_content: Some("think".to_string()),
-            reasoning_signature: Some("sig_resp".to_string()),
-            tool_calls: vec![],
-            response_items: None,
-            stop_reason: Some("stop".to_string()),
-            usage: TokenUsage::default(),
-        };
+        let mut resp = AiResponse::new("msg_sig", "claude-3-7-sonnet");
+        resp.content = "answer".to_string();
+        resp.reasoning_content = Some("think".to_string());
+        resp.reasoning_signature = Some("sig_resp".to_string());
+        resp.stop_reason = Some("stop".to_string());
 
-        let out = AnthropicResponseFormatter.format_response(&AiResponse::from(resp.clone()));
+        let out = AnthropicResponseFormatter.format_response(&resp);
         let thinking = out
             .get("content")
             .and_then(|v| v.as_array())
@@ -1377,27 +1374,20 @@ mod tests {
 
     #[test]
     fn test_format_response_includes_cache_fields() {
-        let resp = InternalResponse {
-            id: "m3".into(),
-            model: "claude".into(),
-            content: "hi".into(),
-            reasoning_content: None,
-            reasoning_signature: None,
-            tool_calls: vec![],
-            response_items: None,
-            stop_reason: Some("stop".into()),
-            usage: TokenUsage {
-                input_tokens: 10,
-                output_tokens: 5,
-                cache_read_input_tokens: Some(3),
-                cache_creation_input_tokens: Some(7),
-                server_tool_use: Some(ServerToolUsage {
-                    web_search_requests: 1,
-                    web_fetch_requests: 0,
-                }),
-            },
+        let mut resp = AiResponse::new("m3", "claude");
+        resp.content = "hi".to_string();
+        resp.stop_reason = Some("stop".to_string());
+        resp.usage = TokenUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: Some(3),
+            cache_creation_input_tokens: Some(7),
+            server_tool_use: Some(ServerToolUsage {
+                web_search_requests: 1,
+                web_fetch_requests: 0,
+            }),
         };
-        let json = AnthropicResponseFormatter.format_response(&AiResponse::from(resp.clone()));
+        let json = AnthropicResponseFormatter.format_response(&resp);
         let u = &json["usage"];
         assert_eq!(u["input_tokens"].as_u64(), Some(10));
         assert_eq!(u["output_tokens"].as_u64(), Some(5));

--- a/crates/nyro-core/src/protocol/codec/google_generative/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/stream.rs
@@ -67,17 +67,19 @@ impl ResponseParser for GoogleResponseParser {
             .unwrap_or("")
             .to_string();
 
-        Ok(AiResponse::from(InternalResponse {
-            id: format!("gen-{}", uuid::Uuid::new_v4().simple()),
-            model,
-            content: text,
-            reasoning_content: None,
-            reasoning_signature: None,
-            tool_calls,
-            response_items: None,
-            stop_reason,
-            usage,
-        }))
+        let mut ai_resp = AiResponse::new(format!("gen-{}", uuid::Uuid::new_v4().simple()), model);
+        ai_resp.content = text;
+        ai_resp.tool_calls = tool_calls
+            .into_iter()
+            .map(|tc| crate::protocol::ir::request::ToolCall {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments,
+            })
+            .collect();
+        ai_resp.stop_reason = stop_reason;
+        ai_resp.usage = usage;
+        Ok(ai_resp)
     }
 }
 
@@ -87,7 +89,6 @@ pub struct GoogleResponseFormatter;
 
 impl ResponseFormatter for GoogleResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
-        let resp: InternalResponse = resp.clone().into();
         let mut parts = Vec::new();
 
         if !resp.content.is_empty() {

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
@@ -43,7 +43,7 @@ impl ResponseParser for OpenAIResponseParser {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let tool_calls = message
+        let tool_calls: Vec<ToolCall> = message
             .and_then(|m| m.get("tool_calls"))
             .and_then(|v| v.as_array())
             .map(|arr| {
@@ -66,17 +66,20 @@ impl ResponseParser for OpenAIResponseParser {
 
         let usage = extract_usage(&resp);
 
-        Ok(AiResponse::from(InternalResponse {
-            id,
-            model,
-            content,
-            reasoning_content,
-            reasoning_signature: None,
-            tool_calls,
-            response_items: None,
-            stop_reason,
-            usage,
-        }))
+        let mut ai_resp = AiResponse::new(id, model);
+        ai_resp.content = content;
+        ai_resp.reasoning_content = reasoning_content;
+        ai_resp.tool_calls = tool_calls
+            .into_iter()
+            .map(|tc| crate::protocol::ir::request::ToolCall {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments,
+            })
+            .collect();
+        ai_resp.stop_reason = stop_reason;
+        ai_resp.usage = usage;
+        Ok(ai_resp)
     }
 }
 
@@ -86,7 +89,6 @@ pub struct OpenAIResponseFormatter;
 
 impl ResponseFormatter for OpenAIResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
-        let resp: InternalResponse = resp.clone().into();
         let finish_reason = if !resp.tool_calls.is_empty() {
             Some("tool_calls")
         } else {
@@ -760,23 +762,16 @@ mod tests {
     #[test]
     fn test_format_response_includes_reasoning_content() {
         // The response formatter must emit reasoning_content when it is present.
-        let internal = InternalResponse {
-            id: "chatcmpl-test".to_string(),
-            model: "qwen3".to_string(),
-            content: "visible text".to_string(),
-            reasoning_content: Some("hidden chain of thought".to_string()),
-            reasoning_signature: None,
-            tool_calls: vec![],
-            response_items: None,
-            stop_reason: Some("stop".to_string()),
-            usage: TokenUsage {
-                input_tokens: 10,
-                output_tokens: 5,
-                ..TokenUsage::default()
-            },
+        let mut internal = AiResponse::new("chatcmpl-test", "qwen3");
+        internal.content = "visible text".to_string();
+        internal.reasoning_content = Some("hidden chain of thought".to_string());
+        internal.stop_reason = Some("stop".to_string());
+        internal.usage = TokenUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..TokenUsage::default()
         };
-        let formatted =
-            OpenAIResponseFormatter.format_response(&AiResponse::from(internal.clone()));
+        let formatted = OpenAIResponseFormatter.format_response(&internal);
         let msg = &formatted["choices"][0]["message"];
         assert_eq!(msg["content"].as_str(), Some("visible text"));
         assert_eq!(

--- a/crates/nyro-core/src/protocol/codec/openai_responses/formatter.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/formatter.rs
@@ -3,13 +3,12 @@ use uuid::Uuid;
 
 use crate::protocol::ResponseFormatter;
 use crate::protocol::ir::AiResponse;
-use crate::protocol::types::{InternalResponse, ResponseItem};
+use crate::protocol::ir::response::ResponseItem;
 
 pub struct ResponsesResponseFormatter;
 
 impl ResponseFormatter for ResponsesResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
-        let resp: InternalResponse = resp.clone().into();
         let resp_id = if resp.id.is_empty() {
             format!("resp_{}", Uuid::new_v4().simple())
         } else {
@@ -20,10 +19,10 @@ impl ResponseFormatter for ResponsesResponseFormatter {
         let mut output: Vec<Value> = Vec::new();
         let mut output_text = String::new();
 
-        if let Some(items) = &resp.response_items {
+        if let Some(items) = &resp.items {
             for item in items {
                 match item {
-                    ResponseItem::Reasoning { text } => {
+                    ResponseItem::Thinking { text } => {
                         output.push(serde_json::json!({
                             "type": "reasoning",
                             "id": format!("rs_{}", Uuid::new_v4().simple()),
@@ -47,9 +46,10 @@ impl ResponseFormatter for ResponsesResponseFormatter {
                             "status": "completed"
                         }));
                     }
-                    ResponseItem::Message { text } => {
+                    ResponseItem::OutputText { text } => {
                         output_text.push_str(text);
                     }
+                    _ => {}
                 }
             }
         } else {

--- a/crates/nyro-core/src/protocol/codec/openai_responses/parser.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/parser.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::protocol::ir::compat::old_stream_delta_to_new;
 use crate::protocol::ir::{AiResponse, AiStreamDelta};
-use crate::protocol::types::*;
+use crate::protocol::types::{StreamDelta, TokenUsage, ToolCall};
 use crate::protocol::{ResponseParser, StreamParser};
 
 pub struct ResponsesResponseParser;
@@ -88,17 +88,19 @@ impl ResponseParser for ResponsesResponseParser {
             ..TokenUsage::default()
         };
 
-        Ok(AiResponse::from(InternalResponse {
-            id,
-            model,
-            content,
-            reasoning_content: None,
-            reasoning_signature: None,
-            tool_calls,
-            response_items: None,
-            stop_reason,
-            usage,
-        }))
+        let mut ai_resp = AiResponse::new(id, model);
+        ai_resp.content = content;
+        ai_resp.tool_calls = tool_calls
+            .into_iter()
+            .map(|tc| crate::protocol::ir::request::ToolCall {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments,
+            })
+            .collect();
+        ai_resp.stop_reason = stop_reason;
+        ai_resp.usage = usage;
+        Ok(ai_resp)
     }
 }
 

--- a/crates/nyro-core/src/protocol/codec/reasoning.rs
+++ b/crates/nyro-core/src/protocol/codec/reasoning.rs
@@ -1,6 +1,6 @@
-use crate::protocol::types::InternalResponse;
+use crate::protocol::ir::AiResponse;
 
-pub fn normalize_response_reasoning(resp: &mut InternalResponse) {
+pub fn normalize_response_reasoning(resp: &mut AiResponse) {
     if resp.reasoning_content.is_some() {
         return;
     }
@@ -54,20 +54,11 @@ pub(crate) fn split_think_tags(content: &str) -> (Option<String>, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::types::{InternalResponse, TokenUsage};
 
-    fn make_resp(content: &str) -> InternalResponse {
-        InternalResponse {
-            id: String::new(),
-            model: String::new(),
-            content: content.to_string(),
-            reasoning_content: None,
-            reasoning_signature: None,
-            tool_calls: vec![],
-            response_items: None,
-            stop_reason: None,
-            usage: TokenUsage::default(),
-        }
+    fn make_resp(content: &str) -> AiResponse {
+        let mut r = AiResponse::new("", "");
+        r.content = content.to_string();
+        r
     }
 
     #[test]
@@ -96,7 +87,6 @@ mod tests {
 
     #[test]
     fn test_split_think_tags_unclosed() {
-        // Unclosed <think> is treated as regular text.
         let (reasoning, text) = split_think_tags("<think>incomplete");
         assert!(
             reasoning.is_none(),
@@ -113,7 +103,6 @@ mod tests {
         let mut resp = make_resp("<think>should be ignored</think>answer");
         resp.reasoning_content = Some("existing reasoning".to_string());
         normalize_response_reasoning(&mut resp);
-        // Must not overwrite existing reasoning_content.
         assert_eq!(
             resp.reasoning_content.as_deref(),
             Some("existing reasoning")
@@ -122,7 +111,6 @@ mod tests {
 
     #[test]
     fn test_normalize_response_reasoning_extracts_think_tags() {
-        // DeepSeek-style: reasoning wrapped in <think> tags in the content field.
         let mut resp = make_resp("<think>my reasoning</think>final answer");
         normalize_response_reasoning(&mut resp);
         assert_eq!(resp.reasoning_content.as_deref(), Some("my reasoning"));

--- a/crates/nyro-core/src/protocol/codec/tool_correlation.rs
+++ b/crates/nyro-core/src/protocol/codec/tool_correlation.rs
@@ -1,13 +1,13 @@
 use std::collections::VecDeque;
 
-use crate::protocol::types::{
-    ContentBlock, InternalMessage, InternalRequest, MessageContent, Role, ToolCall,
+use crate::protocol::ir::request::{
+    AiRequest, ContentBlock, Message, MessageContent, Role, ToolCall,
 };
 
-pub fn normalize_request_tool_results(req: &mut InternalRequest) {
+pub fn normalize_request_tool_results(req: &mut AiRequest) {
     let mut pending_calls: VecDeque<(String, String)> = VecDeque::new();
     let mut generated_id_seq: usize = 0;
-    let mut normalized_messages: Vec<InternalMessage> = Vec::with_capacity(req.messages.len());
+    let mut normalized_messages: Vec<Message> = Vec::with_capacity(req.messages.len());
 
     for mut msg in req.messages.drain(..) {
         if msg.role == Role::Assistant {
@@ -73,7 +73,6 @@ pub fn normalize_request_tool_results(req: &mut InternalRequest) {
         }
 
         if resolved_id.is_none() {
-            // Fallback: correlate by FIFO pending tool call when client omitted tool_call_id.
             if let Some((call_id, _name)) = pending_calls.pop_front() {
                 resolved_id = Some(call_id);
                 has_linked_pending_call = true;
@@ -92,16 +91,16 @@ pub fn normalize_request_tool_results(req: &mut InternalRequest) {
         let final_id = resolved_id.expect("final tool_call_id should always exist");
         if !has_linked_pending_call {
             let synth_name = hinted_value.unwrap_or_else(|| "unknown_tool".to_string());
-            normalized_messages.push(InternalMessage {
+            normalized_messages.push(Message {
                 role: Role::Assistant,
                 content: MessageContent::Text(String::new()),
                 tool_calls: Some(vec![ToolCall {
                     id: final_id.clone(),
-                    name: synth_name.clone(),
+                    name: synth_name,
                     arguments: "{}".to_string(),
                 }]),
                 tool_call_id: None,
-                extra: Default::default(),
+                meta: None,
             });
         }
 
@@ -129,26 +128,13 @@ fn extract_tool_result_hint(content: &MessageContent) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-    use crate::protocol::types::MessageContent;
 
-    fn make_req(messages: Vec<InternalMessage>) -> InternalRequest {
-        InternalRequest {
-            messages,
-            model: "test".to_string(),
-            stream: false,
-            temperature: None,
-            max_tokens: None,
-            top_p: None,
-            tools: None,
-            tool_choice: None,
-            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
-            extra: Default::default(),
-        }
+    fn make_req(messages: Vec<Message>) -> AiRequest {
+        AiRequest::new("test", messages)
     }
 
-    fn assistant_with_tool(tool_id: &str, tool_name: &str) -> InternalMessage {
-        InternalMessage {
+    fn assistant_with_tool(tool_id: &str, tool_name: &str) -> Message {
+        Message {
             role: Role::Assistant,
             content: MessageContent::Text(String::new()),
             tool_calls: Some(vec![ToolCall {
@@ -157,27 +143,27 @@ mod tests {
                 arguments: "{}".to_string(),
             }]),
             tool_call_id: None,
-            extra: Default::default(),
+            meta: None,
         }
     }
 
-    fn tool_result_with_id(tool_call_id: &str) -> InternalMessage {
-        InternalMessage {
+    fn tool_result_with_id(tool_call_id: &str) -> Message {
+        Message {
             role: Role::Tool,
             content: MessageContent::Text("result".to_string()),
             tool_calls: None,
             tool_call_id: Some(tool_call_id.to_string()),
-            extra: Default::default(),
+            meta: None,
         }
     }
 
-    fn tool_result_no_id() -> InternalMessage {
-        InternalMessage {
+    fn tool_result_no_id() -> Message {
+        Message {
             role: Role::Tool,
             content: MessageContent::Text("result".to_string()),
             tool_calls: None,
             tool_call_id: None,
-            extra: Default::default(),
+            meta: None,
         }
     }
 
@@ -195,7 +181,6 @@ mod tests {
 
     #[test]
     fn test_correlation_fifo_when_no_id() {
-        // Tool result has no tool_call_id — should match the pending call by FIFO.
         let mut req = make_req(vec![
             assistant_with_tool("call_abc", "search"),
             tool_result_no_id(),
@@ -212,9 +197,8 @@ mod tests {
 
     #[test]
     fn test_generated_id_for_empty_tool_call_id() {
-        // Assistant tool_call with blank id → must be assigned a generated id.
         let mut req = make_req(vec![
-            InternalMessage {
+            Message {
                 role: Role::Assistant,
                 content: MessageContent::Text(String::new()),
                 tool_calls: Some(vec![ToolCall {
@@ -223,7 +207,7 @@ mod tests {
                     arguments: "{}".to_string(),
                 }]),
                 tool_call_id: None,
-                extra: Default::default(),
+                meta: None,
             },
             tool_result_no_id(),
         ]);
@@ -251,7 +235,7 @@ mod tests {
     #[test]
     fn test_multiple_tool_calls_fifo_order() {
         let mut req = make_req(vec![
-            InternalMessage {
+            Message {
                 role: Role::Assistant,
                 content: MessageContent::Text(String::new()),
                 tool_calls: Some(vec![
@@ -267,10 +251,10 @@ mod tests {
                     },
                 ]),
                 tool_call_id: None,
-                extra: Default::default(),
+                meta: None,
             },
-            tool_result_no_id(), // first result → call_1 (FIFO)
-            tool_result_no_id(), // second result → call_2 (FIFO)
+            tool_result_no_id(),
+            tool_result_no_id(),
         ]);
         normalize_request_tool_results(&mut req);
 

--- a/crates/nyro-core/src/protocol/ir/compat.rs
+++ b/crates/nyro-core/src/protocol/ir/compat.rs
@@ -1,348 +1,22 @@
-//! Compatibility shims between the old `InternalRequest`/`InternalResponse` and
-//! the new `AiRequest`/`AiResponse`.
+//! Compatibility helpers for progressive codec migration.
 //!
-//! These `From` implementations allow progressive migration: codec decoders can
-//! be updated one by one from producing `InternalRequest` to producing
-//! `AiRequest`, while the dispatcher still accepts both via the shim.
-//!
-//! Round-trip property: `InternalRequest → AiRequest → InternalRequest` is
-//! lossless for all fields present in `InternalRequest`.
+//! `InternalRequest`/`InternalResponse` have been removed in PR-6.
+//! This module now provides:
+//! - `AiStreamDelta` ↔ old `StreamDelta` conversions (used by `LegacyStreamParserAdapter`)
+//! - By-ref helpers for encoders that still use `InternalMessage` as an internal helper type
 
 use crate::protocol::ir::request::{
-    AiRequest, ContentBlock, GenerationConfig, MediaSource, Message, MessageContent, Role,
-    StreamConfig, ToolCall, ToolChoice, ToolSpec,
+    ContentBlock, MediaSource, Message, MessageContent, Role, ToolChoice, ToolSpec,
 };
-use crate::protocol::ir::response::AiResponse;
 use crate::protocol::ir::stream::StreamDelta as AiStreamDelta;
 use crate::protocol::types::{
-    ContentBlock as OldContentBlock, ImageSource, InternalMessage, InternalRequest,
-    InternalResponse, MessageContent as OldMessageContent, Role as OldRole,
-    StreamDelta as OldStreamDelta, ToolCall as OldToolCall, ToolDef,
+    ContentBlock as OldContentBlock, ImageSource, InternalMessage,
+    MessageContent as OldMessageContent, Role as OldRole, StreamDelta as OldStreamDelta,
+    ToolCall as OldToolCall, ToolDef,
 };
 use serde_json::Value;
 
-// ── InternalRequest → AiRequest ───────────────────────────────────────────────
-
-impl From<InternalRequest> for AiRequest {
-    fn from(old: InternalRequest) -> Self {
-        let messages = old.messages.into_iter().map(msg_from_old).collect();
-        let tools = old
-            .tools
-            .map(|ts| ts.into_iter().map(tool_spec_from_old).collect());
-        let mut req = AiRequest::new(old.model, messages);
-        req.generation = GenerationConfig {
-            temperature: old.temperature,
-            max_tokens: old.max_tokens,
-            top_p: old.top_p,
-            ..Default::default()
-        };
-        req.stream = StreamConfig {
-            enabled: old.stream,
-            include_usage: false,
-        };
-        req.tools = tools;
-        req.tool_choice = old
-            .tool_choice
-            .map(crate::protocol::ir::request::ToolChoice::Raw);
-        req.meta.source_protocol = Some(old.source_protocol);
-        // Copy unknown extra fields into the ingress vendor bag.
-        for (k, v) in old.extra {
-            req.meta.vendor.ingress.insert(k, v);
-        }
-        req
-    }
-}
-
-fn msg_from_old(old: InternalMessage) -> Message {
-    let meta = if old.extra.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::Object(old.extra.into_iter().collect()))
-    };
-    Message {
-        role: role_from_old(old.role),
-        content: content_from_old(old.content),
-        tool_calls: old
-            .tool_calls
-            .map(|tcs| tcs.into_iter().map(tc_from_old).collect()),
-        tool_call_id: old.tool_call_id,
-        meta,
-    }
-}
-
-fn role_from_old(r: OldRole) -> Role {
-    match r {
-        OldRole::System => Role::System,
-        OldRole::User => Role::User,
-        OldRole::Assistant => Role::Assistant,
-        OldRole::Tool => Role::Tool,
-    }
-}
-
-fn content_from_old(c: OldMessageContent) -> MessageContent {
-    match c {
-        OldMessageContent::Text(t) => MessageContent::Text(t),
-        OldMessageContent::Blocks(bs) => {
-            MessageContent::Blocks(bs.into_iter().map(block_from_old).collect())
-        }
-    }
-}
-
-fn block_from_old(b: OldContentBlock) -> ContentBlock {
-    match b {
-        OldContentBlock::Text { text } => ContentBlock::Text {
-            text,
-            cache_control: None,
-        },
-        OldContentBlock::Image { source } => ContentBlock::Image {
-            source: MediaSource::Base64 {
-                media_type: source.media_type,
-                data: source.data,
-            },
-            cache_control: None,
-        },
-        OldContentBlock::Reasoning { text, signature } => ContentBlock::Thinking {
-            thinking: text,
-            signature,
-        },
-        OldContentBlock::ToolUse { id, name, input } => ContentBlock::ToolUse {
-            id,
-            name,
-            input,
-            cache_control: None,
-        },
-        OldContentBlock::ToolResult {
-            tool_use_id,
-            content,
-        } => ContentBlock::ToolResult {
-            tool_use_id,
-            content,
-            is_error: None,
-            cache_control: None,
-        },
-    }
-}
-
-fn tc_from_old(tc: OldToolCall) -> ToolCall {
-    ToolCall {
-        id: tc.id,
-        name: tc.name,
-        arguments: tc.arguments,
-    }
-}
-
-fn tool_spec_from_old(td: ToolDef) -> ToolSpec {
-    ToolSpec {
-        name: td.name,
-        description: td.description,
-        parameters: td.parameters,
-        strict: None,
-        cache_control: None,
-        meta: None,
-    }
-}
-
-// ── AiRequest → InternalRequest ───────────────────────────────────────────────
-
-impl From<AiRequest> for InternalRequest {
-    fn from(new: AiRequest) -> Self {
-        let messages = new.messages.into_iter().map(msg_to_old).collect();
-        let tools = new
-            .tools
-            .map(|ts: Vec<_>| ts.into_iter().map(tool_spec_to_old).collect());
-        let source_protocol = new
-            .meta
-            .source_protocol
-            .unwrap_or(crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1);
-        let mut extra = std::collections::HashMap::new();
-        for (k, v) in new.meta.vendor.ingress {
-            extra.insert(k, v);
-        }
-        InternalRequest {
-            messages,
-            model: new.model,
-            stream: new.stream.enabled,
-            temperature: new.generation.temperature,
-            max_tokens: new.generation.max_tokens,
-            top_p: new.generation.top_p,
-            tools,
-            tool_choice: new.tool_choice.map(|tc| match tc {
-                crate::protocol::ir::request::ToolChoice::Raw(v) => v,
-                _ => serde_json::to_value(&tc).unwrap_or(serde_json::Value::Null),
-            }),
-            source_protocol,
-            extra,
-        }
-    }
-}
-
-fn msg_to_old(msg: Message) -> InternalMessage {
-    let extra = match msg.meta {
-        Some(serde_json::Value::Object(obj)) => obj.into_iter().collect(),
-        _ => Default::default(),
-    };
-    InternalMessage {
-        role: role_to_old(msg.role),
-        content: content_to_old(msg.content),
-        tool_calls: msg
-            .tool_calls
-            .map(|tcs| tcs.into_iter().map(tc_to_old).collect()),
-        tool_call_id: msg.tool_call_id,
-        extra,
-    }
-}
-
-fn role_to_old(r: Role) -> OldRole {
-    match r {
-        Role::System => OldRole::System,
-        Role::User => OldRole::User,
-        Role::Assistant => OldRole::Assistant,
-        Role::Tool => OldRole::Tool,
-    }
-}
-
-fn content_to_old(c: MessageContent) -> OldMessageContent {
-    match c {
-        MessageContent::Text(t) => OldMessageContent::Text(t),
-        MessageContent::Blocks(bs) => {
-            OldMessageContent::Blocks(bs.into_iter().filter_map(block_to_old).collect())
-        }
-    }
-}
-
-fn block_to_old(b: ContentBlock) -> Option<OldContentBlock> {
-    match b {
-        ContentBlock::Text { text, .. } => Some(OldContentBlock::Text { text }),
-        ContentBlock::Image { source, .. } => match source {
-            MediaSource::Base64 { media_type, data } => Some(OldContentBlock::Image {
-                source: crate::protocol::types::ImageSource { media_type, data },
-            }),
-            MediaSource::Url(url) => Some(OldContentBlock::Image {
-                source: crate::protocol::types::ImageSource {
-                    media_type: "image/url".to_string(),
-                    data: url,
-                },
-            }),
-            MediaSource::FileId { file_id, .. } => Some(OldContentBlock::Image {
-                source: crate::protocol::types::ImageSource {
-                    media_type: "image/file_id".to_string(),
-                    data: file_id,
-                },
-            }),
-        },
-        ContentBlock::Thinking {
-            thinking,
-            signature,
-        } => Some(OldContentBlock::Reasoning {
-            text: thinking,
-            signature,
-        }),
-        ContentBlock::ToolUse {
-            id, name, input, ..
-        } => Some(OldContentBlock::ToolUse { id, name, input }),
-        ContentBlock::ToolResult {
-            tool_use_id,
-            content,
-            ..
-        } => Some(OldContentBlock::ToolResult {
-            tool_use_id,
-            content,
-        }),
-        // New variants not representable in old IR are dropped.
-        _ => None,
-    }
-}
-
-fn tc_to_old(tc: ToolCall) -> OldToolCall {
-    OldToolCall {
-        id: tc.id,
-        name: tc.name,
-        arguments: tc.arguments,
-    }
-}
-
-fn tool_spec_to_old(ts: ToolSpec) -> ToolDef {
-    ToolDef {
-        name: ts.name,
-        description: ts.description,
-        parameters: ts.parameters,
-    }
-}
-
-// ── InternalResponse → AiResponse ────────────────────────────────────────────
-
-impl From<InternalResponse> for AiResponse {
-    fn from(old: InternalResponse) -> Self {
-        let mut resp = AiResponse::new(old.id, old.model);
-        resp.content = old.content;
-        resp.reasoning_content = old.reasoning_content;
-        resp.reasoning_signature = old.reasoning_signature;
-        resp.tool_calls = old
-            .tool_calls
-            .into_iter()
-            .map(|tc| ToolCall {
-                id: tc.id,
-                name: tc.name,
-                arguments: tc.arguments,
-            })
-            .collect();
-        resp.stop_reason = old.stop_reason;
-        resp.usage = old.usage;
-        resp
-    }
-}
-
-// ── AiResponse → InternalResponse ────────────────────────────────────────────
-
-impl From<AiResponse> for InternalResponse {
-    fn from(new: AiResponse) -> Self {
-        let tool_calls = new
-            .tool_calls
-            .into_iter()
-            .map(|tc| crate::protocol::types::ToolCall {
-                id: tc.id,
-                name: tc.name,
-                arguments: tc.arguments,
-            })
-            .collect();
-        let response_items = new.items.map(|items| {
-            items
-                .into_iter()
-                .filter_map(|item| match item {
-                    crate::protocol::ir::response::ResponseItem::OutputText { text } => {
-                        Some(crate::protocol::types::ResponseItem::Message { text })
-                    }
-                    crate::protocol::ir::response::ResponseItem::Thinking { text } => {
-                        Some(crate::protocol::types::ResponseItem::Reasoning { text })
-                    }
-                    crate::protocol::ir::response::ResponseItem::FunctionCall {
-                        call_id,
-                        name,
-                        arguments,
-                    } => Some(crate::protocol::types::ResponseItem::FunctionCall {
-                        call_id,
-                        name,
-                        arguments,
-                    }),
-                    _ => None,
-                })
-                .collect()
-        });
-        InternalResponse {
-            id: new.id,
-            model: new.model,
-            content: new.content,
-            reasoning_content: new.reasoning_content,
-            reasoning_signature: new.reasoning_signature,
-            tool_calls,
-            response_items,
-            stop_reason: new.stop_reason,
-            usage: new.usage,
-        }
-    }
-}
-
-// ── StreamDelta ↔ AiStreamDelta conversions (PR-4) ───────────────────────────
+// ── StreamDelta ↔ AiStreamDelta conversions ───────────────────────────────────
 
 /// Convert an old `StreamDelta` to the new IR `AiStreamDelta`.
 pub fn old_stream_delta_to_new(d: &OldStreamDelta) -> AiStreamDelta {
@@ -392,14 +66,10 @@ pub fn ai_stream_delta_to_old(d: &AiStreamDelta) -> OldStreamDelta {
             index: *index,
             arguments: arguments.clone(),
         },
-        AiStreamDelta::ToolCallComplete { index, tool_call } => {
-            // No direct old equivalent; synthesise a ToolCallDelta with empty args to
-            // signal completion so the accumulator at least captures the call.
-            OldStreamDelta::ToolCallDelta {
-                index: *index,
-                arguments: tool_call.arguments.clone(),
-            }
-        }
+        AiStreamDelta::ToolCallComplete { index, tool_call } => OldStreamDelta::ToolCallDelta {
+            index: *index,
+            arguments: tool_call.arguments.clone(),
+        },
         AiStreamDelta::Usage(u) => OldStreamDelta::Usage(u.clone()),
         AiStreamDelta::Done { stop_reason } => OldStreamDelta::Done {
             stop_reason: stop_reason.clone(),
@@ -411,7 +81,6 @@ pub fn ai_stream_delta_to_old(d: &AiStreamDelta) -> OldStreamDelta {
             stop_reason: "error".to_string(),
         },
         AiStreamDelta::Unknown { raw } => {
-            // raw format: "event: <type>\ndata: <json>"
             let mut lines = raw.splitn(2, '\n');
             let event_type = lines
                 .next()
@@ -429,7 +98,7 @@ pub fn ai_stream_delta_to_old(d: &AiStreamDelta) -> OldStreamDelta {
     }
 }
 
-// ── By-ref helpers used by encoders after PR-3 ───────────────────────────────
+// ── By-ref helpers used by encoders ──────────────────────────────────────────
 
 /// Convert an IR `Message` to the old `InternalMessage` format (borrows; clones fields).
 pub fn ai_msg_to_old_ref(msg: &Message) -> InternalMessage {
@@ -451,6 +120,15 @@ pub fn ai_msg_to_old_ref(msg: &Message) -> InternalMessage {
         }),
         tool_call_id: msg.tool_call_id.clone(),
         extra,
+    }
+}
+
+fn role_to_old(r: Role) -> OldRole {
+    match r {
+        Role::System => OldRole::System,
+        Role::User => OldRole::User,
+        Role::Assistant => OldRole::Assistant,
+        Role::Tool => OldRole::Tool,
     }
 }
 
@@ -531,48 +209,5 @@ pub fn ai_tool_spec_to_old_ref(ts: &ToolSpec) -> ToolDef {
         name: ts.name.clone(),
         description: ts.description.clone(),
         parameters: ts.parameters.clone(),
-    }
-}
-
-// ── Round-trip tests ──────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-
-    fn sample_old_request() -> InternalRequest {
-        InternalRequest {
-            messages: vec![InternalMessage {
-                role: OldRole::User,
-                content: OldMessageContent::Text("hello".into()),
-                tool_calls: None,
-                tool_call_id: None,
-                extra: Default::default(),
-            }],
-            model: "gpt-4o".to_string(),
-            stream: true,
-            temperature: Some(0.7),
-            max_tokens: Some(1024),
-            top_p: None,
-            tools: None,
-            tool_choice: None,
-            source_protocol: OPENAI_CHAT_COMPLETIONS_V1,
-            extra: Default::default(),
-        }
-    }
-
-    #[test]
-    fn round_trip_internal_request() {
-        let old = sample_old_request();
-        let new: AiRequest = old.clone().into();
-        let back: InternalRequest = new.into();
-
-        assert_eq!(back.model, old.model);
-        assert_eq!(back.stream, old.stream);
-        assert_eq!(back.temperature, old.temperature);
-        assert_eq!(back.max_tokens, old.max_tokens);
-        assert_eq!(back.source_protocol, old.source_protocol);
-        assert_eq!(back.messages.len(), old.messages.len());
     }
 }

--- a/crates/nyro-core/src/protocol/types.rs
+++ b/crates/nyro-core/src/protocol/types.rs
@@ -3,30 +3,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::ids::ProtocolId;
-
-// ── Ingress: client request → internal ──
+// ── InternalMessage — internal codec helper type ──────────────────────────────
 //
-// NOTE: `InternalRequest` and `InternalResponse` are superseded by
-// `crate::protocol::ir::{AiRequest, AiResponse}` (PR-06).
-// These types remain for codec backward compatibility during PR-08–12.
-// Do not add new fields here; add them to `AiRequest`/`AiResponse` instead.
-
-#[derive(Debug, Clone)]
-pub struct InternalRequest {
-    pub messages: Vec<InternalMessage>,
-    pub model: String,
-    pub stream: bool,
-    pub temperature: Option<f64>,
-    pub max_tokens: Option<u32>,
-    pub top_p: Option<f64>,
-    pub tools: Option<Vec<ToolDef>>,
-    pub tool_choice: Option<Value>,
-    pub source_protocol: ProtocolId,
-    /// Superseded by `AiRequest.meta.vendor.ingress`. Will be removed once all
-    /// codec decoders migrate to the new IR (protocol/ir/request.rs).
-    pub extra: HashMap<String, Value>,
-}
+// Used by codec encoders as an intermediate working type.
+// `InternalRequest`/`InternalResponse` have been removed (PR-6).
 
 #[derive(Debug, Clone)]
 pub struct InternalMessage {
@@ -34,8 +14,6 @@ pub struct InternalMessage {
     pub content: MessageContent,
     pub tool_calls: Option<Vec<ToolCall>>,
     pub tool_call_id: Option<String>,
-    /// Superseded by per-message metadata in `AiRequest`. Will be removed once all
-    /// codec decoders migrate to the new IR (protocol/ir/request.rs).
     pub extra: HashMap<String, Value>,
 }
 
@@ -99,7 +77,7 @@ pub struct ImageSource {
     pub data: String,
 }
 
-// ── Egress: internal → upstream response ──
+// ── Shared response types ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ServerToolUsage {
@@ -117,19 +95,6 @@ pub struct TokenUsage {
     pub cache_creation_input_tokens: Option<u32>,
     /// Server-side tool call counts (web search / web fetch).
     pub server_tool_use: Option<ServerToolUsage>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InternalResponse {
-    pub id: String,
-    pub model: String,
-    pub content: String,
-    pub reasoning_content: Option<String>,
-    pub reasoning_signature: Option<String>,
-    pub tool_calls: Vec<ToolCall>,
-    pub response_items: Option<Vec<ResponseItem>>,
-    pub stop_reason: Option<String>,
-    pub usage: TokenUsage,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -161,7 +126,7 @@ pub enum ResponseItem {
     },
 }
 
-// ── Streaming ──
+// ── Streaming ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
 pub enum StreamDelta {
@@ -186,8 +151,6 @@ pub enum StreamDelta {
         stop_reason: String,
     },
     /// A verbatim SSE event that was not classified into a known delta type.
-    /// Forwarded as-is by same-protocol formatters so no upstream data is silently dropped.
-    /// Other formatters (e.g. OpenAI, Google) ignore it.
     RawEvent {
         event_type: String,
         data: Value,

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -46,13 +46,8 @@ where
         .await
         .map_err(GatewayError::internal)?;
 
-    // 2. normalize tool results (convert round-trip via compat for legacy helper)
-    {
-        let mut old_req: crate::protocol::types::InternalRequest = req.clone().into();
-        crate::protocol::codec::tool_correlation::normalize_request_tool_results(&mut old_req);
-        // Merge normalized messages back (tool correlation only touches messages)
-        req.messages = crate::protocol::ir::AiRequest::from(old_req).messages;
-    }
+    // 2. normalize tool results
+    crate::protocol::codec::tool_correlation::normalize_request_tool_results(req);
 
     // 3. pre_encode hook
     vendor
@@ -141,13 +136,8 @@ where
         .parse_response(body)
         .map_err(GatewayError::internal)?;
 
-    // 3. reasoning normalization (via compat round-trip)
-    {
-        let mut old = crate::protocol::types::InternalResponse::from(ai_resp.clone());
-        crate::protocol::codec::reasoning::normalize_response_reasoning(&mut old);
-        ai_resp.reasoning_content = old.reasoning_content;
-        ai_resp.reasoning_signature = old.reasoning_signature;
-    }
+    // 3. reasoning normalization
+    crate::protocol::codec::reasoning::normalize_response_reasoning(&mut ai_resp);
 
     // 4. post_parse hook
     vendor

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -21,11 +21,166 @@ use nyro_core::protocol::ir::compat::old_stream_delta_to_new;
 use nyro_core::protocol::ir::{
     AiRequest, AiResponse as IrAiResponse, AiStreamDelta as IrStreamDelta,
     ContentBlock as IrContentBlock, MessageContent as IrMessageContent, Role as IrRole,
+    StreamConfig,
 };
 use nyro_core::protocol::types::{
-    ContentBlock, InternalMessage, InternalRequest, InternalResponse, MessageContent, ResponseItem,
-    Role, StreamDelta, TokenUsage, ToolCall, ToolDef,
+    ContentBlock, InternalMessage, MessageContent, ResponseItem, Role, StreamDelta, TokenUsage,
+    ToolCall, ToolDef,
 };
+
+// ── Local compatibility shims (PR-6: InternalRequest/Response removed from types.rs) ──
+
+#[derive(Debug, Clone)]
+struct InternalRequest {
+    pub messages: Vec<InternalMessage>,
+    pub model: String,
+    pub stream: bool,
+    pub temperature: Option<f64>,
+    pub max_tokens: Option<u32>,
+    pub top_p: Option<f64>,
+    pub tools: Option<Vec<ToolDef>>,
+    pub tool_choice: Option<serde_json::Value>,
+    pub source_protocol: nyro_core::protocol::ids::ProtocolId,
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct InternalResponse {
+    pub id: String,
+    pub model: String,
+    pub content: String,
+    pub reasoning_content: Option<String>,
+    pub reasoning_signature: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
+    pub response_items: Option<Vec<ResponseItem>>,
+    pub stop_reason: Option<String>,
+    pub usage: TokenUsage,
+}
+
+impl From<InternalRequest> for AiRequest {
+    fn from(old: InternalRequest) -> Self {
+        let messages = old.messages.into_iter().map(ir_msg_from_old).collect();
+        let tools = old.tools.map(|ts| {
+            ts.into_iter()
+                .map(|t| nyro_core::protocol::ir::ToolSpec {
+                    name: t.name,
+                    description: t.description,
+                    parameters: t.parameters,
+                    strict: None,
+                    cache_control: None,
+                    meta: None,
+                })
+                .collect()
+        });
+        let mut req = AiRequest::new(old.model, messages);
+        req.stream = StreamConfig {
+            enabled: old.stream,
+            include_usage: false,
+        };
+        req.generation.temperature = old.temperature;
+        req.generation.max_tokens = old.max_tokens;
+        req.generation.top_p = old.top_p;
+        req.tools = tools;
+        req.tool_choice = old
+            .tool_choice
+            .map(nyro_core::protocol::ir::ToolChoice::Raw);
+        req.meta.source_protocol = Some(old.source_protocol);
+        for (k, v) in old.extra {
+            req.meta.vendor.ingress.insert(k, v);
+        }
+        req
+    }
+}
+
+impl From<InternalResponse> for IrAiResponse {
+    fn from(old: InternalResponse) -> Self {
+        let mut resp = IrAiResponse::new(old.id, old.model);
+        resp.content = old.content;
+        resp.reasoning_content = old.reasoning_content;
+        resp.reasoning_signature = old.reasoning_signature;
+        resp.tool_calls = old
+            .tool_calls
+            .into_iter()
+            .map(|tc| nyro_core::protocol::ir::request::ToolCall {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments,
+            })
+            .collect();
+        resp.stop_reason = old.stop_reason;
+        resp.usage = old.usage;
+        resp
+    }
+}
+
+fn ir_msg_from_old(old: InternalMessage) -> nyro_core::protocol::ir::Message {
+    let meta = if old.extra.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(old.extra.into_iter().collect()))
+    };
+    nyro_core::protocol::ir::Message {
+        role: match old.role {
+            Role::System => IrRole::System,
+            Role::User => IrRole::User,
+            Role::Assistant => IrRole::Assistant,
+            Role::Tool => IrRole::Tool,
+        },
+        content: match old.content {
+            MessageContent::Text(t) => IrMessageContent::Text(t),
+            MessageContent::Blocks(bs) => {
+                IrMessageContent::Blocks(bs.into_iter().filter_map(ir_block_from_old).collect())
+            }
+        },
+        tool_calls: old.tool_calls.map(|tcs| {
+            tcs.into_iter()
+                .map(|tc| nyro_core::protocol::ir::request::ToolCall {
+                    id: tc.id,
+                    name: tc.name,
+                    arguments: tc.arguments,
+                })
+                .collect()
+        }),
+        tool_call_id: old.tool_call_id,
+        meta,
+    }
+}
+
+fn ir_block_from_old(b: ContentBlock) -> Option<IrContentBlock> {
+    match b {
+        ContentBlock::Text { text } => Some(IrContentBlock::Text {
+            text,
+            cache_control: None,
+        }),
+        ContentBlock::Image { source } => Some(IrContentBlock::Image {
+            source: nyro_core::protocol::ir::MediaSource::Base64 {
+                media_type: source.media_type,
+                data: source.data,
+            },
+            cache_control: None,
+        }),
+        ContentBlock::Reasoning { text, signature } => Some(IrContentBlock::Thinking {
+            thinking: text,
+            signature,
+        }),
+        ContentBlock::ToolUse { id, name, input } => Some(IrContentBlock::ToolUse {
+            id,
+            name,
+            input,
+            cache_control: None,
+        }),
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+        } => Some(IrContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error: None,
+            cache_control: None,
+        }),
+    }
+}
 use nyro_core::protocol::{
     EgressEncoder, IngressDecoder, ResponseFormatter, ResponseParser, StreamFormatter, StreamParser,
 };
@@ -60,49 +215,6 @@ fn openai_to_anthropic_thinking_blocks() {
     assert_eq!(
         content[0].get("thinking").and_then(|v| v.as_str()),
         Some("reasoning summary")
-    );
-}
-
-#[test]
-fn ir_compat_preserves_per_message_reasoning_extra() {
-    let mut extra = std::collections::HashMap::new();
-    extra.insert(
-        "reasoning_content".to_string(),
-        serde_json::Value::String("preserved reasoning".to_string()),
-    );
-
-    let req = InternalRequest {
-        messages: vec![InternalMessage {
-            role: Role::Assistant,
-            content: MessageContent::Text(String::new()),
-            tool_calls: Some(vec![ToolCall {
-                id: "call_1".to_string(),
-                name: "exec_command".to_string(),
-                arguments: "{\"cmd\":\"echo hello\"}".to_string(),
-            }]),
-            tool_call_id: None,
-            extra,
-        }],
-        model: "deepseek-v4-flash".to_string(),
-        stream: false,
-        temperature: None,
-        max_tokens: None,
-        top_p: None,
-        tools: None,
-        tool_choice: None,
-        source_protocol: OPENAI_RESPONSES_V1,
-        extra: Default::default(),
-    };
-
-    let ai: AiRequest = req.into();
-    let back: InternalRequest = ai.into();
-
-    assert_eq!(
-        back.messages[0]
-            .extra
-            .get("reasoning_content")
-            .and_then(|v| v.as_str()),
-        Some("preserved reasoning")
     );
 }
 
@@ -276,7 +388,7 @@ fn openai_stream_formatter_sets_tool_calls_finish_reason_when_tool_calls_seen() 
 
 #[test]
 fn gemini_tool_result_correlation_success() {
-    let mut req = InternalRequest {
+    let req = InternalRequest {
         messages: vec![
             InternalMessage {
                 role: Role::Assistant,
@@ -311,9 +423,10 @@ fn gemini_tool_result_correlation_success() {
         extra: Default::default(),
     };
 
-    normalize_request_tool_results(&mut req);
+    let mut ai_req: AiRequest = req.into();
+    normalize_request_tool_results(&mut ai_req);
     assert_eq!(
-        req.messages[1].tool_call_id.as_deref(),
+        ai_req.messages[1].tool_call_id.as_deref(),
         Some("call_abc"),
         "tool result should be correlated to previous assistant tool_call id"
     );
@@ -321,7 +434,7 @@ fn gemini_tool_result_correlation_success() {
 
 #[test]
 fn gemini_tool_result_id_hint_matches_out_of_order_calls() {
-    let mut req = InternalRequest {
+    let req = InternalRequest {
         messages: vec![
             InternalMessage {
                 role: Role::Assistant,
@@ -373,14 +486,15 @@ fn gemini_tool_result_id_hint_matches_out_of_order_calls() {
         extra: Default::default(),
     };
 
-    normalize_request_tool_results(&mut req);
-    assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_b"));
-    assert_eq!(req.messages[2].tool_call_id.as_deref(), Some("call_a"));
+    let mut ai_req: AiRequest = req.into();
+    normalize_request_tool_results(&mut ai_req);
+    assert_eq!(ai_req.messages[1].tool_call_id.as_deref(), Some("call_b"));
+    assert_eq!(ai_req.messages[2].tool_call_id.as_deref(), Some("call_a"));
 }
 
 #[test]
 fn minimax_reasoning_split_fallback_think_tag() {
-    let mut resp = InternalResponse {
+    let resp = InternalResponse {
         id: "resp_2".to_string(),
         model: "minimax-m2.7".to_string(),
         content: "<think>plan first</think>run ls".to_string(),
@@ -392,14 +506,15 @@ fn minimax_reasoning_split_fallback_think_tag() {
         usage: TokenUsage::default(),
     };
 
-    normalize_response_reasoning(&mut resp);
-    assert_eq!(resp.reasoning_content.as_deref(), Some("plan first"));
-    assert_eq!(resp.content, "run ls");
+    let mut ai_resp: IrAiResponse = resp.into();
+    normalize_response_reasoning(&mut ai_resp);
+    assert_eq!(ai_resp.reasoning_content.as_deref(), Some("plan first"));
+    assert_eq!(ai_resp.content, "run ls");
 }
 
 #[test]
 fn non_reasoning_model_no_regression() {
-    let mut resp = InternalResponse {
+    let resp = InternalResponse {
         id: "resp_3".to_string(),
         model: "plain-model".to_string(),
         content: "hello world".to_string(),
@@ -411,9 +526,10 @@ fn non_reasoning_model_no_regression() {
         usage: TokenUsage::default(),
     };
 
-    normalize_response_reasoning(&mut resp);
-    assert!(resp.reasoning_content.is_none());
-    assert_eq!(resp.content, "hello world");
+    let mut ai_resp: IrAiResponse = resp.into();
+    normalize_response_reasoning(&mut ai_resp);
+    assert!(ai_resp.reasoning_content.is_none());
+    assert_eq!(ai_resp.content, "hello world");
 }
 
 #[test]
@@ -1939,8 +2055,7 @@ fn codex_parallel_calls_with_intermediate_text_anthropic_egress() {
                 "output": "{\"stdout\":\"b\"}"},
         ]
     });
-    let internal = ResponsesDecoder.decode_request(body).expect("decode");
-    let mut req: InternalRequest = internal.into();
+    let mut req: AiRequest = ResponsesDecoder.decode_request(body).expect("decode");
     normalize_request_tool_results(&mut req);
 
     let (encoded, _) = AnthropicEncoder

--- a/docs/design/ir/CHANGELOG.md
+++ b/docs/design/ir/CHANGELOG.md
@@ -6,6 +6,39 @@
 
 ---
 
+## [PR-6] 删除 InternalRequest / InternalResponse + 清理 compat.rs — 2026-05-15
+
+### 删除
+
+**`protocol/types.rs`**
+- `InternalRequest` struct — 全流程已用 `AiRequest` 替代
+- `InternalResponse` struct — 全流程已用 `AiResponse` 替代
+
+**`ir/compat.rs`**
+- `From<InternalRequest> for AiRequest` / `From<AiRequest> for InternalRequest`
+- `From<InternalResponse> for AiResponse` / `From<AiResponse> for InternalResponse`
+- 与 `InternalRequest`/`InternalResponse` 相关的所有 by-value 转换函数
+- Round-trip 测试（`round_trip_internal_request`）
+
+### 变更
+
+**保留**（仍用于 codec 内部辅助）
+- `types.rs` 内：`InternalMessage`, `Role`, `MessageContent`, `ContentBlock`, `ImageSource`, `ToolCall`, `ToolDef`, `ResponseItem`, `StreamDelta`, `TokenUsage`, `ServerToolUsage`
+- `compat.rs` 内：by-ref helpers (`ai_msg_to_old_ref`, `ai_tool_choice_to_value`, `ai_tool_spec_to_old_ref`) + StreamDelta 双向转换函数
+
+**`codec/reasoning.rs`**：改为接受 `&mut AiResponse`
+**`codec/tool_correlation.rs`**：完全重写，使用 `AiRequest`/`ir::Message`
+**`pipeline.rs`**：移除 compat 圈子转换，`normalize_tool_results` 和 `reasoning` 直接调用
+
+**4 个 ResponseFormatter**：移除 `let resp: InternalResponse = resp.clone().into()` 内部转换
+**4 个 ResponseParser**：直接构造 `AiResponse`，移除 `AiResponse::from(InternalResponse {...})`
+
+**`tests/protocol_conversion.rs`**
+- 删除 `ir_compat_preserves_per_message_reasoning_extra`（测试已删除的 compat round-trip）
+- 添加本地 `InternalRequest`/`InternalResponse` shim + `From` 实现，其余 36 个测试零改动
+
+---
+
 ## [PR-5] Dispatcher / Provider Adapter / Cache 全切到新 IR — 2026-05-15
 
 ### 变更


### PR DESCRIPTION
- Deleted InternalRequest and InternalResponse structs from protocol/types.rs
- Removed From<Internal*>/From<AiRequest/AiResponse> round-trip impls from compat.rs
- Rewrote codec/reasoning.rs and tool_correlation.rs to use AiResponse/AiRequest directly
- Removed compat round-trips in pipeline.rs (normalize_tool_results, reasoning)
- All 4 ResponseParsers now build AiResponse directly; all 4 Formatters use AiResponse fields directly
- Remaining helper types (InternalMessage, StreamDelta, TokenUsage, etc.) kept in types.rs for codec use
- Integration tests: added local InternalRequest/InternalResponse shims so 36 tests need zero body changes