### PR TITLE
feat(protocol): PR-C — unify codec trait names with Decoder/Encoder vocabulary

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
@@ -8,7 +8,7 @@
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::protocol::IngressDecoder;
+use crate::protocol::RequestDecoder;
 use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
 use crate::protocol::ir::DocumentSource as IrDocumentSource;
 use crate::protocol::ir::{
@@ -25,7 +25,7 @@ use super::types::{
 
 pub struct AnthropicDecoder;
 
-impl IngressDecoder for AnthropicDecoder {
+impl RequestDecoder for AnthropicDecoder {
     fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let req: AnthropicRequest = serde_json::from_value(body)?;
 

--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/encoder.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 
-use crate::protocol::EgressEncoder;
+use crate::protocol::RequestEncoder;
 use crate::protocol::ir::AiRequest;
 use crate::protocol::ir::request::{
     ContentBlock, MediaSource, Message, MessageContent, Role, ToolChoice,
@@ -10,7 +10,7 @@ use crate::protocol::ir::request::{
 
 pub struct AnthropicEncoder;
 
-impl EgressEncoder for AnthropicEncoder {
+impl RequestEncoder for AnthropicEncoder {
     fn encode_request(&self, req: &AiRequest) -> Result<(Value, HeaderMap)> {
         let ingress = &req.meta.vendor.ingress;
 

--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/messages.rs
@@ -28,22 +28,22 @@ impl EndpointHandler for AnthropicMessages2023 {
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
     }
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send> {
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send> {
         Box::new(super::decoder::AnthropicDecoder)
     }
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send> {
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send> {
         Box::new(super::encoder::AnthropicEncoder)
     }
-    fn make_response_parser(&self) -> Box<dyn ResponseParser> {
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder> {
         Box::new(super::stream::AnthropicResponseParser)
     }
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter> {
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder> {
         Box::new(super::stream::AnthropicResponseFormatter)
     }
-    fn make_stream_parser(&self) -> Box<dyn StreamParser> {
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder> {
         Box::new(super::stream::AnthropicStreamParser::new())
     }
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter> {
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder> {
         Box::new(super::stream::AnthropicStreamFormatter::new())
     }
 }

--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/stream.rs
@@ -11,7 +11,7 @@ use crate::protocol::*;
 
 pub struct AnthropicResponseParser;
 
-impl ResponseParser for AnthropicResponseParser {
+impl ResponseDecoder for AnthropicResponseParser {
     fn parse_response(&self, resp: Value) -> Result<AiResponse> {
         let id = resp
             .get("id")
@@ -111,7 +111,7 @@ impl ResponseParser for AnthropicResponseParser {
 
 pub struct AnthropicResponseFormatter;
 
-impl ResponseFormatter for AnthropicResponseFormatter {
+impl ResponseEncoder for AnthropicResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
         let mut content = Vec::new();
 
@@ -198,7 +198,7 @@ impl AnthropicStreamParser {
     }
 }
 
-impl StreamParser for AnthropicStreamParser {
+impl StreamResponseDecoder for AnthropicStreamParser {
     fn parse_chunk(&mut self, raw: &str) -> Result<Vec<AiStreamDelta>> {
         self.buffer.push_str(raw);
         let mut deltas = Vec::new();
@@ -442,7 +442,7 @@ impl AnthropicStreamFormatter {
     }
 }
 
-impl StreamFormatter for AnthropicStreamFormatter {
+impl StreamResponseEncoder for AnthropicStreamFormatter {
     fn format_deltas(&mut self, deltas: &[AiStreamDelta]) -> Vec<SseEvent> {
         let mut events = Vec::new();
 
@@ -728,7 +728,9 @@ fn extend_usage_json(obj: &mut Value, u: &Usage) {
 mod tests {
     use super::*;
     use crate::protocol::ir::{AiResponse, AiStreamDelta};
-    use crate::protocol::{ResponseFormatter, ResponseParser, StreamFormatter, StreamParser};
+    use crate::protocol::{
+        ResponseDecoder, ResponseEncoder, StreamResponseDecoder, StreamResponseEncoder,
+    };
 
     fn make_sse_block(event: &str, data: &str) -> String {
         format!("event: {event}\ndata: {data}\n\n")

--- a/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::protocol::IngressDecoder;
+use crate::protocol::RequestDecoder;
 use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
 use crate::protocol::ir::{
     AiRequest, ContentBlock, GenerationConfig, GoogleExt, MediaSource, Message, MessageContent,
@@ -240,7 +240,7 @@ impl GoogleDecoder {
     }
 }
 
-impl IngressDecoder for GoogleDecoder {
+impl RequestDecoder for GoogleDecoder {
     fn decode_request(&self, body: Value) -> Result<AiRequest> {
         self.decode_with_model(body, "gemini-2.0-flash", false)
     }

--- a/crates/nyro-core/src/protocol/codec/google_generative/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/encoder.rs
@@ -2,13 +2,13 @@ use anyhow::Result;
 use reqwest::header::HeaderMap;
 use serde_json::Value;
 
-use crate::protocol::EgressEncoder;
+use crate::protocol::RequestEncoder;
 use crate::protocol::ir::AiRequest;
 use crate::protocol::ir::request::{ContentBlock, MediaSource, Message, MessageContent, Role};
 
 pub struct GoogleEncoder;
 
-impl EgressEncoder for GoogleEncoder {
+impl RequestEncoder for GoogleEncoder {
     fn encode_request(&self, req: &AiRequest) -> Result<(Value, HeaderMap)> {
         let ingress = &req.meta.vendor.ingress;
 

--- a/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
@@ -31,22 +31,22 @@ impl EndpointHandler for GoogleGenerateContentV1Beta {
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
     }
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send> {
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send> {
         Box::new(super::decoder::GoogleDecoder)
     }
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send> {
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send> {
         Box::new(super::encoder::GoogleEncoder)
     }
-    fn make_response_parser(&self) -> Box<dyn ResponseParser> {
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder> {
         Box::new(super::stream::GoogleResponseParser)
     }
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter> {
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder> {
         Box::new(super::stream::GoogleResponseFormatter)
     }
-    fn make_stream_parser(&self) -> Box<dyn StreamParser> {
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder> {
         Box::new(super::stream::GoogleStreamParser::new())
     }
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter> {
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder> {
         Box::new(super::stream::GoogleStreamFormatter::new())
     }
 }

--- a/crates/nyro-core/src/protocol/codec/google_generative/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/stream.rs
@@ -11,7 +11,7 @@ use crate::protocol::*;
 
 pub struct GoogleResponseParser;
 
-impl ResponseParser for GoogleResponseParser {
+impl ResponseDecoder for GoogleResponseParser {
     fn parse_response(&self, resp: Value) -> Result<AiResponse> {
         let candidate = resp
             .get("candidates")
@@ -80,7 +80,7 @@ impl ResponseParser for GoogleResponseParser {
 
 pub struct GoogleResponseFormatter;
 
-impl ResponseFormatter for GoogleResponseFormatter {
+impl ResponseEncoder for GoogleResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
         let mut parts = Vec::new();
 
@@ -139,7 +139,7 @@ impl GoogleStreamParser {
     }
 }
 
-impl StreamParser for GoogleStreamParser {
+impl StreamResponseDecoder for GoogleStreamParser {
     fn parse_chunk(&mut self, raw: &str) -> Result<Vec<AiStreamDelta>> {
         self.buffer.push_str(raw);
         let mut deltas = Vec::new();
@@ -269,7 +269,7 @@ impl GoogleStreamFormatter {
     }
 }
 
-impl StreamFormatter for GoogleStreamFormatter {
+impl StreamResponseEncoder for GoogleStreamFormatter {
     fn format_deltas(&mut self, deltas: &[AiStreamDelta]) -> Vec<SseEvent> {
         let mut events = Vec::new();
 

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
@@ -27,22 +27,22 @@ impl EndpointHandler for OpenAIChatCompletionsV1 {
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
     }
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send> {
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send> {
         Box::new(super::decoder::OpenAIDecoder)
     }
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send> {
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send> {
         Box::new(super::encoder::OpenAIEncoder)
     }
-    fn make_response_parser(&self) -> Box<dyn ResponseParser> {
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder> {
         Box::new(super::stream::OpenAIResponseParser)
     }
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter> {
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder> {
         Box::new(super::stream::OpenAIResponseFormatter)
     }
-    fn make_stream_parser(&self) -> Box<dyn StreamParser> {
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder> {
         Box::new(super::stream::OpenAIStreamParser::new())
     }
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter> {
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder> {
         Box::new(super::stream::OpenAIStreamFormatter::new())
     }
 }

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::protocol::IngressDecoder;
+use crate::protocol::RequestDecoder;
 use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use crate::protocol::ir::{
     AiRequest, ContentBlock, GenerationConfig, MediaSource, Message, MessageContent, OpenAIChatExt,
@@ -19,7 +19,7 @@ use super::types::*;
 
 pub struct OpenAIDecoder;
 
-impl IngressDecoder for OpenAIDecoder {
+impl RequestDecoder for OpenAIDecoder {
     fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let req: OpenAIRequest = serde_json::from_value(body)?;
 

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
@@ -2,7 +2,7 @@
 //!
 //! Embeddings is a passthrough endpoint — the gateway forwards the
 //! request body verbatim and only inspects `usage.prompt_tokens` from
-//! the response. We still register a `ProtocolHandler` so that:
+//! the response. We still register a `EndpointHandler` so that:
 //!
 //! 1. `ProtocolRegistry::find_by_ingress_route` resolves
 //!    `POST /v1/embeddings` (and `/embeddings`) to a known
@@ -74,22 +74,22 @@ impl EndpointHandler for OpenAIEmbeddingsV1 {
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
     }
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send> {
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send> {
         Box::new(EmbeddingsDecoder)
     }
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send> {
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send> {
         Box::new(EmbeddingsEncoder)
     }
-    fn make_response_parser(&self) -> Box<dyn ResponseParser> {
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder> {
         Box::new(EmbeddingsResponseParser)
     }
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter> {
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder> {
         Box::new(EmbeddingsResponseFormatter)
     }
-    fn make_stream_parser(&self) -> Box<dyn StreamParser> {
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder> {
         Box::new(EmbeddingsStreamParser)
     }
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter> {
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder> {
         Box::new(EmbeddingsStreamFormatter)
     }
 }
@@ -102,7 +102,7 @@ inventory::submit! {
 
 struct EmbeddingsDecoder;
 
-impl IngressDecoder for EmbeddingsDecoder {
+impl RequestDecoder for EmbeddingsDecoder {
     fn decode_request(&self, body: Value) -> anyhow::Result<AiRequest> {
         let obj = body
             .as_object()
@@ -163,7 +163,7 @@ impl IngressDecoder for EmbeddingsDecoder {
 
 struct EmbeddingsEncoder;
 
-impl EgressEncoder for EmbeddingsEncoder {
+impl RequestEncoder for EmbeddingsEncoder {
     fn encode_request(&self, req: &AiRequest) -> anyhow::Result<(Value, HeaderMap)> {
         let ingress = &req.meta.vendor.ingress;
         let mut obj = serde_json::Map::new();
@@ -198,7 +198,7 @@ impl EgressEncoder for EmbeddingsEncoder {
 
 struct EmbeddingsResponseParser;
 
-impl ResponseParser for EmbeddingsResponseParser {
+impl ResponseDecoder for EmbeddingsResponseParser {
     fn parse_response(&self, _resp: Value) -> anyhow::Result<crate::protocol::ir::AiResponse> {
         unreachable!(
             "embeddings_proxy bypasses the codec pipeline; \
@@ -209,7 +209,7 @@ impl ResponseParser for EmbeddingsResponseParser {
 
 struct EmbeddingsResponseFormatter;
 
-impl ResponseFormatter for EmbeddingsResponseFormatter {
+impl ResponseEncoder for EmbeddingsResponseFormatter {
     fn format_response(&self, _resp: &crate::protocol::ir::AiResponse) -> Value {
         unreachable!(
             "embeddings_proxy bypasses the codec pipeline; \
@@ -220,7 +220,7 @@ impl ResponseFormatter for EmbeddingsResponseFormatter {
 
 struct EmbeddingsStreamParser;
 
-impl StreamParser for EmbeddingsStreamParser {
+impl StreamResponseDecoder for EmbeddingsStreamParser {
     fn parse_chunk(
         &mut self,
         _raw: &str,
@@ -234,7 +234,7 @@ impl StreamParser for EmbeddingsStreamParser {
 
 struct EmbeddingsStreamFormatter;
 
-impl StreamFormatter for EmbeddingsStreamFormatter {
+impl StreamResponseEncoder for EmbeddingsStreamFormatter {
     fn format_deltas(&mut self, _deltas: &[crate::protocol::ir::AiStreamDelta]) -> Vec<SseEvent> {
         unreachable!("embeddings has streaming=false; check capabilities before calling")
     }

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/encoder.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-use crate::protocol::EgressEncoder;
+use crate::protocol::RequestEncoder;
 use crate::protocol::ir::request::{
     ContentBlock, MediaSource, Message, MessageContent, Role, ToolChoice, ToolSpec,
 };
@@ -12,7 +12,7 @@ use crate::protocol::ir::{AiRequest, ToolCall};
 
 pub struct OpenAIEncoder;
 
-impl EgressEncoder for OpenAIEncoder {
+impl RequestEncoder for OpenAIEncoder {
     fn encode_request(&self, req: &AiRequest) -> Result<(Value, HeaderMap)> {
         let tools = req.tools.as_deref().unwrap_or(&[]);
         let tools_opt: Option<&[ToolSpec]> = if tools.is_empty() { None } else { Some(tools) };

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
@@ -11,7 +11,7 @@ use crate::protocol::*;
 
 pub struct OpenAIResponseParser;
 
-impl ResponseParser for OpenAIResponseParser {
+impl ResponseDecoder for OpenAIResponseParser {
     fn parse_response(&self, resp: Value) -> Result<AiResponse> {
         let id = resp
             .get("id")
@@ -80,7 +80,7 @@ impl ResponseParser for OpenAIResponseParser {
 
 pub struct OpenAIResponseFormatter;
 
-impl ResponseFormatter for OpenAIResponseFormatter {
+impl ResponseEncoder for OpenAIResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
         let finish_reason = if !resp.tool_calls.is_empty() {
             Some("tool_calls")
@@ -163,7 +163,7 @@ impl OpenAIStreamParser {
     }
 }
 
-impl StreamParser for OpenAIStreamParser {
+impl StreamResponseDecoder for OpenAIStreamParser {
     fn parse_chunk(&mut self, raw: &str) -> Result<Vec<AiStreamDelta>> {
         self.buffer.push_str(raw);
         let mut deltas = Vec::new();
@@ -375,7 +375,7 @@ impl OpenAIStreamFormatter {
     }
 }
 
-impl StreamFormatter for OpenAIStreamFormatter {
+impl StreamResponseEncoder for OpenAIStreamFormatter {
     fn format_deltas(&mut self, deltas: &[AiStreamDelta]) -> Vec<SseEvent> {
         let mut events = Vec::new();
         for delta in deltas {
@@ -546,7 +546,7 @@ pub(crate) fn extract_reasoning_from_message(message: &Value) -> Option<String> 
 mod tests {
     use super::*;
     use crate::protocol::ir::{AiResponse, AiStreamDelta};
-    use crate::protocol::{ResponseParser, StreamParser};
+    use crate::protocol::{ResponseDecoder, StreamResponseDecoder};
 
     fn data_sse(json: &str) -> String {
         format!("data: {json}\n\n")

--- a/crates/nyro-core/src/protocol/codec/openai_responses/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/decoder.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::protocol::IngressDecoder;
+use crate::protocol::RequestDecoder;
 use crate::protocol::ids::OPENAI_RESPONSES_V1;
 use crate::protocol::ir::{
     AiRequest, GenerationConfig, Message, MessageContent, OpenAIResponsesExt, ProtocolExt,
@@ -38,7 +38,7 @@ const KNOWN_FIELDS: &[&str] = &[
     "user",
 ];
 
-impl IngressDecoder for ResponsesDecoder {
+impl RequestDecoder for ResponsesDecoder {
     fn decode_request(&self, body: Value) -> Result<AiRequest> {
         let obj = body
             .as_object()

--- a/crates/nyro-core/src/protocol/codec/openai_responses/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/encoder.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use reqwest::header::HeaderMap;
 use serde_json::Value;
 
-use crate::protocol::EgressEncoder;
+use crate::protocol::RequestEncoder;
 use crate::protocol::ir::AiRequest;
 use crate::protocol::ir::request::{Role, ToolChoice};
 
@@ -26,7 +26,7 @@ pub struct ResponsesEncoder;
 // Fields that must NOT be copied blindly from extra into the egress body.
 const SKIP_FROM_EXTRA: &[&str] = &["messages", "input", "instructions", "stream", "model"];
 
-impl EgressEncoder for ResponsesEncoder {
+impl RequestEncoder for ResponsesEncoder {
     fn encode_request(&self, req: &AiRequest) -> Result<(Value, HeaderMap)> {
         let ingress = &req.meta.vendor.ingress;
 

--- a/crates/nyro-core/src/protocol/codec/openai_responses/formatter.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/formatter.rs
@@ -1,13 +1,13 @@
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::protocol::ResponseFormatter;
+use crate::protocol::ResponseEncoder;
 use crate::protocol::ir::AiResponse;
 use crate::protocol::ir::response::ResponseItem;
 
 pub struct ResponsesResponseFormatter;
 
-impl ResponseFormatter for ResponsesResponseFormatter {
+impl ResponseEncoder for ResponsesResponseFormatter {
     fn format_response(&self, resp: &AiResponse) -> Value {
         let resp_id = if resp.id.is_empty() {
             format!("resp_{}", Uuid::new_v4().simple())

--- a/crates/nyro-core/src/protocol/codec/openai_responses/parser.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/parser.rs
@@ -4,11 +4,11 @@ use serde_json::Value;
 use crate::protocol::ir::request::ToolCall;
 use crate::protocol::ir::usage::Usage;
 use crate::protocol::ir::{AiResponse, AiStreamDelta};
-use crate::protocol::{ResponseParser, StreamParser};
+use crate::protocol::{ResponseDecoder, StreamResponseDecoder};
 
 pub struct ResponsesResponseParser;
 
-impl ResponseParser for ResponsesResponseParser {
+impl ResponseDecoder for ResponsesResponseParser {
     fn parse_response(&self, resp: Value) -> Result<AiResponse> {
         let id = resp
             .get("id")
@@ -117,7 +117,7 @@ impl ResponsesStreamParser {
     }
 }
 
-impl StreamParser for ResponsesStreamParser {
+impl StreamResponseDecoder for ResponsesStreamParser {
     fn parse_chunk(&mut self, raw: &str) -> Result<Vec<AiStreamDelta>> {
         self.buffer.push_str(raw);
         let mut deltas = Vec::new();
@@ -278,7 +278,7 @@ impl ResponsesStreamParser {
 mod tests {
     use super::*;
     use crate::protocol::ir::AiStreamDelta;
-    use crate::protocol::{ResponseParser, StreamParser};
+    use crate::protocol::{ResponseDecoder, StreamResponseDecoder};
 
     fn sse_event(event: &str, data: &str) -> String {
         format!("event: {event}\ndata: {data}\n\n")

--- a/crates/nyro-core/src/protocol/codec/openai_responses/responses.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/responses.rs
@@ -27,22 +27,22 @@ impl EndpointHandler for OpenAIResponsesV1 {
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
     }
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send> {
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send> {
         Box::new(super::decoder::ResponsesDecoder)
     }
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send> {
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send> {
         Box::new(super::encoder::ResponsesEncoder)
     }
-    fn make_response_parser(&self) -> Box<dyn ResponseParser> {
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder> {
         Box::new(super::parser::ResponsesResponseParser)
     }
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter> {
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder> {
         Box::new(super::formatter::ResponsesResponseFormatter)
     }
-    fn make_stream_parser(&self) -> Box<dyn StreamParser> {
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder> {
         Box::new(super::parser::ResponsesStreamParser::new())
     }
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter> {
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder> {
         Box::new(super::stream::ResponsesStreamFormatter::new())
     }
 }

--- a/crates/nyro-core/src/protocol/codec/openai_responses/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_responses/stream.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::protocol::ir::AiStreamDelta;
 use crate::protocol::ir::usage::Usage;
-use crate::protocol::{SseEvent, StreamFormatter};
+use crate::protocol::{SseEvent, StreamResponseEncoder};
 
 struct PendingFunctionCall {
     output_index: usize,
@@ -281,7 +281,7 @@ impl ResponsesStreamFormatter {
     }
 }
 
-impl StreamFormatter for ResponsesStreamFormatter {
+impl StreamResponseEncoder for ResponsesStreamFormatter {
     fn format_deltas(&mut self, deltas: &[AiStreamDelta]) -> Vec<SseEvent> {
         let mut events = Vec::new();
 

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -43,13 +43,13 @@ use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
 
 // ── Client → Gateway ──
 
-pub trait IngressDecoder {
+pub trait RequestDecoder {
     fn decode_request(&self, body: serde_json::Value) -> anyhow::Result<ir::AiRequest>;
 }
 
 // ── Gateway → Provider ──
 
-pub trait EgressEncoder {
+pub trait RequestEncoder {
     fn encode_request(&self, req: &ir::AiRequest)
     -> anyhow::Result<(serde_json::Value, HeaderMap)>;
 
@@ -58,26 +58,26 @@ pub trait EgressEncoder {
 
 // ── Provider response → internal ──
 
-pub trait ResponseParser: Send {
+pub trait ResponseDecoder: Send {
     fn parse_response(&self, resp: serde_json::Value) -> anyhow::Result<ir::AiResponse>;
 }
 
 // ── Internal → client response ──
 
-pub trait ResponseFormatter: Send {
+pub trait ResponseEncoder: Send {
     fn format_response(&self, resp: &ir::AiResponse) -> serde_json::Value;
 }
 
 // ── Streaming: provider → internal deltas ──
 
-pub trait StreamParser: Send {
+pub trait StreamResponseDecoder: Send {
     fn parse_chunk(&mut self, raw: &str) -> anyhow::Result<Vec<ir::AiStreamDelta>>;
     fn finish(&mut self) -> anyhow::Result<Vec<ir::AiStreamDelta>>;
 }
 
 // ── Streaming: internal deltas → client SSE ──
 
-pub trait StreamFormatter: Send {
+pub trait StreamResponseEncoder: Send {
     fn format_deltas(&mut self, deltas: &[ir::AiStreamDelta]) -> Vec<SseEvent>;
     fn format_done(&mut self) -> Vec<SseEvent>;
     fn usage(&self) -> ir::Usage;

--- a/crates/nyro-core/src/protocol/traits.rs
+++ b/crates/nyro-core/src/protocol/traits.rs
@@ -1,16 +1,17 @@
 //! Aggregated `EndpointHandler` trait.
 //!
 //! A handler bundles a `ProtocolEndpoint`, static `EndpointCapabilities`, and factory
-//! methods for the six codec components (decoder / encoder / response parser /
-//! response formatter / streaming parser / streaming formatter).
+//! methods for the six codec components (request decoder / request encoder /
+//! response decoder / response encoder / stream response decoder / stream response encoder).
 //!
 //! Codec traits remain defined in `super` (i.e. `protocol/mod.rs`) for backward
-//! compatibility with existing `use crate::protocol::IngressDecoder` call sites;
+//! compatibility with existing `use crate::protocol::RequestDecoder` call sites;
 //! this module re-exports them so new code can `use crate::protocol::traits::*`
 //! to pull in everything needed to implement a handler.
 
 pub use super::{
-    EgressEncoder, IngressDecoder, ResponseFormatter, ResponseParser, StreamFormatter, StreamParser,
+    RequestDecoder, RequestEncoder, ResponseDecoder, ResponseEncoder, StreamResponseDecoder,
+    StreamResponseEncoder,
 };
 
 use crate::protocol::ids::{EndpointCapabilities, Protocol, ProtocolEndpoint};
@@ -33,13 +34,10 @@ pub trait EndpointHandler: Send + Sync + 'static {
         self.id().protocol
     }
 
-    fn make_decoder(&self) -> Box<dyn IngressDecoder + Send>;
-    fn make_encoder(&self) -> Box<dyn EgressEncoder + Send>;
-    fn make_response_parser(&self) -> Box<dyn ResponseParser>;
-    fn make_response_formatter(&self) -> Box<dyn ResponseFormatter>;
-    fn make_stream_parser(&self) -> Box<dyn StreamParser>;
-    fn make_stream_formatter(&self) -> Box<dyn StreamFormatter>;
+    fn make_request_decoder(&self) -> Box<dyn RequestDecoder + Send>;
+    fn make_request_encoder(&self) -> Box<dyn RequestEncoder + Send>;
+    fn make_response_decoder(&self) -> Box<dyn ResponseDecoder>;
+    fn make_response_encoder(&self) -> Box<dyn ResponseEncoder>;
+    fn make_stream_response_decoder(&self) -> Box<dyn StreamResponseDecoder>;
+    fn make_stream_response_encoder(&self) -> Box<dyn StreamResponseEncoder>;
 }
-
-/// Backward-compat alias — prefer `EndpointHandler`.
-pub use EndpointHandler as ProtocolHandler;

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -53,7 +53,7 @@ where
 
     // 4. codec encode
     let egress_handler = ctx.protocol.handler();
-    let encoder = egress_handler.make_encoder();
+    let encoder = egress_handler.make_request_encoder();
     let (mut body, mut extra_headers) = encoder
         .encode_request(req)
         .map_err(GatewayError::internal)?;
@@ -127,7 +127,7 @@ where
 
     // 2. codec parse
     let egress_handler = ctx.protocol.handler();
-    let parser = egress_handler.make_response_parser();
+    let parser = egress_handler.make_response_decoder();
     let mut ai_resp = parser
         .parse_response(body)
         .map_err(GatewayError::internal)?;
@@ -190,7 +190,7 @@ pub async fn passthrough_run(
     let egress_path = ctx
         .protocol
         .handler()
-        .make_encoder()
+        .make_request_encoder()
         .egress_path(ctx.actual_model, is_stream);
     let url = vendor.build_url(&vendor_ctx, ctx.egress_base_url, &egress_path);
 

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -676,7 +676,7 @@ pub async fn dispatch(
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, method, path);
 
-    let decoder = ingress.handler().make_decoder();
+    let decoder = ingress.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => {
@@ -994,7 +994,7 @@ fn replay_cached_stream(
     stream_replay_tps: u32,
     expose_headers: bool,
 ) -> Response {
-    let mut formatter = ingress.handler().make_stream_formatter();
+    let mut formatter = ingress.handler().make_stream_response_encoder();
     let ai_deltas = ai_response_to_deltas(ai_resp);
     let ai_deltas = if stream_replay_tps > 0 {
         split_text_deltas(ai_deltas, 4)

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -164,7 +164,7 @@ pub(super) async fn handle_non_stream(
 
     let is_tool = !ai_resp.tool_calls.is_empty();
     let usage = ai_resp.usage.clone();
-    let formatter = ingress.handler().make_response_formatter();
+    let formatter = ingress.handler().make_response_encoder();
     let output = formatter.format_response(&ai_resp);
 
     let response_body_full = serde_json::to_string(&output).ok();
@@ -276,7 +276,7 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
             .into_response();
     }
 
-    let mut stream_parser = egress.handler().make_stream_parser();
+    let mut stream_parser = egress.handler().make_stream_response_decoder();
     let mut byte_stream = resp.bytes_stream();
     let mut accumulator = StreamResponseAccumulator::default();
 
@@ -313,7 +313,7 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
 
     let is_tool = !ai_resp.tool_calls.is_empty();
     let usage = ai_resp.usage.clone();
-    let formatter = ingress.handler().make_response_formatter();
+    let formatter = ingress.handler().make_response_encoder();
     let output = formatter.format_response(&ai_resp);
 
     let response_preview = serde_json::to_string(&output)

--- a/crates/nyro-core/src/proxy/dispatcher/stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/stream.rs
@@ -136,7 +136,7 @@ pub(super) async fn handle_stream(
 
             // Parse accumulated buffer for usage stats and log entry (best-effort).
             let log_text = String::from_utf8_lossy(&log_buf);
-            let mut log_parser = egress.handler().make_stream_parser();
+            let mut log_parser = egress.handler().make_stream_response_decoder();
             let mut accumulator = StreamResponseAccumulator::default();
             if let Ok(ai_deltas) = log_parser.parse_chunk(&log_text) {
                 accumulator.apply_all(&ai_deltas);
@@ -153,7 +153,7 @@ pub(super) async fn handle_stream(
                 ai_resp.model = log_pt.actual_model.clone();
             }
 
-            let aggregated_formatter = ingress.handler().make_response_formatter();
+            let aggregated_formatter = ingress.handler().make_response_encoder();
             let aggregated_output = aggregated_formatter.format_response(&ai_resp);
             let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
 
@@ -187,8 +187,8 @@ pub(super) async fn handle_stream(
     }
 
     // ── IR round-trip path ────────────────────────────────────────────────────
-    let mut stream_parser = egress.handler().make_stream_parser();
-    let mut stream_formatter = ingress.handler().make_stream_formatter();
+    let mut stream_parser = egress.handler().make_stream_response_decoder();
+    let mut stream_formatter = ingress.handler().make_stream_response_encoder();
     let mut byte_stream = resp.bytes_stream();
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<String, Infallible>>(64);
 
@@ -264,7 +264,7 @@ pub(super) async fn handle_stream(
             ai_resp.stop_reason = Some("stop".to_string());
         }
 
-        let aggregated_formatter = ingress.handler().make_response_formatter();
+        let aggregated_formatter = ingress.handler().make_response_encoder();
         let aggregated_output = aggregated_formatter.format_response(&ai_resp);
         let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
         log_ir
@@ -281,7 +281,7 @@ pub(super) async fn handle_stream(
             if let (Some(cache_backend), Some(cache_key)) =
                 (cache_backend.as_ref(), cache_key_owned.as_deref())
             {
-                let formatter = ingress.handler().make_response_formatter();
+                let formatter = ingress.handler().make_response_encoder();
                 let payload = formatter.format_response(&ai_resp);
                 let entry = CacheEntry {
                     payload,
@@ -319,7 +319,7 @@ pub(super) async fn handle_stream(
             if let (Some(vector_store), Some(ctx)) =
                 (vector_store.as_ref(), semantic_write_ctx_owned.as_ref())
             {
-                let formatter = ingress.handler().make_response_formatter();
+                let formatter = ingress.handler().make_response_encoder();
                 let payload = formatter.format_response(&ai_resp);
                 let entry = CacheEntry {
                     payload,

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
@@ -28,7 +28,9 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/messages");
-    let decoder = ANTHROPIC_MESSAGES_2023_06_01.handler().make_decoder();
+    let decoder = ANTHROPIC_MESSAGES_2023_06_01
+        .handler()
+        .make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -33,7 +33,7 @@ pub async fn handler(
         "POST",
         "/v1/chat/completions",
     );
-    let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_decoder();
+    let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -28,7 +28,7 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
-    let decoder = OPENAI_EMBEDDINGS_V1.handler().make_decoder();
+    let decoder = OPENAI_EMBEDDINGS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
@@ -28,7 +28,7 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/responses");
-    let decoder = OPENAI_RESPONSES_V1.handler().make_decoder();
+    let decoder = OPENAI_RESPONSES_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return error_response(400, &format!("invalid request: {e}")),

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -24,7 +24,8 @@ use nyro_core::protocol::ir::{
     StreamConfig, ToolCall, ToolSpec,
 };
 use nyro_core::protocol::{
-    EgressEncoder, IngressDecoder, ResponseFormatter, ResponseParser, StreamFormatter, StreamParser,
+    RequestDecoder, RequestEncoder, ResponseDecoder, ResponseEncoder, StreamResponseDecoder,
+    StreamResponseEncoder,
 };
 
 #[test]

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -147,7 +147,7 @@ fn decoder_preserves_role_sequence_and_source_protocol() {
         let req = reg
             .get(&id)
             .unwrap()
-            .make_decoder()
+            .make_request_decoder()
             .decode_request(body)
             .unwrap_or_else(|e| panic!("decoder failed for {id}: {e}"));
 
@@ -172,9 +172,9 @@ fn encoder_round_trips_body_for_every_handler() {
     ] {
         let body = sample_body(id);
         let h = reg.get(&id).unwrap();
-        let internal = h.make_decoder().decode_request(body).unwrap();
+        let internal = h.make_request_decoder().decode_request(body).unwrap();
         let (out_body, headers) = h
-            .make_encoder()
+            .make_request_encoder()
             .encode_request(&internal)
             .unwrap_or_else(|e| panic!("encoder failed for {id}: {e}"));
         assert!(
@@ -184,7 +184,7 @@ fn encoder_round_trips_body_for_every_handler() {
         let _ = headers;
 
         let _path = h
-            .make_encoder()
+            .make_request_encoder()
             .egress_path(&internal.model, internal.stream.enabled);
     }
 }
@@ -199,10 +199,10 @@ fn parser_and_formatter_factories_construct() {
         GOOGLE_GENERATE_CONTENT_V1BETA,
     ] {
         let h = reg.get(&id).unwrap();
-        let _ = h.make_response_parser();
-        let _ = h.make_response_formatter();
-        let _ = h.make_stream_parser();
-        let _ = h.make_stream_formatter();
+        let _ = h.make_response_decoder();
+        let _ = h.make_response_encoder();
+        let _ = h.make_stream_response_decoder();
+        let _ = h.make_stream_response_encoder();
     }
 }
 
@@ -255,7 +255,7 @@ fn embeddings_decoder_round_trips_body() {
     let internal = reg
         .get(&OPENAI_EMBEDDINGS_V1)
         .unwrap()
-        .make_decoder()
+        .make_request_decoder()
         .decode_request(body.clone())
         .unwrap();
     assert_eq!(internal.model, "text-embedding-3-small");
@@ -264,7 +264,7 @@ fn embeddings_decoder_round_trips_body() {
     let (encoded, _headers) = reg
         .get(&OPENAI_EMBEDDINGS_V1)
         .unwrap()
-        .make_encoder()
+        .make_request_encoder()
         .encode_request(&internal)
         .unwrap();
     assert_eq!(encoded, body, "encoder must round-trip the original body");

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -12,7 +12,7 @@
 //!    against a provider that only declares chat/v1 (codec layer
 //!    converts).
 //! 3. `ProtocolId::handler()` — `proxy/handler.rs` calls
-//!    `ingress.handler().make_decoder()` on every request, so we assert
+//!    `ingress.handler().make_request_decoder()` on every request, so we assert
 //!    it returns a registered handler for every canonical id we ship.
 
 use nyro_core::db::models::Provider;

--- a/docs/design/ir/CHANGELOG.md
+++ b/docs/design/ir/CHANGELOG.md
@@ -6,6 +6,48 @@
 
 ---
 
+## [PR-C] 6 个 codec trait 统一重命名 — 2026-05-16
+
+### 重命名 / 变更
+
+**`protocol/mod.rs` — 6 个 trait 重命名**
+
+| 旧名 | 新名 |
+|------|------|
+| `IngressDecoder` | `RequestDecoder` |
+| `EgressEncoder` | `RequestEncoder` |
+| `ResponseParser` | `ResponseDecoder` |
+| `ResponseFormatter` | `ResponseEncoder` |
+| `StreamParser` | `StreamResponseDecoder` |
+| `StreamFormatter` | `StreamResponseEncoder` |
+
+**`protocol/traits.rs` — `EndpointHandler` 工厂方法重命名**
+
+| 旧名 | 新名 |
+|------|------|
+| `make_decoder` | `make_request_decoder` |
+| `make_encoder` | `make_request_encoder` |
+| `make_response_parser` | `make_response_decoder` |
+| `make_response_formatter` | `make_response_encoder` |
+| `make_stream_parser` | `make_stream_response_decoder` |
+| `make_stream_formatter` | `make_stream_response_encoder` |
+
+### 删除
+
+- `protocol/traits.rs`：移除 `pub use EndpointHandler as ProtocolHandler;` 别名
+
+### 清理
+
+- `openai_compatible/embeddings.rs`：doc comment 中 `ProtocolHandler` → `EndpointHandler`
+- 全部 4 个 codec `EndpointHandler impl`、~50 处调用点、所有 use 语句同步替换
+
+### 完成态
+
+- 数据流向一目了然：`RequestDecoder → AiRequest → RequestEncoder → wire → Provider → wire → ResponseDecoder → AiResponse`，流式路径 `StreamResponseDecoder → Vec<AiStreamDelta> → StreamResponseEncoder`
+- 无任何旧名残留，编译器负责全量校验
+
+---
+
 ## [PR-B] Stream Parser 直产 AiStreamDelta + 删除遗留文件 — 2026-05-16
 
 ### 重命名 / 变更


### PR DESCRIPTION
Rename 6 protocol traits for directional clarity:
  IngressDecoder    → RequestDecoder
  EgressEncoder     → RequestEncoder
  ResponseParser    → ResponseDecoder
  ResponseFormatter → ResponseEncoder
  StreamParser      → StreamResponseDecoder
  StreamFormatter   → StreamResponseEncoder

Rename 6 EndpointHandler factory methods accordingly:
  make_decoder          → make_request_decoder
  make_encoder          → make_request_encoder
  make_response_parser  → make_response_decoder
  make_response_formatter → make_response_encoder
  make_stream_parser    → make_stream_response_decoder
  make_stream_formatter → make_stream_response_encoder

Remove ProtocolHandler alias from traits.rs; update embeddings.rs doc-comment. Update CHANGELOG for PR-C.