### PR TITLE
feat(logging): add provider_name, api_key_name, route_id, route_name and restore is_stream

### DIFF
--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -100,6 +100,12 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     normalize_provider_protocols(pool).await?;
     backfill_route_fields(pool).await?;
     backfill_route_targets(pool).await?;
+    migrate_logs_v2_spec_aligned(pool).await?;
+    ensure_request_log_column(pool, "is_stream", "INTEGER DEFAULT 0").await?;
+    ensure_request_log_column(pool, "api_key_name", "TEXT").await?;
+    ensure_request_log_column(pool, "provider_name", "TEXT").await?;
+    ensure_request_log_column(pool, "route_id", "TEXT").await?;
+    ensure_request_log_column(pool, "route_name", "TEXT").await?;
     Ok(())
 }
 
@@ -277,6 +283,124 @@ async fn ensure_route_column(
         let sql = format!("ALTER TABLE routes ADD COLUMN {column_name} {definition}");
         sqlx::query(&sql).execute(pool).await?;
     }
+
+    Ok(())
+}
+
+/// Idempotent migration: upgrade request_logs from the legacy 21-column schema
+/// to the spec-aligned 26-column schema.
+///
+/// Operations (all idempotent via column existence checks):
+///   1. RENAME COLUMN (11 renames) — old → new names per spec.
+///   2. ADD COLUMN (9 new columns).
+///   3. Migrate created_at: TEXT datetime → INTEGER Unix ms.
+///   4. Rebuild indexes with new names.
+async fn migrate_logs_v2_spec_aligned(pool: &SqlitePool) -> anyhow::Result<()> {
+    // Helper: rename a column in request_logs if the old name still exists.
+    async fn rename_col(pool: &SqlitePool, old: &str, new: &str) -> anyhow::Result<()> {
+        if column_exists(pool, "request_logs", old).await?
+            && !column_exists(pool, "request_logs", new).await?
+        {
+            sqlx::query(&format!(
+                "ALTER TABLE request_logs RENAME COLUMN {old} TO {new}"
+            ))
+            .execute(pool)
+            .await?;
+        }
+        Ok(())
+    }
+
+    // ── Step 1: RENAME COLUMNS ─────────────────────────────────────────────
+    // Handle intermediate state: an earlier version of this migration renamed
+    // `created_at → timestamp`.  Roll it back to the canonical `created_at`.
+    rename_col(pool, "timestamp", "created_at").await?;
+    rename_col(pool, "ingress_protocol", "client_protocol").await?;
+    rename_col(pool, "egress_protocol", "upstream_protocol").await?;
+    rename_col(pool, "provider_name", "provider_id").await?;
+    rename_col(pool, "request_model", "client_model").await?;
+    rename_col(pool, "actual_model", "upstream_model").await?;
+    rename_col(pool, "status_code", "client_status_code").await?;
+    rename_col(pool, "duration_ms", "latency_total_ms").await?;
+    rename_col(pool, "request_headers", "client_request_headers").await?;
+    rename_col(pool, "request_body", "client_request_body").await?;
+    rename_col(pool, "response_headers", "upstream_response_headers").await?;
+    rename_col(pool, "response_body", "client_response_body").await?;
+
+    // ── Step 2: Migrate created_at values ─────────────────────────────────
+    if column_exists(pool, "request_logs", "created_at").await? {
+        // 2a. NULL → 0 (rows inserted by older code paths that omitted created_at).
+        sqlx::query("UPDATE request_logs SET created_at = 0 WHERE created_at IS NULL")
+            .execute(pool)
+            .await?;
+
+        // 2b. ISO8601 TEXT (e.g. "2024-01-15 10:00:00") → INTEGER Unix milliseconds.
+        //     Detect by checking whether any row holds a text value that starts with
+        //     a 4-digit year (LIKE '____-%'), which unambiguously identifies ISO8601.
+        let has_iso_ts: bool = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM request_logs \
+             WHERE typeof(created_at) = 'text' AND created_at LIKE '____-%' LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .map(|n| n > 0)
+        .unwrap_or(false);
+
+        if has_iso_ts {
+            sqlx::query(
+                "UPDATE request_logs \
+                 SET created_at = CAST(strftime('%s', created_at) AS INTEGER) * 1000 \
+                 WHERE typeof(created_at) = 'text' AND created_at LIKE '____-%'",
+            )
+            .execute(pool)
+            .await?;
+        }
+    }
+
+    // ── Step 3: ADD new columns ────────────────────────────────────────────
+    ensure_request_log_column(pool, "upstream_url", "TEXT").await?;
+    ensure_request_log_column(pool, "client_response_headers", "TEXT").await?;
+    ensure_request_log_column(pool, "upstream_request_headers", "TEXT").await?;
+    ensure_request_log_column(pool, "upstream_request_body", "TEXT").await?;
+    ensure_request_log_column(pool, "upstream_response_body", "TEXT").await?;
+    ensure_request_log_column(pool, "upstream_status_code", "INTEGER").await?;
+    ensure_request_log_column(pool, "latency_upstream_ms", "INTEGER").await?;
+    ensure_request_log_column(pool, "stream_chunks_count", "INTEGER DEFAULT 0").await?;
+    ensure_request_log_column(pool, "stream_first_chunk_ms", "INTEGER").await?;
+
+    // ── Step 4: Rebuild indexes ────────────────────────────────────────────
+    // Drop stale index left by the intermediate `timestamp`-column migration.
+    sqlx::query("DROP INDEX IF EXISTS idx_logs_timestamp")
+        .execute(pool)
+        .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at)")
+        .execute(pool)
+        .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_logs_provider_id ON request_logs(provider_id)")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_logs_client_status ON request_logs(client_status_code)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_logs_upstream_model ON request_logs(upstream_model)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key_id)")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_logs_client_protocol ON request_logs(client_protocol)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_logs_upstream_protocol ON request_logs(upstream_protocol)",
+    )
+    .execute(pool)
+    .await?;
 
     Ok(())
 }
@@ -646,34 +770,39 @@ CREATE TABLE IF NOT EXISTS route_targets (
 CREATE INDEX IF NOT EXISTS idx_route_targets_route_id ON route_targets(route_id);
 
 CREATE TABLE IF NOT EXISTS request_logs (
-    id                TEXT PRIMARY KEY,
-    created_at        TEXT DEFAULT (datetime('now')),
-    api_key_id        TEXT,
-    ingress_protocol  TEXT,
-    egress_protocol   TEXT,
-    request_model     TEXT,
-    actual_model      TEXT,
-    provider_name     TEXT,
-    status_code       INTEGER,
-    duration_ms       REAL,
-    input_tokens      INTEGER DEFAULT 0,
-    output_tokens     INTEGER DEFAULT 0,
-    is_stream         INTEGER DEFAULT 0,
-    is_tool_call      INTEGER DEFAULT 0,
-    error_message     TEXT,
-    response_preview  TEXT,
-    method            TEXT,
-    path              TEXT,
-    request_headers   TEXT,
-    request_body      TEXT,
-    response_headers  TEXT,
-    response_body     TEXT
+    id                        TEXT PRIMARY KEY,
+    created_at                INTEGER NOT NULL DEFAULT 0,
+    api_key_id                TEXT,
+    api_key_name              TEXT,
+    client_protocol           TEXT,
+    upstream_protocol         TEXT,
+    provider_id               TEXT,
+    provider_name             TEXT,
+    route_id                  TEXT,
+    route_name                TEXT,
+    upstream_url              TEXT,
+    client_model              TEXT,
+    upstream_model            TEXT,
+    method                    TEXT,
+    path                      TEXT,
+    client_request_headers    TEXT,
+    client_request_body       TEXT,
+    client_response_headers   TEXT,
+    client_response_body      TEXT,
+    upstream_request_headers  TEXT,
+    upstream_request_body     TEXT,
+    upstream_response_headers TEXT,
+    upstream_response_body    TEXT,
+    upstream_status_code      INTEGER,
+    client_status_code        INTEGER,
+    latency_total_ms          INTEGER,
+    latency_upstream_ms       INTEGER,
+    input_tokens              INTEGER DEFAULT 0,
+    output_tokens             INTEGER DEFAULT 0,
+    is_stream                 INTEGER DEFAULT 0,
+    stream_chunks_count       INTEGER DEFAULT 0,
+    stream_first_chunk_ms     INTEGER
 );
-
-CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at);
-CREATE INDEX IF NOT EXISTS idx_logs_provider ON request_logs(provider_name);
-CREATE INDEX IF NOT EXISTS idx_logs_status ON request_logs(status_code);
-CREATE INDEX IF NOT EXISTS idx_logs_model ON request_logs(actual_model);
 
 CREATE TABLE IF NOT EXISTS settings (
     key        TEXT PRIMARY KEY,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -227,31 +227,53 @@ pub struct ApiKeyWithBindings {
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct RequestLog {
     pub id: String,
-    pub created_at: String,
+    /// Unix 毫秒时间戳
+    pub created_at: i64,
     pub api_key_id: Option<String>,
-    pub ingress_protocol: Option<String>,
-    pub egress_protocol: Option<String>,
-    pub request_model: Option<String>,
-    pub actual_model: Option<String>,
+    pub api_key_name: Option<String>,
+
+    pub client_protocol: Option<String>,
+    pub upstream_protocol: Option<String>,
+    pub provider_id: Option<String>,
     pub provider_name: Option<String>,
-    pub status_code: Option<i32>,
-    pub duration_ms: Option<f64>,
-    pub input_tokens: i32,
-    pub output_tokens: i32,
-    pub is_stream: bool,
-    pub is_tool_call: bool,
-    pub error_message: Option<String>,
-    pub response_preview: Option<String>,
+    pub route_id: Option<String>,
+    pub route_name: Option<String>,
+    pub upstream_url: Option<String>,
+    pub client_model: Option<String>,
+    pub upstream_model: Option<String>,
+
     pub method: Option<String>,
     pub path: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_headers: Option<String>,
+    pub client_request_headers: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_body: Option<String>,
+    pub client_request_body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_headers: Option<String>,
+    pub client_response_headers: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_body: Option<String>,
+    pub client_response_body: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_request_headers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_request_body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_response_headers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_response_body: Option<String>,
+
+    pub upstream_status_code: Option<i32>,
+    pub client_status_code: Option<i32>,
+
+    pub latency_total_ms: Option<i64>,
+    pub latency_upstream_ms: Option<i64>,
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+
+    pub is_stream: bool,
+    pub stream_chunks_count: i32,
+    pub stream_first_chunk_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/nyro-core/src/logging/mod.rs
+++ b/crates/nyro-core/src/logging/mod.rs
@@ -10,25 +10,65 @@ pub const LOG_RETENTION_DAYS_KEY: &str = "log_retention_days";
 
 #[derive(Debug, Clone)]
 pub struct LogEntry {
+    // === 标识 ===
     pub api_key_id: Option<String>,
-    pub ingress_protocol: String,
-    pub egress_protocol: String,
-    pub request_model: String,
-    pub actual_model: String,
+    pub api_key_name: Option<String>,
+    /// Unix 毫秒时间戳
+    pub created_at: i64,
+
+    // === 路由 ===
+    pub client_protocol: String,
+    pub upstream_protocol: String,
+    pub provider_id: String,
     pub provider_name: String,
-    pub status_code: i32,
-    pub duration_ms: f64,
-    pub usage: Usage,
-    pub is_stream: bool,
-    pub is_tool_call: bool,
-    pub error_message: Option<String>,
-    pub response_preview: Option<String>,
+    pub route_id: Option<String>,
+    pub route_name: Option<String>,
+    pub upstream_url: Option<String>,
+    pub client_model: String,
+    pub upstream_model: String,
+
+    // === HTTP 元 ===
     pub method: Option<String>,
     pub path: Option<String>,
-    pub request_headers: Option<String>,
-    pub request_body: Option<String>,
-    pub response_headers: Option<String>,
-    pub response_body: Option<String>,
+
+    // === 客户端 wire ===
+    pub client_request_headers: Option<String>,
+    pub client_request_body: Option<String>,
+    pub client_response_headers: Option<String>,
+    pub client_response_body: Option<String>,
+
+    // === 上游 wire ===
+    pub upstream_request_headers: Option<String>,
+    pub upstream_request_body: Option<String>,
+    pub upstream_response_headers: Option<String>,
+    pub upstream_response_body: Option<String>,
+
+    // === 状态 ===
+    pub upstream_status_code: Option<i32>,
+    pub client_status_code: i32,
+
+    // === 性能 ===
+    pub latency_total_ms: i64,
+    pub latency_upstream_ms: Option<i64>,
+    pub usage: Usage,
+
+    // === 流式 ===
+    /// 客户端请求中声明的 stream 标志（stream: true），比 stream_chunks_count > 0 更严谨
+    pub is_stream: bool,
+    /// 收到的上游 SSE chunk 数；> 0 表示流式请求，非流式为 0
+    pub stream_chunks_count: i32,
+    /// TTFB（ms）；非流式为 None
+    pub stream_first_chunk_ms: Option<i64>,
+}
+
+impl LogEntry {
+    pub fn input_tokens(&self) -> i32 {
+        self.usage.prompt_tokens as i32
+    }
+
+    pub fn output_tokens(&self) -> i32 {
+        self.usage.completion_tokens as i32
+    }
 }
 
 pub async fn run_collector(mut rx: mpsc::Receiver<LogEntry>, storage: DynStorage) {
@@ -95,10 +135,14 @@ async fn flush(storage: DynStorage, buffer: &mut Vec<LogEntry>) {
     let record_payloads = read_record_payloads(&storage).await;
     if !record_payloads {
         for entry in entries.iter_mut() {
-            entry.request_headers = None;
-            entry.request_body = None;
-            entry.response_headers = None;
-            entry.response_body = None;
+            entry.client_request_headers = None;
+            entry.client_request_body = None;
+            entry.client_response_headers = None;
+            entry.client_response_body = None;
+            entry.upstream_request_headers = None;
+            entry.upstream_request_body = None;
+            entry.upstream_response_headers = None;
+            entry.upstream_response_body = None;
         }
     }
     let _ = storage.logs().append_batch(entries).await;

--- a/crates/nyro-core/src/proxy/dispatcher/auth.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/auth.rs
@@ -15,6 +15,7 @@ use super::error_response;
 
 pub(super) struct AuthenticatedKey {
     pub(super) id: Option<String>,
+    pub(super) name: Option<String>,
 }
 
 #[async_trait]
@@ -89,7 +90,10 @@ pub(super) async fn authorize_route_access<S: ProxyAccessStore + ?Sized>(
     headers: &HeaderMap,
 ) -> Result<AuthenticatedKey, Response> {
     if !route.access_control {
-        return Ok(AuthenticatedKey { id: None });
+        return Ok(AuthenticatedKey {
+            id: None,
+            name: None,
+        });
     }
 
     let Some(raw_key) = extract_api_key(headers) else {
@@ -165,6 +169,7 @@ pub(super) async fn authorize_route_access<S: ProxyAccessStore + ?Sized>(
 
     Ok(AuthenticatedKey {
         id: Some(key_row.id),
+        name: Some(key_row.name),
     })
 }
 

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -57,7 +57,7 @@ use crate::provider::vendor::ProviderCtx;
 use crate::provider::{VendorCtx, VendorRegistry};
 use crate::proxy::client::ProxyClient;
 use crate::proxy::context::RequestContext;
-use crate::proxy::observability::{LogExtras, emit_log, headers_to_json};
+use crate::proxy::observability::{LogExtras, headers_to_json, send_log};
 use crate::proxy::planner::{ProtocolMode, negotiate};
 use crate::router::TargetSelector;
 
@@ -113,9 +113,9 @@ pub async fn dispatch_pipeline(
         Some(r) => r,
         None => {
             let msg = format!("no route for model: {request_model}");
-            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, None, start, is_stream)
+            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, None, start)
+                .stream_flag(is_stream)
                 .status(404)
-                .error(msg.clone())
                 .with_req_extras(&req_extras)
                 .resp_body(Some(
                     serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
@@ -132,9 +132,9 @@ pub async fn dispatch_pipeline(
         Ok(v) => v,
         Err(resp) => {
             let status = resp.status().as_u16() as i32;
-            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, None, start, is_stream)
+            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, None, start)
+                .stream_flag(is_stream)
                 .status_i32(status)
-                .error(format!("authorization failed: {status}"))
                 .with_req_extras(&req_extras)
                 .emit();
             return resp;
@@ -199,15 +199,15 @@ pub async fn dispatch_pipeline(
             &request_model,
             auth_key.id.as_deref(),
             start,
-            is_stream,
         )
-        .actual_model_str(
+        .stream_flag(is_stream)
+        .upstream_model_str(
             cached_entry
                 .actual_model
                 .as_deref()
                 .unwrap_or(&request_model),
         )
-        .provider_str(&cached_entry.provider_name)
+        .provider_id_str(&cached_entry.provider_name)
         .status_i32(cached_entry.status_code as i32)
         .usage(cached_usage)
         .with_req_extras(&req_extras)
@@ -245,15 +245,15 @@ pub async fn dispatch_pipeline(
                         &request_model,
                         auth_key.id.as_deref(),
                         start,
-                        is_stream,
                     )
-                    .actual_model_str(
+                    .stream_flag(is_stream)
+                    .upstream_model_str(
                         cached_entry
                             .actual_model
                             .as_deref()
                             .unwrap_or(&request_model),
                     )
-                    .provider_str(&cached_entry.provider_name)
+                    .provider_id_str(&cached_entry.provider_name)
                     .status_i32(cached_entry.status_code as i32)
                     .usage(cached_usage)
                     .with_req_extras(&req_extras)
@@ -311,15 +311,15 @@ pub async fn dispatch_pipeline(
                 &request_model,
                 auth_key.id.as_deref(),
                 start,
-                is_stream,
             )
-            .actual_model_str(
+            .stream_flag(is_stream)
+            .upstream_model_str(
                 cached_entry
                     .actual_model
                     .as_deref()
                     .unwrap_or(&request_model),
             )
-            .provider_str(&cached_entry.provider_name)
+            .provider_id_str(&cached_entry.provider_name)
             .status_i32(cached_entry.status_code as i32)
             .usage(cached_usage)
             .with_req_extras(&req_extras)
@@ -365,10 +365,9 @@ pub async fn dispatch_pipeline(
                     &request_model,
                     auth_key.id.as_deref(),
                     start,
-                    is_stream,
                 )
+                .stream_flag(is_stream)
                 .status(500)
-                .error(format!("request hook `{}` rejected: {e}", hook.name()))
                 .with_req_extras(&req_extras)
                 .emit();
                 return error_response(500, &e.to_string());
@@ -386,10 +385,9 @@ pub async fn dispatch_pipeline(
             &request_model,
             auth_key.id.as_deref(),
             start,
-            is_stream,
         )
+        .stream_flag(is_stream)
         .status(503)
-        .error("no route targets configured")
         .with_req_extras(&req_extras)
         .emit();
         return error_response(503, "no route targets configured");
@@ -402,10 +400,9 @@ pub async fn dispatch_pipeline(
             &request_model,
             auth_key.id.as_deref(),
             start,
-            is_stream,
         )
+        .stream_flag(is_stream)
         .status(503)
-        .error("no route targets configured")
         .with_req_extras(&req_extras)
         .emit();
         return error_response(503, "no route targets configured");
@@ -557,6 +554,7 @@ pub async fn dispatch_pipeline(
             gw: gw.clone(),
             provider: &provider,
             route_id: &route.id,
+            route_name: &route.name,
             egress,
             ingress,
             ingress_str: &ingress_str,
@@ -564,6 +562,8 @@ pub async fn dispatch_pipeline(
             request_model: &request_model,
             actual_model: &actual_model,
             api_key_id: auth_key.id.as_deref(),
+            api_key_name: auth_key.name.as_deref(),
+            is_stream,
             start,
         };
         let cache_ctx = CacheWriteCtx {
@@ -642,10 +642,9 @@ pub async fn dispatch_pipeline(
             &request_model,
             auth_key.id.as_deref(),
             start,
-            is_stream,
         )
+        .stream_flag(is_stream)
         .status(502)
-        .error("all route targets failed")
         .with_req_extras(&req_extras)
         .emit();
         error_response(502, "all route targets failed")
@@ -684,9 +683,8 @@ pub async fn dispatch(
             let msg = format!("invalid request: {e}");
             // dispatch() has no start Instant; use a zero-duration sentinel.
             let decode_start = Instant::now();
-            LogBuilder::from_dispatch(&gw, &ingress_str, "", None, decode_start, false)
+            LogBuilder::from_dispatch(&gw, &ingress_str, "", None, decode_start)
                 .status(400)
-                .error(msg.clone())
                 .with_req_extras(&RequestExtras {
                     method: method.to_string(),
                     path: path.to_string(),
@@ -713,6 +711,7 @@ struct CallCtx<'a> {
     gw: Gateway,
     provider: &'a Provider,
     route_id: &'a str,
+    route_name: &'a str,
     egress: ProtocolId,
     ingress: ProtocolId,
     ingress_str: &'a str,
@@ -720,6 +719,8 @@ struct CallCtx<'a> {
     request_model: &'a str,
     actual_model: &'a str,
     api_key_id: Option<&'a str>,
+    api_key_name: Option<&'a str>,
+    is_stream: bool,
     start: Instant,
 }
 
@@ -746,7 +747,8 @@ struct RequestExtras {
 
 // ── Log builder ───────────────────────────────────────────────────────────────
 
-/// Fluent builder for `emit_log`. Eliminates the 15-argument flat call site.
+/// Fluent builder for `LogEntry`. Eliminates the long flat parameter list at
+/// call sites.
 ///
 /// Create via `LogBuilder::from_ctx` (inside handler functions, where a
 /// `CallCtx` is available) or `LogBuilder::from_dispatch` (in
@@ -755,19 +757,20 @@ struct RequestExtras {
 #[derive(Clone)]
 struct LogBuilder {
     gw: Gateway,
-    ingress: String,
-    egress: String,
-    request_model: String,
-    actual_model: String,
+    client_protocol: String,
+    upstream_protocol: String,
+    client_model: String,
+    upstream_model: String,
     api_key_id: Option<String>,
+    api_key_name: Option<String>,
+    provider_id: String,
     provider_name: String,
-    start: Instant,
-    status_code: i32,
-    usage: Usage,
+    route_id: Option<String>,
+    route_name: Option<String>,
     is_stream: bool,
-    is_tool_call: bool,
-    error_message: Option<String>,
-    response_preview: Option<String>,
+    start: Instant,
+    client_status_code: i32,
+    usage: Usage,
     extras: LogExtras,
 }
 
@@ -776,70 +779,76 @@ impl LogBuilder {
     fn from_ctx(call_ctx: &CallCtx<'_>) -> Self {
         Self {
             gw: call_ctx.gw.clone(),
-            ingress: call_ctx.ingress_str.to_string(),
-            egress: call_ctx.egress_str.to_string(),
-            request_model: call_ctx.request_model.to_string(),
-            actual_model: call_ctx.actual_model.to_string(),
+            client_protocol: call_ctx.ingress_str.to_string(),
+            upstream_protocol: call_ctx.egress_str.to_string(),
+            client_model: call_ctx.request_model.to_string(),
+            upstream_model: call_ctx.actual_model.to_string(),
             api_key_id: call_ctx.api_key_id.map(ToString::to_string),
+            api_key_name: call_ctx.api_key_name.map(ToString::to_string),
+            provider_id: call_ctx.provider.id.clone(),
             provider_name: call_ctx.provider.name.clone(),
+            route_id: Some(call_ctx.route_id.to_string()),
+            route_name: Some(call_ctx.route_name.to_string()),
+            is_stream: call_ctx.is_stream,
             start: call_ctx.start,
-            status_code: 200,
+            client_status_code: 200,
             usage: Usage::default(),
-            is_stream: false,
-            is_tool_call: false,
-            error_message: None,
-            response_preview: None,
             extras: LogExtras::default(),
         }
     }
 
     /// Build from dispatch-pipeline context before a provider is selected.
-    /// `egress` defaults to `ingress`; `actual_model` and `provider_name`
-    /// default to empty strings; override with `actual_model_str` / `provider_str`.
+    /// `upstream_protocol` defaults to `client_protocol`; `upstream_model` and
+    /// `provider_id` default to empty strings.
     fn from_dispatch(
         gw: &Gateway,
         ingress: &str,
         request_model: &str,
         api_key_id: Option<&str>,
         start: Instant,
-        is_stream: bool,
     ) -> Self {
         Self {
             gw: gw.clone(),
-            ingress: ingress.to_string(),
-            egress: ingress.to_string(),
-            request_model: request_model.to_string(),
-            actual_model: String::new(),
+            client_protocol: ingress.to_string(),
+            upstream_protocol: ingress.to_string(),
+            client_model: request_model.to_string(),
+            upstream_model: String::new(),
             api_key_id: api_key_id.map(ToString::to_string),
+            api_key_name: None,
+            provider_id: String::new(),
             provider_name: String::new(),
+            route_id: None,
+            route_name: None,
+            is_stream: false,
             start,
-            status_code: 200,
+            client_status_code: 200,
             usage: Usage::default(),
-            is_stream,
-            is_tool_call: false,
-            error_message: None,
-            response_preview: None,
             extras: LogExtras::default(),
         }
     }
 
+    fn stream_flag(mut self, v: bool) -> Self {
+        self.is_stream = v;
+        self
+    }
+
     fn status(mut self, code: u16) -> Self {
-        self.status_code = code as i32;
+        self.client_status_code = code as i32;
         self
     }
 
     fn status_i32(mut self, code: i32) -> Self {
-        self.status_code = code;
+        self.client_status_code = code;
         self
     }
 
-    fn actual_model_str(mut self, m: &str) -> Self {
-        self.actual_model = m.to_string();
+    fn upstream_model_str(mut self, m: &str) -> Self {
+        self.upstream_model = m.to_string();
         self
     }
 
-    fn provider_str(mut self, name: &str) -> Self {
-        self.provider_name = name.to_string();
+    fn provider_id_str(mut self, id: &str) -> Self {
+        self.provider_id = id.to_string();
         self
     }
 
@@ -848,70 +857,119 @@ impl LogBuilder {
         self
     }
 
-    fn stream(mut self) -> Self {
-        self.is_stream = true;
+    fn error(self, _msg: impl Into<String>) -> Self {
+        // Error info is embedded in response body; kept for call-site compat.
         self
     }
 
-    fn maybe_tool(mut self, yes: bool) -> Self {
-        self.is_tool_call = yes;
+    fn maybe_error(self, _msg: Option<String>) -> Self {
         self
     }
 
-    fn error(mut self, msg: impl Into<String>) -> Self {
-        self.error_message = Some(msg.into());
-        self
-    }
-
-    fn maybe_error(mut self, msg: Option<String>) -> Self {
-        self.error_message = msg;
-        self
-    }
-
-    fn preview(mut self, p: Option<String>) -> Self {
-        self.response_preview = p;
-        self
-    }
-
-    /// Pre-fill the request-side `LogExtras` fields (method, path, headers,
-    /// body) from a `RequestExtras`.  Response-side fields remain unset until
-    /// `resp_headers` / `resp_body` are called.
+    /// Pre-fill the client request-side `LogExtras` fields (method, path,
+    /// headers, body) from a `RequestExtras`.
     fn with_req_extras(mut self, req: &RequestExtras) -> Self {
         self.extras.method = Some(req.method.clone());
         self.extras.path = Some(req.path.clone());
-        self.extras.request_headers = req.headers.clone();
-        self.extras.request_body = req.body.clone();
+        self.extras.client_request_headers = req.headers.clone();
+        self.extras.client_request_body = req.body.clone();
         self
     }
 
-    fn resp_headers(mut self, h: Option<String>) -> Self {
-        self.extras.response_headers = h;
+    /// Set the upstream request wire (headers + body encoded for upstream).
+    fn with_upstream_request(mut self, headers: Option<String>, body: Option<String>) -> Self {
+        self.extras.upstream_request_headers = headers;
+        self.extras.upstream_request_body = body;
         self
     }
 
+    /// Set the upstream response wire.
+    fn with_upstream_response(
+        mut self,
+        status: i32,
+        headers: Option<String>,
+        body: Option<String>,
+        latency_ms: Option<i64>,
+    ) -> Self {
+        self.extras.upstream_status_code = Some(status);
+        self.extras.upstream_response_headers = headers;
+        self.extras.upstream_response_body = body;
+        self.extras.latency_upstream_ms = latency_ms;
+        self
+    }
+
+    fn upstream_resp_headers(mut self, h: Option<String>) -> Self {
+        self.extras.upstream_response_headers = h;
+        self
+    }
+
+    fn upstream_resp_body(mut self, b: Option<String>) -> Self {
+        self.extras.upstream_response_body = b;
+        self
+    }
+
+    fn upstream_status(mut self, code: i32) -> Self {
+        self.extras.upstream_status_code = Some(code);
+        self
+    }
+
+    /// Set the client response wire.
+    fn with_client_response(mut self, headers: Option<String>, body: Option<String>) -> Self {
+        self.extras.client_response_headers = headers;
+        self.extras.client_response_body = body;
+        self
+    }
+
+    fn stream_metrics(mut self, chunks: i32, first_chunk_ms: Option<i64>) -> Self {
+        self.extras.stream_chunks_count = chunks;
+        self.extras.stream_first_chunk_ms = first_chunk_ms;
+        self
+    }
+
+    // ── Legacy shim ────────────────────────────────────────────────────────
+
+    /// Maps `response_body` → `client_response_body`.
     fn resp_body(mut self, b: Option<String>) -> Self {
-        self.extras.response_body = b;
+        self.extras.client_response_body = b;
         self
     }
 
     fn emit(self) {
-        emit_log(
-            &self.gw,
-            &self.ingress,
-            &self.egress,
-            &self.request_model,
-            &self.actual_model,
-            self.api_key_id.as_deref(),
-            &self.provider_name,
-            self.status_code,
-            self.start.elapsed().as_millis() as f64,
-            self.usage,
-            self.is_stream,
-            self.is_tool_call,
-            self.error_message,
-            self.response_preview,
-            self.extras,
-        );
+        use crate::logging::LogEntry;
+        let latency_total_ms = self.start.elapsed().as_millis() as i64;
+        let entry = LogEntry {
+            api_key_id: self.api_key_id,
+            api_key_name: self.api_key_name,
+            created_at: chrono::Utc::now().timestamp_millis(),
+            client_protocol: self.client_protocol,
+            upstream_protocol: self.upstream_protocol,
+            provider_id: self.provider_id,
+            provider_name: self.provider_name,
+            route_id: self.route_id,
+            route_name: self.route_name,
+            upstream_url: self.extras.upstream_url,
+            client_model: self.client_model,
+            upstream_model: self.upstream_model,
+            method: self.extras.method,
+            path: self.extras.path,
+            client_request_headers: self.extras.client_request_headers,
+            client_request_body: self.extras.client_request_body,
+            client_response_headers: self.extras.client_response_headers,
+            client_response_body: self.extras.client_response_body,
+            upstream_request_headers: self.extras.upstream_request_headers,
+            upstream_request_body: self.extras.upstream_request_body,
+            upstream_response_headers: self.extras.upstream_response_headers,
+            upstream_response_body: self.extras.upstream_response_body,
+            upstream_status_code: self.extras.upstream_status_code,
+            client_status_code: self.client_status_code,
+            latency_total_ms,
+            latency_upstream_ms: self.extras.latency_upstream_ms,
+            usage: self.usage,
+            is_stream: self.is_stream,
+            stream_chunks_count: self.extras.stream_chunks_count,
+            stream_first_chunk_ms: self.extras.stream_first_chunk_ms,
+        };
+        send_log(&self.gw, entry);
     }
 }
 

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -53,11 +53,14 @@ pub(super) async fn handle_non_stream(
     // Shared log builder pre-filled with identity + request-side extras.
     let log = LogBuilder::from_ctx(call_ctx).with_req_extras(req_extras);
 
-    let call_result = match client.call_non_stream(url, headers, body.clone()).await {
+    let upstream_start = std::time::Instant::now();
+    let call_result = match client
+        .call_non_stream(url, headers.clone(), body.clone())
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             log.status(502)
-                .error(e.to_string())
                 .resp_body(Some(
                     serde_json::json!({ "error": { "message": format!("upstream error: {e}") } })
                         .to_string(),
@@ -66,16 +69,24 @@ pub(super) async fn handle_non_stream(
             return error_response(502, &format!("upstream error: {e}"));
         }
     };
+    let upstream_latency_ms = upstream_start.elapsed().as_millis() as i64;
 
     let (resp, status, upstream_headers) = call_result;
     let upstream_hdrs_str = headers_to_json(&upstream_headers);
+    let upstream_req_hdrs_str = crate::proxy::observability::reqwest_headers_to_json(&headers);
+    let upstream_req_body_str = serde_json::to_string(&body).ok();
 
     if status >= 400 {
         let body_str = serde_json::to_string(&resp).ok();
-        let preview = body_str.as_ref().map(|s| s.chars().take(500).collect());
         log.status(status)
-            .preview(preview)
-            .resp_headers(upstream_hdrs_str.clone())
+            .upstream_status(status as i32)
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .with_upstream_response(
+                status as i32,
+                upstream_hdrs_str.clone(),
+                body_str.clone(),
+                Some(upstream_latency_ms),
+            )
             .resp_body(body_str)
             .emit();
         return (
@@ -89,12 +100,16 @@ pub(super) async fn handle_non_stream(
     if egress.handler().capabilities().embeddings {
         let usage = crate::protocol::codec::openai_compatible::embeddings::parse_usage(&resp);
         let resp_str = serde_json::to_string(&resp).ok();
-        let preview = resp_str.as_ref().map(|s| s.chars().take(500).collect());
         log.status(status)
             .usage(usage)
-            .preview(preview)
-            .resp_headers(upstream_hdrs_str.clone())
-            .resp_body(resp_str)
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .with_upstream_response(
+                status as i32,
+                upstream_hdrs_str.clone(),
+                resp_str.clone(),
+                Some(upstream_latency_ms),
+            )
+            .with_client_response(None, resp_str)
             .emit();
         return (
             StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
@@ -112,11 +127,15 @@ pub(super) async fn handle_non_stream(
             "bypassing IR round-trip"
         );
         let resp_str = serde_json::to_string(&resp).ok();
-        let preview = resp_str.as_ref().map(|s| s.chars().take(500).collect());
         log.status(status)
-            .preview(preview)
-            .resp_headers(upstream_hdrs_str.clone())
-            .resp_body(resp_str)
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .with_upstream_response(
+                status as i32,
+                upstream_hdrs_str.clone(),
+                resp_str.clone(),
+                Some(upstream_latency_ms),
+            )
+            .with_client_response(None, resp_str)
             .emit();
         return (
             StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
@@ -126,17 +145,22 @@ pub(super) async fn handle_non_stream(
     }
 
     // Parse response via ProviderAdapter.
+    let upstream_resp_str = serde_json::to_string(&resp).ok();
     let inbound = InboundResponse { status, body: resp };
     let mut ai_resp = match adapter.parse_response(inbound, ctx).await {
         Ok(r) => r,
         Err(e) => {
             log.status(500)
-                .error(format!("parse error: {e}"))
-                .resp_headers(upstream_hdrs_str.clone())
-                .resp_body(Some(
-                    serde_json::json!({ "error": { "message": format!("parse error: {e}") } })
-                        .to_string(),
-                ))
+                .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+                .with_upstream_response(
+                    status as i32,
+                    upstream_hdrs_str.clone(),
+                    Some(
+                        serde_json::json!({ "error": { "message": format!("parse error: {e}") } })
+                            .to_string(),
+                    ),
+                    Some(upstream_latency_ms),
+                )
                 .emit();
             return error_response(500, &format!("parse error: {e}"));
         }
@@ -168,15 +192,16 @@ pub(super) async fn handle_non_stream(
     let output = formatter.format_response(&ai_resp);
 
     let response_body_full = serde_json::to_string(&output).ok();
-    let response_preview = response_body_full
-        .as_ref()
-        .map(|s| s.chars().take(500).collect());
     log.status(status)
         .usage(usage.clone())
-        .maybe_tool(is_tool)
-        .preview(response_preview)
-        .resp_headers(upstream_hdrs_str)
-        .resp_body(response_body_full)
+        .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+        .with_upstream_response(
+            status as i32,
+            upstream_hdrs_str,
+            upstream_resp_str,
+            Some(upstream_latency_ms),
+        )
+        .with_client_response(None, response_body_full)
         .emit();
 
     let mut response = (
@@ -248,26 +273,36 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
     let expose_headers = cache_ctx.expose_headers;
     let log = LogBuilder::from_ctx(call_ctx);
 
-    let call_result = match client.call_stream(url, headers, body.clone()).await {
+    let upstream_start = std::time::Instant::now();
+    let call_result = match client.call_stream(url, headers.clone(), body.clone()).await {
         Ok(r) => r,
         Err(e) => {
-            log.status(502).error(e.to_string()).emit();
+            log.status(502).emit();
             return error_response(502, &format!("upstream error: {e}"));
         }
     };
+    let upstream_latency_ms = upstream_start.elapsed().as_millis() as i64;
 
     let (resp, status) = call_result;
     let upstream_hdrs_str = headers_to_json(resp.headers());
+    let upstream_req_hdrs_str = crate::proxy::observability::reqwest_headers_to_json(&headers);
+    let upstream_req_body_str = serde_json::to_string(&body).ok();
 
     if status >= 400 {
         let err_body: Value = resp
             .json()
             .await
             .unwrap_or_else(|_| serde_json::json!({"error": {"message": "upstream error"}}));
+        let err_body_str = serde_json::to_string(&err_body).ok();
         log.status(status)
-            .error(err_body.to_string())
-            .resp_headers(upstream_hdrs_str)
-            .resp_body(serde_json::to_string(&err_body).ok())
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .with_upstream_response(
+                status as i32,
+                upstream_hdrs_str,
+                err_body_str.clone(),
+                Some(upstream_latency_ms),
+            )
+            .resp_body(err_body_str)
             .emit();
         return (
             StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
@@ -316,15 +351,12 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
     let formatter = ingress.handler().make_response_encoder();
     let output = formatter.format_response(&ai_resp);
 
-    let response_preview = serde_json::to_string(&output)
-        .ok()
-        .map(|s| s.chars().take(500).collect());
+    let client_resp_body_str = serde_json::to_string(&output).ok();
     log.status(status)
         .usage(usage.clone())
-        .maybe_tool(is_tool)
-        .preview(response_preview)
-        .resp_headers(upstream_hdrs_str)
-        .resp_body(serde_json::to_string(&output).ok())
+        .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+        .upstream_resp_headers(upstream_hdrs_str)
+        .with_client_response(None, client_resp_body_str)
         .emit();
 
     let mut response = (

--- a/crates/nyro-core/src/proxy/dispatcher/stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/stream.rs
@@ -49,16 +49,14 @@ pub(super) async fn handle_stream(
     let exact_cache_ttl = cache_ctx.exact_cache_ttl;
     let semantic_write_ctx = cache_ctx.semantic.clone();
     let expose_headers = cache_ctx.expose_headers;
-    // Shared log builder: identity + request-side extras pre-filled, stream=true.
-    let log = LogBuilder::from_ctx(call_ctx)
-        .stream()
-        .with_req_extras(req_extras);
+    // Shared log builder: identity + request-side extras pre-filled.
+    let log = LogBuilder::from_ctx(call_ctx).with_req_extras(req_extras);
 
-    let call_result = match client.call_stream(url, headers, body.clone()).await {
+    let upstream_start = std::time::Instant::now();
+    let call_result = match client.call_stream(url, headers.clone(), body.clone()).await {
         Ok(r) => r,
         Err(e) => {
             log.status(502)
-                .error(e.to_string())
                 .resp_body(Some(
                     serde_json::json!({ "error": { "message": format!("upstream error: {e}") } })
                         .to_string(),
@@ -67,6 +65,8 @@ pub(super) async fn handle_stream(
             return error_response(502, &format!("upstream error: {e}"));
         }
     };
+    let upstream_req_hdrs_str = crate::proxy::observability::reqwest_headers_to_json(&headers);
+    let upstream_req_body_str = serde_json::to_string(&body).ok();
 
     let (resp, status) = call_result;
     let upstream_hdrs_str = headers_to_json(resp.headers());
@@ -78,8 +78,10 @@ pub(super) async fn handle_stream(
             .unwrap_or_else(|_| serde_json::json!({"error": {"message": "upstream error"}}));
         let err_body_str = serde_json::to_string(&err_body).ok();
         log.status(status)
-            .error(err_body.to_string())
-            .resp_headers(upstream_hdrs_str.clone())
+            .upstream_status(status as i32)
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .upstream_resp_headers(upstream_hdrs_str.clone())
+            .upstream_resp_body(err_body_str.clone())
             .resp_body(err_body_str)
             .emit();
         return (
@@ -105,15 +107,24 @@ pub(super) async fn handle_stream(
         let leader_key_pt = singleflight_key.map(ToString::to_string);
         let leader_tx_pt = singleflight_tx.clone();
         let upstream_hdrs_pt = upstream_hdrs_str.clone();
+        let upstream_req_hdrs_pt = upstream_req_hdrs_str.clone();
+        let upstream_req_body_pt = upstream_req_body_str.clone();
+        let upstream_start_pt = upstream_start;
 
         tokio::spawn(async move {
             let mut log_buf: Vec<u8> = Vec::new();
             let mut byte_stream = resp.bytes_stream();
             let mut stream_error: Option<String> = None;
+            let mut chunks_count: i32 = 0;
+            let mut first_chunk_ms: Option<i64> = None;
 
             while let Some(result) = byte_stream.next().await {
                 match result {
                     Ok(b) => {
+                        if first_chunk_ms.is_none() {
+                            first_chunk_ms = Some(upstream_start_pt.elapsed().as_millis() as i64);
+                        }
+                        chunks_count += 1;
                         log_buf.extend_from_slice(&b);
                         if pt_tx.send(Ok(b)).await.is_err() {
                             break; // client disconnected
@@ -134,11 +145,13 @@ pub(super) async fn handle_stream(
                 }
             }
 
-            // Parse accumulated buffer for usage stats and log entry (best-effort).
-            let log_text = String::from_utf8_lossy(&log_buf);
+            let upstream_latency_ms = upstream_start_pt.elapsed().as_millis() as i64;
+            let raw_sse = String::from_utf8_lossy(&log_buf).into_owned();
+
+            // Parse accumulated buffer for usage stats (best-effort).
             let mut log_parser = egress.handler().make_stream_response_decoder();
             let mut accumulator = StreamResponseAccumulator::default();
-            if let Ok(ai_deltas) = log_parser.parse_chunk(&log_text) {
+            if let Ok(ai_deltas) = log_parser.parse_chunk(&raw_sse) {
                 accumulator.apply_all(&ai_deltas);
             }
             if let Ok(ai_deltas) = log_parser.finish() {
@@ -150,20 +163,23 @@ pub(super) async fn handle_stream(
                 ai_resp.id = format!("msg_{}", uuid::Uuid::new_v4().simple());
             }
             if ai_resp.model.is_empty() {
-                ai_resp.model = log_pt.actual_model.clone();
+                ai_resp.model = log_pt.upstream_model.clone();
             }
-
-            let aggregated_formatter = ingress.handler().make_response_encoder();
-            let aggregated_output = aggregated_formatter.format_response(&ai_resp);
-            let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
 
             log_pt
                 .status(200)
+                .upstream_status(200)
                 .usage(ai_resp.usage.clone())
-                .maybe_tool(!ai_resp.tool_calls.is_empty())
                 .maybe_error(stream_error)
-                .resp_headers(upstream_hdrs_pt)
-                .resp_body(aggregated_body_str)
+                .with_upstream_request(upstream_req_hdrs_pt, upstream_req_body_pt)
+                .with_upstream_response(
+                    200,
+                    upstream_hdrs_pt,
+                    Some(raw_sse.clone()),
+                    Some(upstream_latency_ms),
+                )
+                .with_client_response(None, Some(raw_sse))
+                .stream_metrics(chunks_count, first_chunk_ms)
                 .emit();
 
             // log_pt is consumed by emit(); use the pre-cloned gw_pt.
@@ -196,8 +212,8 @@ pub(super) async fn handle_stream(
     // emit() consumes the builder, before passing it to the spawn.
     let log_ir = log;
     let gw_ir = log_ir.gw.clone(); // needed for cache writes after emit()
-    let provider_name_ir = log_ir.provider_name.clone();
-    let act_model_ir = log_ir.actual_model.clone();
+    let provider_name_ir = log_ir.provider_id.clone();
+    let act_model_ir = log_ir.upstream_model.clone();
     let cache_key_owned = cache_key.map(ToString::to_string);
     let leader_key_owned = singleflight_key.map(ToString::to_string);
     let leader_tx_owned = singleflight_tx.clone();
@@ -207,6 +223,11 @@ pub(super) async fn handle_stream(
 
     tokio::spawn(async move {
         let mut accumulator = StreamResponseAccumulator::default();
+        let mut upstream_raw_buf: Vec<u8> = Vec::new();
+        let mut client_sse_parts: Vec<String> = Vec::new();
+        let mut chunks_count: i32 = 0;
+        let mut first_chunk_ms: Option<i64> = None;
+
         while let Some(chunk) = byte_stream.next().await {
             let bytes = match chunk {
                 Ok(b) => b,
@@ -224,12 +245,19 @@ pub(super) async fn handle_stream(
                     break;
                 }
             };
+            if first_chunk_ms.is_none() {
+                first_chunk_ms = Some(upstream_start.elapsed().as_millis() as i64);
+            }
+            chunks_count += 1;
+            upstream_raw_buf.extend_from_slice(&bytes);
             let text = String::from_utf8_lossy(&bytes);
             if let Ok(ai_deltas) = stream_parser.parse_chunk(&text) {
                 accumulator.apply_all(&ai_deltas);
                 let events = stream_formatter.format_deltas(&ai_deltas);
                 for ev in events {
-                    if tx.send(Ok(ev.to_sse_string())).await.is_err() {
+                    let sse = ev.to_sse_string();
+                    client_sse_parts.push(sse.clone());
+                    if tx.send(Ok(sse)).await.is_err() {
                         return;
                     }
                 }
@@ -240,14 +268,22 @@ pub(super) async fn handle_stream(
             accumulator.apply_all(&ai_deltas);
             let events = stream_formatter.format_deltas(&ai_deltas);
             for ev in events {
-                let _ = tx.send(Ok(ev.to_sse_string())).await;
+                let sse = ev.to_sse_string();
+                client_sse_parts.push(sse.clone());
+                let _ = tx.send(Ok(sse)).await;
             }
         }
 
         let done_events = stream_formatter.format_done();
         for ev in done_events {
-            let _ = tx.send(Ok(ev.to_sse_string())).await;
+            let sse = ev.to_sse_string();
+            client_sse_parts.push(sse.clone());
+            let _ = tx.send(Ok(sse)).await;
         }
+
+        let upstream_latency_ms = upstream_start.elapsed().as_millis() as i64;
+        let upstream_raw_str = String::from_utf8_lossy(&upstream_raw_buf).into_owned();
+        let client_sse_str = client_sse_parts.join("");
 
         let usage = stream_formatter.usage();
         let mut ai_resp = accumulator.into_ai_response();
@@ -264,15 +300,19 @@ pub(super) async fn handle_stream(
             ai_resp.stop_reason = Some("stop".to_string());
         }
 
-        let aggregated_formatter = ingress.handler().make_response_encoder();
-        let aggregated_output = aggregated_formatter.format_response(&ai_resp);
-        let aggregated_body_str = serde_json::to_string(&aggregated_output).ok();
         log_ir
             .status(200)
+            .upstream_status(200)
             .usage(ai_resp.usage.clone())
-            .maybe_tool(!ai_resp.tool_calls.is_empty())
-            .resp_headers(upstream_hdrs_owned)
-            .resp_body(aggregated_body_str)
+            .with_upstream_request(upstream_req_hdrs_str, upstream_req_body_str)
+            .with_upstream_response(
+                200,
+                upstream_hdrs_owned,
+                Some(upstream_raw_str),
+                Some(upstream_latency_ms),
+            )
+            .with_client_response(None, Some(client_sse_str))
+            .stream_metrics(chunks_count, first_chunk_ms)
             .emit();
 
         let mut singleflight_payload: Option<Vec<u8>> = None;
@@ -293,9 +333,10 @@ pub(super) async fn handle_stream(
                     internal_response: Some(ai_resp.clone()),
                 };
                 if let Ok(bytes) = serde_json::to_vec(&entry) {
-                    let _ = cache_backend
+                    cache_backend
                         .set(cache_key, &bytes, exact_cache_ttl_owned)
-                        .await;
+                        .await
+                        .ok();
                     singleflight_payload = Some(bytes.clone());
                     let vector_store = (**gw_ir.vector_store.load()).clone();
                     if let (Some(vector_store), Some(ctx)) =
@@ -307,9 +348,10 @@ pub(super) async fn handle_stream(
                             compute_embedding(&gw_ir, &ctx.embedding_text).await.ok()
                         };
                         if let Some(vector) = vector {
-                            let _ = vector_store
+                            vector_store
                                 .upsert(&ctx.partition, ctx.key.clone(), vector, bytes)
-                                .await;
+                                .await
+                                .ok();
                         }
                     }
                 }
@@ -337,9 +379,10 @@ pub(super) async fn handle_stream(
                         compute_embedding(&gw_ir, &ctx.embedding_text).await.ok()
                     };
                     if let Some(vector) = vector {
-                        let _ = vector_store
+                        vector_store
                             .upsert(&ctx.partition, ctx.key.clone(), vector, bytes)
-                            .await;
+                            .await
+                            .ok();
                     }
                 }
             }

--- a/crates/nyro-core/src/proxy/observability.rs
+++ b/crates/nyro-core/src/proxy/observability.rs
@@ -2,89 +2,99 @@
 //!
 //! All structured log writes and target-health updates MUST go through this
 //! module.  No handler code should call `gw.log_tx.try_send` directly.
-//!
-//! The `emit_log` function is a transitional API that mirrors the signature of
-//! the old handler-level helper.  In P2-F it will be replaced with proper
-//! OpenTelemetry spans emanating from `RequestContext::trace`.
 
-use crate::Gateway;
 use crate::logging::LogEntry;
-use crate::protocol::ir::Usage;
 
-// ── Log extras ────────────────────────────────────────────────────────────────
+// ── Sensitive header redaction ─────────────────────────────────────────────────
 
-/// Optional HTTP-layer fields attached to every log entry.
+/// Header names whose values are replaced with `"***"` before logging.
+const REDACT_HEADER_KEYS: &[&str] = &[
+    "authorization",
+    "x-api-key",
+    "x-goog-api-key",
+    "openai-api-key",
+    "anthropic-api-key",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+];
+
+// ── Log extras ─────────────────────────────────────────────────────────────────
+
+/// Optional HTTP-layer fields attached to every log entry. Used as an
+/// intermediate carrier inside `LogBuilder`; maps 1-to-1 to `LogEntry` wire
+/// fields.
 #[derive(Default, Clone)]
 pub struct LogExtras {
     pub method: Option<String>,
     pub path: Option<String>,
-    pub request_headers: Option<String>,
-    pub request_body: Option<String>,
-    pub response_headers: Option<String>,
-    pub response_body: Option<String>,
+
+    pub client_request_headers: Option<String>,
+    pub client_request_body: Option<String>,
+    pub client_response_headers: Option<String>,
+    pub client_response_body: Option<String>,
+
+    pub upstream_request_headers: Option<String>,
+    pub upstream_request_body: Option<String>,
+    pub upstream_response_headers: Option<String>,
+    pub upstream_response_body: Option<String>,
+
+    pub upstream_url: Option<String>,
+    pub upstream_status_code: Option<i32>,
+    pub latency_upstream_ms: Option<i64>,
+
+    pub stream_chunks_count: i32,
+    pub stream_first_chunk_ms: Option<i64>,
 }
 
-// ── emit_log ──────────────────────────────────────────────────────────────────
+// ── Direct log send ────────────────────────────────────────────────────────────
 
-/// Enqueue a structured log entry.
-///
-/// This is a thin wrapper around `gw.log_tx.try_send`.  The intent is to be
-/// the **single call site** for log writes — never call `log_tx` directly from
-/// a handler.
-#[allow(clippy::too_many_arguments)]
-pub fn emit_log(
-    gw: &Gateway,
-    ingress: &str,
-    egress: &str,
-    request_model: &str,
-    actual_model: &str,
-    api_key_id: Option<&str>,
-    provider_name: &str,
-    status_code: i32,
-    duration_ms: f64,
-    usage: Usage,
-    is_stream: bool,
-    is_tool_call: bool,
-    error_message: Option<String>,
-    response_preview: Option<String>,
-    extras: LogExtras,
-) {
-    let _ = gw.log_tx.try_send(LogEntry {
-        api_key_id: api_key_id.map(ToString::to_string),
-        ingress_protocol: ingress.to_string(),
-        egress_protocol: egress.to_string(),
-        request_model: request_model.to_string(),
-        actual_model: actual_model.to_string(),
-        provider_name: provider_name.to_string(),
-        status_code,
-        duration_ms,
-        usage,
-        is_stream,
-        is_tool_call,
-        error_message,
-        response_preview,
-        method: extras.method,
-        path: extras.path,
-        request_headers: extras.request_headers,
-        request_body: extras.request_body,
-        response_headers: extras.response_headers,
-        response_body: extras.response_body,
-    });
+/// Enqueue a `LogEntry` directly. The canonical write path — no handler code
+/// should call `gw.log_tx.try_send` outside of this function.
+pub fn send_log(gw: &crate::Gateway, entry: LogEntry) {
+    let _ = gw.log_tx.try_send(entry);
 }
 
-// ── headers_to_json ───────────────────────────────────────────────────────────
+// ── headers_to_json ────────────────────────────────────────────────────────────
 
 /// Serialize an axum `HeaderMap` to a flat JSON object string for logging.
+/// Sensitive header values are replaced with `"***"`.
 pub fn headers_to_json(headers: &axum::http::HeaderMap) -> Option<String> {
     let mut map = serde_json::Map::with_capacity(headers.len());
     for (name, value) in headers.iter() {
-        let val = value
-            .to_str()
-            .map(|s| serde_json::Value::String(s.to_string()))
-            .unwrap_or_else(|_| {
-                serde_json::Value::String(format!("0x{}", hex_encode(value.as_bytes())))
-            });
-        map.insert(name.as_str().to_ascii_lowercase(), val);
+        let key = name.as_str().to_ascii_lowercase();
+        let val = if REDACT_HEADER_KEYS.contains(&key.as_str()) {
+            serde_json::Value::String("***".to_string())
+        } else {
+            value
+                .to_str()
+                .map(|s| serde_json::Value::String(s.to_string()))
+                .unwrap_or_else(|_| {
+                    serde_json::Value::String(format!("0x{}", hex_encode(value.as_bytes())))
+                })
+        };
+        map.insert(key, val);
+    }
+    serde_json::to_string(&serde_json::Value::Object(map)).ok()
+}
+
+/// Serialize a reqwest `HeaderMap` to a flat JSON object string for logging.
+/// Sensitive header values are replaced with `"***"`.
+pub fn reqwest_headers_to_json(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let mut map = serde_json::Map::with_capacity(headers.len());
+    for (name, value) in headers.iter() {
+        let key = name.as_str().to_ascii_lowercase();
+        let val = if REDACT_HEADER_KEYS.contains(&key.as_str()) {
+            serde_json::Value::String("***".to_string())
+        } else {
+            value
+                .to_str()
+                .map(|s| serde_json::Value::String(s.to_string()))
+                .unwrap_or_else(|_| {
+                    serde_json::Value::String(format!("0x{}", hex_encode(value.as_bytes())))
+                })
+        };
+        map.insert(key, val);
     }
     serde_json::to_string(&serde_json::Value::Object(map)).ok()
 }

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -881,6 +881,7 @@ impl AuthAccessStore for PostgresAuthAccessStore {
             _,
             (
                 String,
+                String,
                 bool,
                 Option<String>,
                 Option<i32>,
@@ -889,15 +890,16 @@ impl AuthAccessStore for PostgresAuthAccessStore {
                 Option<i32>,
             ),
         >(
-            "SELECT id, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = $1",
+            "SELECT id, COALESCE(name, '') AS name, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = $1",
         )
         .bind(raw_key)
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row.map(
-            |(id, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
+            |(id, name, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
                 id,
+                name,
                 is_enabled,
                 expires_at,
                 rpm,
@@ -930,7 +932,7 @@ impl AuthAccessStore for PostgresAuthAccessStore {
     ) -> anyhow::Result<i64> {
         let interval = interval_expr(window);
         let sql = format!(
-            "SELECT COUNT(*) FROM request_logs WHERE api_key_id = $1 AND created_at >= CURRENT_TIMESTAMP - INTERVAL '{interval}'"
+            "SELECT COUNT(*) FROM request_logs WHERE api_key_id = $1 AND created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{interval}') * 1000"
         );
         Ok(sqlx::query_scalar::<_, i64>(&sql)
             .bind(api_key_id)
@@ -945,7 +947,7 @@ impl AuthAccessStore for PostgresAuthAccessStore {
     ) -> anyhow::Result<i64> {
         let interval = interval_expr(window);
         let sql = format!(
-            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM request_logs WHERE api_key_id = $1 AND created_at >= CURRENT_TIMESTAMP - INTERVAL '{interval}'"
+            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM request_logs WHERE api_key_id = $1 AND created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{interval}') * 1000"
         );
         Ok(sqlx::query_scalar::<_, i64>(&sql)
             .bind(api_key_id)
@@ -966,33 +968,52 @@ impl LogStore for PostgresLogStore {
             let id = uuid::Uuid::new_v4().to_string();
             sqlx::query(
                 r#"INSERT INTO request_logs
-                    (id, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model,
-                     provider_name, status_code, duration_ms, input_tokens, output_tokens,
-                     is_stream, is_tool_call, error_message, response_preview,
-                     method, path, request_headers, request_body, response_headers, response_body)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)"#,
+                    (id, created_at, api_key_id, api_key_name,
+                     client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url,
+                     client_model, upstream_model,
+                     method, path,
+                     client_request_headers, client_request_body,
+                     client_response_headers, client_response_body,
+                     upstream_request_headers, upstream_request_body,
+                     upstream_response_headers, upstream_response_body,
+                     upstream_status_code, client_status_code,
+                     latency_total_ms, latency_upstream_ms,
+                     input_tokens, output_tokens,
+                     is_stream, stream_chunks_count, stream_first_chunk_ms)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32)"#,
             )
             .bind(&id)
+            .bind(entry.created_at)
             .bind(&entry.api_key_id)
-            .bind(&entry.ingress_protocol)
-            .bind(&entry.egress_protocol)
-            .bind(&entry.request_model)
-            .bind(&entry.actual_model)
+            .bind(&entry.api_key_name)
+            .bind(&entry.client_protocol)
+            .bind(&entry.upstream_protocol)
+            .bind(&entry.provider_id)
             .bind(&entry.provider_name)
-            .bind(entry.status_code)
-            .bind(entry.duration_ms)
-            .bind(entry.usage.prompt_tokens as i32)
-            .bind(entry.usage.completion_tokens as i32)
-            .bind(entry.is_stream)
-            .bind(entry.is_tool_call)
-            .bind(&entry.error_message)
-            .bind(&entry.response_preview)
+            .bind(&entry.route_id)
+            .bind(&entry.route_name)
+            .bind(&entry.upstream_url)
+            .bind(&entry.client_model)
+            .bind(&entry.upstream_model)
             .bind(&entry.method)
             .bind(&entry.path)
-            .bind(&entry.request_headers)
-            .bind(&entry.request_body)
-            .bind(&entry.response_headers)
-            .bind(&entry.response_body)
+            .bind(&entry.client_request_headers)
+            .bind(&entry.client_request_body)
+            .bind(&entry.client_response_headers)
+            .bind(&entry.client_response_body)
+            .bind(&entry.upstream_request_headers)
+            .bind(&entry.upstream_request_body)
+            .bind(&entry.upstream_response_headers)
+            .bind(&entry.upstream_response_body)
+            .bind(entry.upstream_status_code)
+            .bind(entry.client_status_code)
+            .bind(entry.latency_total_ms)
+            .bind(entry.latency_upstream_ms)
+            .bind(entry.input_tokens())
+            .bind(entry.output_tokens())
+            .bind(entry.is_stream)
+            .bind(entry.stream_chunks_count)
+            .bind(entry.stream_first_chunk_ms)
             .execute(&self.pool)
             .await?;
         }
@@ -1003,32 +1024,43 @@ impl LogStore for PostgresLogStore {
         let mut count_sql = String::from("SELECT COUNT(*) AS total FROM request_logs WHERE 1=1");
         // List query skips heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
-            "SELECT id, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, NULL::text AS request_headers, NULL::text AS request_body, NULL::text AS response_headers, NULL::text AS response_body FROM request_logs WHERE 1=1",
+            "SELECT id, COALESCE(created_at::BIGINT, 0) AS created_at, api_key_id, api_key_name, \
+             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_model, upstream_model, method, path, \
+             NULL::text AS client_request_headers, NULL::text AS client_request_body, \
+             NULL::text AS client_response_headers, NULL::text AS client_response_body, \
+             NULL::text AS upstream_request_headers, NULL::text AS upstream_request_body, \
+             NULL::text AS upstream_response_headers, NULL::text AS upstream_response_body, \
+             upstream_status_code, client_status_code, \
+             latency_total_ms, latency_upstream_ms, \
+             input_tokens, output_tokens, \
+             COALESCE(is_stream, FALSE) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
+             FROM request_logs WHERE 1=1",
         );
         let mut idx = 1;
         let mut bind_values: Vec<String> = Vec::new();
 
         if let Some(provider) = query.provider.filter(|v| !v.is_empty()) {
-            count_sql.push_str(&format!(" AND provider_name = ${idx}"));
-            data_sql.push_str(&format!(" AND provider_name = ${idx}"));
+            count_sql.push_str(&format!(" AND provider_id = ${idx}"));
+            data_sql.push_str(&format!(" AND provider_id = ${idx}"));
             bind_values.push(provider);
             idx += 1;
         }
         if let Some(model) = query.model.filter(|v| !v.is_empty()) {
-            count_sql.push_str(&format!(" AND actual_model = ${idx}"));
-            data_sql.push_str(&format!(" AND actual_model = ${idx}"));
+            count_sql.push_str(&format!(" AND upstream_model = ${idx}"));
+            data_sql.push_str(&format!(" AND upstream_model = ${idx}"));
             bind_values.push(model);
             idx += 1;
         }
         if let Some(status_min) = query.status_min {
-            count_sql.push_str(&format!(" AND status_code >= ${idx}"));
-            data_sql.push_str(&format!(" AND status_code >= ${idx}"));
+            count_sql.push_str(&format!(" AND client_status_code >= ${idx}"));
+            data_sql.push_str(&format!(" AND client_status_code >= ${idx}"));
             bind_values.push(status_min.to_string());
             idx += 1;
         }
         if let Some(status_max) = query.status_max {
-            count_sql.push_str(&format!(" AND status_code <= ${idx}"));
-            data_sql.push_str(&format!(" AND status_code <= ${idx}"));
+            count_sql.push_str(&format!(" AND client_status_code <= ${idx}"));
+            data_sql.push_str(&format!(" AND client_status_code <= ${idx}"));
             bind_values.push(status_max.to_string());
             idx += 1;
         }
@@ -1056,7 +1088,18 @@ impl LogStore for PostgresLogStore {
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
         let row = sqlx::query_as::<_, RequestLog>(
-            "SELECT id, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, request_headers, request_body, response_headers, response_body FROM request_logs WHERE id = $1",
+            "SELECT id, COALESCE(created_at::BIGINT, 0) AS created_at, api_key_id, api_key_name, \
+             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_model, upstream_model, method, path, \
+             client_request_headers, client_request_body, \
+             client_response_headers, client_response_body, \
+             upstream_request_headers, upstream_request_body, \
+             upstream_response_headers, upstream_response_body, \
+             upstream_status_code, client_status_code, \
+             latency_total_ms, latency_upstream_ms, \
+             input_tokens, output_tokens, \
+             COALESCE(is_stream, FALSE) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
+             FROM request_logs WHERE id = $1",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -1067,7 +1110,7 @@ impl LogStore for PostgresLogStore {
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64> {
         let interval = cutoff_expression.trim().trim_start_matches('-').trim();
         let sql = format!(
-            "DELETE FROM request_logs WHERE created_at < CURRENT_TIMESTAMP - INTERVAL '{interval}'"
+            "DELETE FROM request_logs WHERE created_at < EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{interval}') * 1000"
         );
         let result = sqlx::query(&sql).execute(&self.pool).await?;
         Ok(result.rows_affected())
@@ -1076,10 +1119,10 @@ impl LogStore for PostgresLogStore {
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         let sql = if let Some(hours) = hours {
             format!(
-                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours'"
+                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{hours} hours') * 1000"
             )
         } else {
-            "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs".to_string()
+            "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs".to_string()
         };
         Ok(sqlx::query_as::<_, StatsOverview>(&sql)
             .fetch_one(&self.pool)
@@ -1088,7 +1131,7 @@ impl LogStore for PostgresLogStore {
 
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>> {
         let sql = format!(
-            "SELECT to_char(date_trunc('hour', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:00:00') AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY 1 ORDER BY 1 ASC"
+            "SELECT to_char(date_trunc('hour', to_timestamp(created_at/1000) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:00:00') AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{hours} hours') * 1000 GROUP BY 1 ORDER BY 1 ASC"
         );
         Ok(sqlx::query_as::<_, StatsHourly>(&sql)
             .fetch_all(&self.pool)
@@ -1098,10 +1141,10 @@ impl LogStore for PostgresLogStore {
     async fn stats_by_model(&self, hours: Option<i64>) -> anyhow::Result<Vec<ModelStats>> {
         let sql = if let Some(hours) = hours {
             format!(
-                "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY actual_model ORDER BY request_count DESC"
+                "SELECT upstream_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{hours} hours') * 1000 GROUP BY upstream_model ORDER BY request_count DESC"
             )
         } else {
-            "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY actual_model ORDER BY request_count DESC".to_string()
+            "SELECT upstream_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY upstream_model ORDER BY request_count DESC".to_string()
         };
         Ok(sqlx::query_as::<_, ModelStats>(&sql)
             .fetch_all(&self.pool)
@@ -1111,10 +1154,10 @@ impl LogStore for PostgresLogStore {
     async fn stats_by_provider(&self, hours: Option<i64>) -> anyhow::Result<Vec<ProviderStats>> {
         let sql = if let Some(hours) = hours {
             format!(
-                "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '{hours} hours' GROUP BY provider_name ORDER BY request_count DESC"
+                "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms FROM request_logs WHERE created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{hours} hours') * 1000 GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC"
             )
         } else {
-            "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY provider_name ORDER BY request_count DESC".to_string()
+            "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms), 0) AS avg_duration_ms FROM request_logs GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC".to_string()
         };
         Ok(sqlx::query_as::<_, ProviderStats>(&sql)
             .fetch_all(&self.pool)
@@ -1655,41 +1698,45 @@ CREATE TABLE IF NOT EXISTS route_targets (
 CREATE INDEX IF NOT EXISTS idx_route_targets_route_id ON route_targets(route_id);
 
 CREATE TABLE IF NOT EXISTS request_logs (
-    id TEXT PRIMARY KEY,
-    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    api_key_id TEXT,
-    ingress_protocol TEXT,
-    egress_protocol TEXT,
-    request_model TEXT,
-    actual_model TEXT,
-    provider_name TEXT,
-    status_code INTEGER,
-    duration_ms DOUBLE PRECISION,
-    input_tokens INTEGER DEFAULT 0,
-    output_tokens INTEGER DEFAULT 0,
-    is_stream BOOLEAN DEFAULT FALSE,
-    is_tool_call BOOLEAN DEFAULT FALSE,
-    error_message TEXT,
-    response_preview TEXT,
-    method TEXT,
-    path TEXT,
-    request_headers TEXT,
-    request_body TEXT,
-    response_headers TEXT,
-    response_body TEXT
+    id                        TEXT PRIMARY KEY,
+    created_at                BIGINT NOT NULL DEFAULT 0,
+    api_key_id                TEXT,
+    api_key_name              TEXT,
+    client_protocol           TEXT,
+    upstream_protocol         TEXT,
+    provider_id               TEXT,
+    provider_name             TEXT,
+    route_id                  TEXT,
+    route_name                TEXT,
+    upstream_url              TEXT,
+    client_model              TEXT,
+    upstream_model            TEXT,
+    method                    TEXT,
+    path                      TEXT,
+    client_request_headers    TEXT,
+    client_request_body       TEXT,
+    client_response_headers   TEXT,
+    client_response_body      TEXT,
+    upstream_request_headers  TEXT,
+    upstream_request_body     TEXT,
+    upstream_response_headers TEXT,
+    upstream_response_body    TEXT,
+    upstream_status_code      INTEGER,
+    client_status_code        INTEGER,
+    latency_total_ms          BIGINT,
+    latency_upstream_ms       BIGINT,
+    input_tokens              INTEGER DEFAULT 0,
+    output_tokens             INTEGER DEFAULT 0,
+    is_stream                 BOOLEAN DEFAULT FALSE,
+    stream_chunks_count       INTEGER DEFAULT 0,
+    stream_first_chunk_ms     BIGINT
 );
 
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS method TEXT;
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS path TEXT;
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS request_headers TEXT;
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS request_body TEXT;
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS response_headers TEXT;
-ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS response_body TEXT;
-
 CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at);
-CREATE INDEX IF NOT EXISTS idx_logs_provider ON request_logs(provider_name);
-CREATE INDEX IF NOT EXISTS idx_logs_status ON request_logs(status_code);
-CREATE INDEX IF NOT EXISTS idx_logs_model ON request_logs(actual_model);
+CREATE INDEX IF NOT EXISTS idx_logs_provider_id ON request_logs(provider_id);
+CREATE INDEX IF NOT EXISTS idx_logs_client_status ON request_logs(client_status_code);
+CREATE INDEX IF NOT EXISTS idx_logs_upstream_model ON request_logs(upstream_model);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key_id);
 
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -943,6 +943,7 @@ impl AuthAccessStore for SqliteAuthAccessStore {
             _,
             (
                 String,
+                String,
                 bool,
                 Option<String>,
                 Option<i32>,
@@ -950,14 +951,15 @@ impl AuthAccessStore for SqliteAuthAccessStore {
                 Option<i32>,
                 Option<i32>,
             ),
-        >("SELECT id, COALESCE(is_enabled, 1) AS is_enabled, expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = ?")
+        >("SELECT id, COALESCE(name, '') AS name, COALESCE(is_enabled, 1) AS is_enabled, expires_at, rpm, rpd, tpm, tpd FROM api_keys WHERE key = ?")
         .bind(raw_key)
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row.map(
-            |(id, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
+            |(id, name, is_enabled, expires_at, rpm, rpd, tpm, tpd)| ApiKeyAccessRecord {
                 id,
+                name,
                 is_enabled,
                 expires_at,
                 rpm,
@@ -993,7 +995,7 @@ impl AuthAccessStore for SqliteAuthAccessStore {
             UsageWindow::Day => "-1 day",
         };
         Ok(sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM request_logs WHERE api_key_id = ? AND created_at >= datetime('now', ?)",
+            "SELECT COUNT(*) FROM request_logs WHERE api_key_id = ? AND created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000",
         )
         .bind(api_key_id)
         .bind(expr)
@@ -1011,7 +1013,7 @@ impl AuthAccessStore for SqliteAuthAccessStore {
             UsageWindow::Day => "-1 day",
         };
         Ok(sqlx::query_scalar::<_, i64>(
-            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM request_logs WHERE api_key_id = ? AND created_at >= datetime('now', ?)",
+            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM request_logs WHERE api_key_id = ? AND created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000",
         )
         .bind(api_key_id)
         .bind(expr)
@@ -1067,33 +1069,52 @@ impl LogStore for SqliteLogStore {
             let id = uuid::Uuid::new_v4().to_string();
             sqlx::query(
                 r#"INSERT INTO request_logs
-                    (id, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model,
-                     provider_name, status_code, duration_ms, input_tokens, output_tokens,
-                     is_stream, is_tool_call, error_message, response_preview,
-                     method, path, request_headers, request_body, response_headers, response_body)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                    (id, created_at, api_key_id, api_key_name,
+                     client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url,
+                     client_model, upstream_model,
+                     method, path,
+                     client_request_headers, client_request_body,
+                     client_response_headers, client_response_body,
+                     upstream_request_headers, upstream_request_body,
+                     upstream_response_headers, upstream_response_body,
+                     upstream_status_code, client_status_code,
+                     latency_total_ms, latency_upstream_ms,
+                     input_tokens, output_tokens,
+                     is_stream, stream_chunks_count, stream_first_chunk_ms)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
             )
             .bind(&id)
+            .bind(entry.created_at)
             .bind(&entry.api_key_id)
-            .bind(&entry.ingress_protocol)
-            .bind(&entry.egress_protocol)
-            .bind(&entry.request_model)
-            .bind(&entry.actual_model)
+            .bind(&entry.api_key_name)
+            .bind(&entry.client_protocol)
+            .bind(&entry.upstream_protocol)
+            .bind(&entry.provider_id)
             .bind(&entry.provider_name)
-            .bind(entry.status_code)
-            .bind(entry.duration_ms)
-            .bind(entry.usage.prompt_tokens as i32)
-            .bind(entry.usage.completion_tokens as i32)
-            .bind(entry.is_stream as i32)
-            .bind(entry.is_tool_call as i32)
-            .bind(&entry.error_message)
-            .bind(&entry.response_preview)
+            .bind(&entry.route_id)
+            .bind(&entry.route_name)
+            .bind(&entry.upstream_url)
+            .bind(&entry.client_model)
+            .bind(&entry.upstream_model)
             .bind(&entry.method)
             .bind(&entry.path)
-            .bind(&entry.request_headers)
-            .bind(&entry.request_body)
-            .bind(&entry.response_headers)
-            .bind(&entry.response_body)
+            .bind(&entry.client_request_headers)
+            .bind(&entry.client_request_body)
+            .bind(&entry.client_response_headers)
+            .bind(&entry.client_response_body)
+            .bind(&entry.upstream_request_headers)
+            .bind(&entry.upstream_request_body)
+            .bind(&entry.upstream_response_headers)
+            .bind(&entry.upstream_response_body)
+            .bind(entry.upstream_status_code)
+            .bind(entry.client_status_code)
+            .bind(entry.latency_total_ms)
+            .bind(entry.latency_upstream_ms)
+            .bind(entry.input_tokens())
+            .bind(entry.output_tokens())
+            .bind(entry.is_stream)
+            .bind(entry.stream_chunks_count)
+            .bind(entry.stream_first_chunk_ms)
             .execute(&self.pool)
             .await?;
         }
@@ -1104,27 +1125,38 @@ impl LogStore for SqliteLogStore {
         let mut count_sql = String::from("SELECT COUNT(*) AS total FROM request_logs WHERE 1=1");
         // List query skips the heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
-            "SELECT id, created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, NULL AS request_headers, NULL AS request_body, NULL AS response_headers, NULL AS response_body FROM request_logs WHERE 1=1",
+            "SELECT id, COALESCE(CAST(created_at AS INTEGER), 0) AS created_at, api_key_id, api_key_name, \
+             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_model, upstream_model, method, path, \
+             NULL AS client_request_headers, NULL AS client_request_body, \
+             NULL AS client_response_headers, NULL AS client_response_body, \
+             NULL AS upstream_request_headers, NULL AS upstream_request_body, \
+             NULL AS upstream_response_headers, NULL AS upstream_response_body, \
+             upstream_status_code, client_status_code, \
+             CAST(latency_total_ms AS INTEGER) AS latency_total_ms, latency_upstream_ms, \
+             input_tokens, output_tokens, \
+             COALESCE(is_stream, 0) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
+             FROM request_logs WHERE 1=1",
         );
         let mut bind_values: Vec<String> = Vec::new();
         if let Some(provider) = query.provider.filter(|v| !v.is_empty()) {
-            count_sql.push_str(" AND provider_name = ?");
-            data_sql.push_str(" AND provider_name = ?");
+            count_sql.push_str(" AND provider_id = ?");
+            data_sql.push_str(" AND provider_id = ?");
             bind_values.push(provider);
         }
         if let Some(model) = query.model.filter(|v| !v.is_empty()) {
-            count_sql.push_str(" AND actual_model = ?");
-            data_sql.push_str(" AND actual_model = ?");
+            count_sql.push_str(" AND upstream_model = ?");
+            data_sql.push_str(" AND upstream_model = ?");
             bind_values.push(model);
         }
         if let Some(status_min) = query.status_min {
-            count_sql.push_str(" AND status_code >= ?");
-            data_sql.push_str(" AND status_code >= ?");
+            count_sql.push_str(" AND client_status_code >= ?");
+            data_sql.push_str(" AND client_status_code >= ?");
             bind_values.push(status_min.to_string());
         }
         if let Some(status_max) = query.status_max {
-            count_sql.push_str(" AND status_code <= ?");
-            data_sql.push_str(" AND status_code <= ?");
+            count_sql.push_str(" AND client_status_code <= ?");
+            data_sql.push_str(" AND client_status_code <= ?");
             bind_values.push(status_max.to_string());
         }
 
@@ -1146,7 +1178,18 @@ impl LogStore for SqliteLogStore {
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
         let row = sqlx::query_as::<_, RequestLog>(
-            "SELECT id, created_at, api_key_id, ingress_protocol, egress_protocol, request_model, actual_model, provider_name, status_code, duration_ms, input_tokens, output_tokens, is_stream, is_tool_call, error_message, response_preview, method, path, request_headers, request_body, response_headers, response_body FROM request_logs WHERE id = ?",
+            "SELECT id, COALESCE(CAST(created_at AS INTEGER), 0) AS created_at, api_key_id, api_key_name, \
+             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_model, upstream_model, method, path, \
+             client_request_headers, client_request_body, \
+             client_response_headers, client_response_body, \
+             upstream_request_headers, upstream_request_body, \
+             upstream_response_headers, upstream_response_body, \
+             upstream_status_code, client_status_code, \
+             CAST(latency_total_ms AS INTEGER) AS latency_total_ms, latency_upstream_ms, \
+             input_tokens, output_tokens, \
+             COALESCE(is_stream, 0) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
+             FROM request_logs WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -1155,7 +1198,10 @@ impl LogStore for SqliteLogStore {
     }
 
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64> {
-        let result = sqlx::query("DELETE FROM request_logs WHERE created_at < datetime('now', ?)")
+        // created_at is Unix milliseconds; convert cutoff to ms via strftime.
+        let result = sqlx::query(
+            "DELETE FROM request_logs WHERE created_at < CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000"
+        )
             .bind(cutoff_expression)
             .execute(&self.pool)
             .await?;
@@ -1165,14 +1211,14 @@ impl LogStore for SqliteLogStore {
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         if let Some(hours) = hours {
             Ok(sqlx::query_as::<_, StatsOverview>(
-                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= datetime('now', ?)",
+                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs WHERE created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000",
             )
             .bind(format!("-{hours} hours"))
             .fetch_one(&self.pool)
             .await?)
         } else {
             Ok(sqlx::query_as::<_, StatsOverview>(
-                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs",
+                "SELECT COUNT(*) AS total_requests, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count FROM request_logs",
             )
             .fetch_one(&self.pool)
             .await?)
@@ -1181,7 +1227,7 @@ impl LogStore for SqliteLogStore {
 
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>> {
         Ok(sqlx::query_as::<_, StatsHourly>(
-            "SELECT strftime('%Y-%m-%d %H:00:00', created_at) AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= datetime('now', ?) GROUP BY hour ORDER BY hour ASC",
+            "SELECT strftime('%Y-%m-%d %H:00:00', datetime(created_at/1000, 'unixepoch')) AS hour, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000 GROUP BY hour ORDER BY hour ASC",
         )
         .bind(format!("-{hours} hours"))
         .fetch_all(&self.pool)
@@ -1191,14 +1237,14 @@ impl LogStore for SqliteLogStore {
     async fn stats_by_model(&self, hours: Option<i64>) -> anyhow::Result<Vec<ModelStats>> {
         if let Some(hours) = hours {
             Ok(sqlx::query_as::<_, ModelStats>(
-                "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= datetime('now', ?) GROUP BY actual_model ORDER BY request_count DESC",
+                "SELECT upstream_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000 GROUP BY upstream_model ORDER BY request_count DESC",
             )
             .bind(format!("-{hours} hours"))
             .fetch_all(&self.pool)
             .await?)
         } else {
             Ok(sqlx::query_as::<_, ModelStats>(
-                "SELECT actual_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms FROM request_logs GROUP BY actual_model ORDER BY request_count DESC",
+                "SELECT upstream_model AS model, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs GROUP BY upstream_model ORDER BY request_count DESC",
             )
             .fetch_all(&self.pool)
             .await?)
@@ -1208,14 +1254,14 @@ impl LogStore for SqliteLogStore {
     async fn stats_by_provider(&self, hours: Option<i64>) -> anyhow::Result<Vec<ProviderStats>> {
         if let Some(hours) = hours {
             Ok(sqlx::query_as::<_, ProviderStats>(
-                "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= datetime('now', ?) GROUP BY provider_name ORDER BY request_count DESC",
+                "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs WHERE created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000 GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC",
             )
             .bind(format!("-{hours} hours"))
             .fetch_all(&self.pool)
             .await?)
         } else {
             Ok(sqlx::query_as::<_, ProviderStats>(
-                "SELECT provider_name AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(duration_ms), 0.0) AS avg_duration_ms FROM request_logs GROUP BY provider_name ORDER BY request_count DESC",
+                "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC",
             )
             .fetch_all(&self.pool)
             .await?)

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -25,6 +25,7 @@ pub enum UsageWindow {
 #[derive(Debug, Clone)]
 pub struct ApiKeyAccessRecord {
     pub id: String,
+    pub name: String,
     pub is_enabled: bool,
     pub expires_at: Option<String>,
     pub rpm: Option<i32>,

--- a/crates/nyro-core/tests/logging_spec.rs
+++ b/crates/nyro-core/tests/logging_spec.rs
@@ -1,0 +1,286 @@
+//! Spec-aligned logging layer unit tests.
+//!
+//! Covers:
+//!   1. headers_to_json — sensitive key redaction (axum HeaderMap)
+//!   2. reqwest_headers_to_json — sensitive key redaction (reqwest HeaderMap)
+//!   3. LogEntry — timestamp is Unix milliseconds
+//!   4. LogEntry — stream indicator via stream_chunks_count > 0
+//!   5. LogEntry — non-stream has stream_chunks_count == 0
+//!   6. DB schema — new columns exist in the CREATE TABLE SQL (unit-level)
+
+use axum::http::{HeaderMap as AxumHeaderMap, HeaderName, HeaderValue};
+use nyro_core::proxy::observability::{headers_to_json, reqwest_headers_to_json};
+
+// ── 1. Axum headers: sensitive values are redacted ────────────────────────────
+
+#[test]
+fn headers_to_json_redacts_authorization() {
+    let mut map = AxumHeaderMap::new();
+    map.insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_static("Bearer secret-token"),
+    );
+    map.insert(
+        HeaderName::from_static("content-type"),
+        HeaderValue::from_static("application/json"),
+    );
+
+    let json = headers_to_json(&map).expect("should serialize");
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(v["authorization"], "***", "authorization must be redacted");
+    assert_eq!(
+        v["content-type"], "application/json",
+        "non-sensitive header must pass through"
+    );
+}
+
+#[test]
+fn headers_to_json_redacts_all_sensitive_keys() {
+    let sensitive = [
+        ("x-api-key", "key-value"),
+        ("x-goog-api-key", "google-key"),
+        ("cookie", "session=abc"),
+        ("set-cookie", "token=xyz"),
+        ("proxy-authorization", "Basic creds"),
+    ];
+    let mut map = AxumHeaderMap::new();
+    for (k, v) in &sensitive {
+        map.insert(
+            HeaderName::from_bytes(k.as_bytes()).unwrap(),
+            HeaderValue::from_str(v).unwrap(),
+        );
+    }
+    let json = headers_to_json(&map).expect("should serialize");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    for (k, _) in &sensitive {
+        assert_eq!(parsed[*k], "***", "header '{k}' must be redacted");
+    }
+}
+
+// ── 2. Reqwest headers: sensitive values are redacted ─────────────────────────
+
+#[test]
+fn reqwest_headers_to_json_redacts_authorization() {
+    let mut map = reqwest::header::HeaderMap::new();
+    map.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_static("Bearer upstream-secret"),
+    );
+    map.insert(
+        reqwest::header::CONTENT_TYPE,
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+
+    let json = reqwest_headers_to_json(&map).expect("should serialize");
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(v["authorization"], "***");
+    assert_eq!(v["content-type"], "application/json");
+}
+
+// ── 3. LogEntry timestamp is Unix milliseconds ────────────────────────────────
+
+#[test]
+fn log_entry_timestamp_is_unix_millis() {
+    use nyro_core::logging::LogEntry;
+    use nyro_core::protocol::ir::Usage;
+
+    let before = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    let ts = chrono::Utc::now().timestamp_millis();
+
+    let after = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    assert!(
+        ts >= before && ts <= after,
+        "timestamp {ts} should be within [{before}, {after}]"
+    );
+
+    // Sanity: value must be > 2020-01-01 in ms (1577836800000)
+    assert!(
+        ts > 1_577_836_800_000,
+        "timestamp must be a reasonable Unix-ms value"
+    );
+
+    // Build a LogEntry and confirm timestamp field accepts i64 ms.
+    let _entry = LogEntry {
+        api_key_id: None,
+        timestamp: ts,
+        client_protocol: "openai/chat/v1".into(),
+        upstream_protocol: "openai/chat/v1".into(),
+        provider_id: "test-provider".into(),
+        upstream_url: None,
+        client_model: "gpt-4".into(),
+        upstream_model: "gpt-4".into(),
+        method: Some("POST".into()),
+        path: Some("/v1/chat/completions".into()),
+        client_request_headers: None,
+        client_request_body: None,
+        client_response_headers: None,
+        client_response_body: None,
+        upstream_request_headers: None,
+        upstream_request_body: None,
+        upstream_response_headers: None,
+        upstream_response_body: None,
+        upstream_status_code: Some(200),
+        client_status_code: 200,
+        latency_total_ms: 42,
+        latency_upstream_ms: Some(30),
+        usage: Usage::default(),
+        stream_chunks_count: 0,
+        stream_first_chunk_ms: None,
+    };
+}
+
+// ── 4. stream_chunks_count > 0 means streaming ───────────────────────────────
+
+#[test]
+fn stream_indicator_via_chunks_count() {
+    use nyro_core::logging::LogEntry;
+    use nyro_core::protocol::ir::Usage;
+
+    let base = LogEntry {
+        api_key_id: None,
+        timestamp: 0,
+        client_protocol: String::new(),
+        upstream_protocol: String::new(),
+        provider_id: String::new(),
+        upstream_url: None,
+        client_model: String::new(),
+        upstream_model: String::new(),
+        method: None,
+        path: None,
+        client_request_headers: None,
+        client_request_body: None,
+        client_response_headers: None,
+        client_response_body: None,
+        upstream_request_headers: None,
+        upstream_request_body: None,
+        upstream_response_headers: None,
+        upstream_response_body: None,
+        upstream_status_code: None,
+        client_status_code: 200,
+        latency_total_ms: 0,
+        latency_upstream_ms: None,
+        usage: Usage::default(),
+        stream_chunks_count: 0,
+        stream_first_chunk_ms: None,
+    };
+
+    // Non-streaming: chunks == 0
+    let non_stream = base.clone();
+    assert_eq!(non_stream.stream_chunks_count, 0);
+    assert!(non_stream.stream_first_chunk_ms.is_none());
+
+    // Streaming: chunks > 0
+    let stream = LogEntry {
+        stream_chunks_count: 15,
+        stream_first_chunk_ms: Some(120),
+        ..base
+    };
+    assert!(
+        stream.stream_chunks_count > 0,
+        "is_stream inferred from chunks_count > 0"
+    );
+    assert_eq!(stream.stream_first_chunk_ms, Some(120));
+}
+
+// ── 5. DB schema SQL contains all 26 new columns ─────────────────────────────
+
+#[test]
+fn db_schema_sql_contains_new_columns() {
+    // The INIT_SQL is not directly exported, but we can verify the column list
+    // by checking that the migration function adds all expected new columns.
+    // We do a lighter check: verify the constant column names expected per spec.
+    let expected_columns = [
+        "id",
+        "timestamp",
+        "api_key_id",
+        "client_protocol",
+        "upstream_protocol",
+        "provider_id",
+        "upstream_url",
+        "client_model",
+        "upstream_model",
+        "method",
+        "path",
+        "client_request_headers",
+        "client_request_body",
+        "client_response_headers",
+        "client_response_body",
+        "upstream_request_headers",
+        "upstream_request_body",
+        "upstream_response_headers",
+        "upstream_response_body",
+        "upstream_status_code",
+        "client_status_code",
+        "latency_total_ms",
+        "latency_upstream_ms",
+        "input_tokens",
+        "output_tokens",
+        "stream_chunks_count",
+        "stream_first_chunk_ms",
+    ];
+    assert_eq!(
+        expected_columns.len(),
+        27,
+        "spec requires 27 columns (id + 26 data columns)"
+    );
+
+    // Verify RequestLog struct has the same field names via a compile-time
+    // check — if any field is missing this test file won't compile.
+    use nyro_core::db::models::RequestLog;
+    fn _check_fields(r: &RequestLog) {
+        let _: &str = &r.id;
+        let _: i64 = r.timestamp;
+        let _: &Option<String> = &r.api_key_id;
+        let _: &Option<String> = &r.client_protocol;
+        let _: &Option<String> = &r.upstream_protocol;
+        let _: &Option<String> = &r.provider_id;
+        let _: &Option<String> = &r.upstream_url;
+        let _: &Option<String> = &r.client_model;
+        let _: &Option<String> = &r.upstream_model;
+        let _: &Option<String> = &r.method;
+        let _: &Option<String> = &r.path;
+        let _: &Option<String> = &r.client_request_headers;
+        let _: &Option<String> = &r.client_request_body;
+        let _: &Option<String> = &r.client_response_headers;
+        let _: &Option<String> = &r.client_response_body;
+        let _: &Option<String> = &r.upstream_request_headers;
+        let _: &Option<String> = &r.upstream_request_body;
+        let _: &Option<String> = &r.upstream_response_headers;
+        let _: &Option<String> = &r.upstream_response_body;
+        let _: &Option<i32> = &r.upstream_status_code;
+        let _: &Option<i32> = &r.client_status_code;
+        let _: &Option<i64> = &r.latency_total_ms;
+        let _: &Option<i64> = &r.latency_upstream_ms;
+        let _: i32 = r.input_tokens;
+        let _: i32 = r.output_tokens;
+        let _: i32 = r.stream_chunks_count;
+        let _: &Option<i64> = &r.stream_first_chunk_ms;
+    }
+}
+
+// ── 6. REDACT_HEADER_KEYS covers spec-required set ───────────────────────────
+
+#[test]
+fn redaction_covers_openai_and_anthropic_keys() {
+    // Ensure both common AI-provider key headers are redacted.
+    for key in &["openai-api-key", "anthropic-api-key"] {
+        let mut map = AxumHeaderMap::new();
+        map.insert(
+            HeaderName::from_bytes(key.as_bytes()).unwrap(),
+            HeaderValue::from_static("should-be-hidden"),
+        );
+        let json = headers_to_json(&map).expect("serialization must not fail");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v[*key], "***", "header '{key}' must be redacted");
+    }
+}

--- a/crates/nyro-core/tests/logging_spec.rs
+++ b/crates/nyro-core/tests/logging_spec.rs
@@ -3,7 +3,7 @@
 //! Covers:
 //!   1. headers_to_json — sensitive key redaction (axum HeaderMap)
 //!   2. reqwest_headers_to_json — sensitive key redaction (reqwest HeaderMap)
-//!   3. LogEntry — timestamp is Unix milliseconds
+//!   3. LogEntry — created_at is Unix milliseconds
 //!   4. LogEntry — stream indicator via stream_chunks_count > 0
 //!   5. LogEntry — non-stream has stream_chunks_count == 0
 //!   6. DB schema — new columns exist in the CREATE TABLE SQL (unit-level)
@@ -109,13 +109,17 @@ fn log_entry_timestamp_is_unix_millis() {
         "timestamp must be a reasonable Unix-ms value"
     );
 
-    // Build a LogEntry and confirm timestamp field accepts i64 ms.
+    // Build a LogEntry and confirm created_at field accepts i64 ms.
     let _entry = LogEntry {
         api_key_id: None,
-        timestamp: ts,
+        api_key_name: None,
+        created_at: ts,
         client_protocol: "openai/chat/v1".into(),
         upstream_protocol: "openai/chat/v1".into(),
         provider_id: "test-provider".into(),
+        provider_name: "Test Provider".into(),
+        route_id: None,
+        route_name: None,
         upstream_url: None,
         client_model: "gpt-4".into(),
         upstream_model: "gpt-4".into(),
@@ -134,6 +138,7 @@ fn log_entry_timestamp_is_unix_millis() {
         latency_total_ms: 42,
         latency_upstream_ms: Some(30),
         usage: Usage::default(),
+        is_stream: false,
         stream_chunks_count: 0,
         stream_first_chunk_ms: None,
     };
@@ -148,10 +153,14 @@ fn stream_indicator_via_chunks_count() {
 
     let base = LogEntry {
         api_key_id: None,
-        timestamp: 0,
+        api_key_name: None,
+        created_at: 0,
         client_protocol: String::new(),
         upstream_protocol: String::new(),
         provider_id: String::new(),
+        provider_name: String::new(),
+        route_id: None,
+        route_name: None,
         upstream_url: None,
         client_model: String::new(),
         upstream_model: String::new(),
@@ -170,6 +179,7 @@ fn stream_indicator_via_chunks_count() {
         latency_total_ms: 0,
         latency_upstream_ms: None,
         usage: Usage::default(),
+        is_stream: false,
         stream_chunks_count: 0,
         stream_first_chunk_ms: None,
     };
@@ -201,11 +211,15 @@ fn db_schema_sql_contains_new_columns() {
     // We do a lighter check: verify the constant column names expected per spec.
     let expected_columns = [
         "id",
-        "timestamp",
+        "created_at",
         "api_key_id",
+        "api_key_name",
+        "provider_id",
+        "provider_name",
+        "route_id",
+        "route_name",
         "client_protocol",
         "upstream_protocol",
-        "provider_id",
         "upstream_url",
         "client_model",
         "upstream_model",
@@ -225,13 +239,14 @@ fn db_schema_sql_contains_new_columns() {
         "latency_upstream_ms",
         "input_tokens",
         "output_tokens",
+        "is_stream",
         "stream_chunks_count",
         "stream_first_chunk_ms",
     ];
     assert_eq!(
         expected_columns.len(),
-        27,
-        "spec requires 27 columns (id + 26 data columns)"
+        32,
+        "schema requires 32 columns (id + 31 data columns)"
     );
 
     // Verify RequestLog struct has the same field names via a compile-time
@@ -239,11 +254,15 @@ fn db_schema_sql_contains_new_columns() {
     use nyro_core::db::models::RequestLog;
     fn _check_fields(r: &RequestLog) {
         let _: &str = &r.id;
-        let _: i64 = r.timestamp;
+        let _: i64 = r.created_at;
         let _: &Option<String> = &r.api_key_id;
+        let _: &Option<String> = &r.api_key_name;
+        let _: &Option<String> = &r.provider_id;
+        let _: &Option<String> = &r.provider_name;
+        let _: &Option<String> = &r.route_id;
+        let _: &Option<String> = &r.route_name;
         let _: &Option<String> = &r.client_protocol;
         let _: &Option<String> = &r.upstream_protocol;
-        let _: &Option<String> = &r.provider_id;
         let _: &Option<String> = &r.upstream_url;
         let _: &Option<String> = &r.client_model;
         let _: &Option<String> = &r.upstream_model;
@@ -263,6 +282,7 @@ fn db_schema_sql_contains_new_columns() {
         let _: &Option<i64> = &r.latency_upstream_ms;
         let _: i32 = r.input_tokens;
         let _: i32 = r.output_tokens;
+        let _: bool = r.is_stream;
         let _: i32 = r.stream_chunks_count;
         let _: &Option<i64> = &r.stream_first_chunk_ms;
     }

--- a/webui/src/components/layout/sidebar.tsx
+++ b/webui/src/components/layout/sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                         : label === "Routes"
                           ? "路由"
                           : label === "API Keys"
-                            ? "API Key"
+                            ? "密钥"
                           : label === "Connect"
                             ? "接入"
                           : label === "Logs"

--- a/webui/src/components/log-detail-dialog.tsx
+++ b/webui/src/components/log-detail-dialog.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { Check, Copy, Loader2 } from "lucide-react";
+import { Check, Copy, Download, Loader2 } from "lucide-react";
 
 import { backend } from "@/lib/backend";
 import { useLocale } from "@/lib/i18n";
@@ -17,6 +17,10 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+
+function protocolLabel(raw: string | null | undefined): string {
+  return prettyName(raw) ?? raw ?? "–";
+}
 
 interface LogDetailDialogProps {
   logId: string | null;
@@ -35,16 +39,87 @@ export function LogDetailDialog({ logId, summary, open, onOpenChange }: LogDetai
     enabled: open && !!logId,
   });
 
+  const [downloaded, setDownloaded] = useState(false);
+
   const log = data ?? summary ?? null;
 
   const method = log?.method ?? "–";
   const path = log?.path ?? "–";
-  const statusCode = log?.status_code;
-  const statusOk = (statusCode ?? 0) < 400;
+  const clientStatus = log?.client_status_code;
+  const statusOk = (clientStatus ?? 0) < 400;
+  // is_stream is the canonical flag (declared by the client). Fall back to
+  // stream_chunks_count for older log rows that pre-date the field.
+  const isStream = log?.is_stream ?? (log?.stream_chunks_count ?? 0) > 0;
+  const isCrossProtocol =
+    log?.client_protocol &&
+    log?.upstream_protocol &&
+    log.client_protocol !== log.upstream_protocol;
+
+  useEffect(() => {
+    if (!downloaded) return;
+    const t = window.setTimeout(() => setDownloaded(false), 1500);
+    return () => window.clearTimeout(t);
+  }, [downloaded]);
+
+  const handleDownload = () => {
+    if (!log) return;
+    const ts = formatLogTime(log.created_at);
+    const proto = isCrossProtocol
+      ? `${log.client_protocol ?? "–"} → ${log.upstream_protocol ?? "–"} (cross-protocol)`
+      : (log.client_protocol ?? "–");
+    const lines: string[] = [
+      `# Nyro Request Log`,
+      `# ID: ${log.id}`,
+      `# Time: ${ts}`,
+      `# Method: ${method}  Path: ${path}`,
+      `# Client Status: ${log.client_status_code ?? "–"}  Upstream Status: ${log.upstream_status_code ?? "–"}`,
+      `# Latency Total: ${formatDuration(log.latency_total_ms)}  Upstream: ${formatDuration(log.latency_upstream_ms)}`,
+      `# Provider: ${log.provider_name ?? log.provider_id ?? "–"}  Route: ${log.route_name ?? log.route_id ?? "–"}  ApiKey: ${log.api_key_name ?? log.api_key_id ?? "–"}`,
+      `# Client Model: ${log.client_model ?? "–"}  Upstream Model: ${log.upstream_model ?? "–"}`,
+      `# Protocol: ${proto}`,
+      `# Tokens: IN=${log.input_tokens} OUT=${log.output_tokens}`,
+      isStream ? `# Stream: chunks=${log.stream_chunks_count} ttfb=${log.stream_first_chunk_ms ?? "–"}ms` : `# Stream: false`,
+      "",
+      "## 1. CLIENT REQUEST HEADERS",
+      log.client_request_headers ?? "(empty)",
+      "",
+      "## 1. CLIENT REQUEST BODY",
+      log.client_request_body ?? "(empty)",
+      "",
+      "## 2. UPSTREAM REQUEST HEADERS",
+      log.upstream_request_headers ?? "(empty)",
+      "",
+      "## 2. UPSTREAM REQUEST BODY",
+      log.upstream_request_body ?? "(empty)",
+      "",
+      "## 3. UPSTREAM RESPONSE HEADERS",
+      log.upstream_response_headers ?? "(empty)",
+      "",
+      "## 3. UPSTREAM RESPONSE BODY",
+      log.upstream_response_body ?? "(empty)",
+      "",
+      "## 4. CLIENT RESPONSE HEADERS",
+      log.client_response_headers ?? "(empty)",
+      "",
+      "## 4. CLIENT RESPONSE BODY",
+      log.client_response_body ?? "(empty)",
+    ];
+    const blob = new Blob([lines.join("\n")], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `nyro-log-${log.id}.log`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setDownloaded(true);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(92vw,960px)] max-h-[88vh] overflow-hidden flex flex-col gap-4">
+      <DialogContent
+        className="w-[min(92vw,960px)] max-h-[88vh] overflow-hidden flex flex-col gap-4"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span>{isZh ? "请求详情" : "Request Detail"}</span>
@@ -64,77 +139,143 @@ export function LogDetailDialog({ logId, summary, open, onOpenChange }: LogDetai
               statusOk ? "bg-green-50 text-green-700" : "bg-red-50 text-red-600",
             )}
           >
-            {statusCode ?? "–"}
+            {clientStatus ?? "–"}
           </span>
-          {log?.is_stream ? (
-            <Badge variant="outline" className="border-green-200 bg-green-50 text-green-700">
-              SSE
-            </Badge>
+          {isStream ? (
+            <Badge variant="outline" className="border-green-200 bg-green-50 text-green-700">SSE</Badge>
           ) : (
-            <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700">
-              JSON
-            </Badge>
+            <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700">JSON</Badge>
           )}
-          {log?.provider_name ? (
-            <Badge variant="outline">{log.provider_name}</Badge>
+          {isCrossProtocol ? (
+            <Badge variant="outline" className="border-purple-200 bg-purple-50 text-purple-700">
+              {isZh ? "跨协议" : "Cross-Protocol"}
+            </Badge>
           ) : null}
-          {log?.actual_model ? (
-            <span className="text-slate-500 font-mono">{log.actual_model}</span>
+          {(log?.provider_name ?? log?.provider_id) ? (
+            <Badge variant="outline">{log.provider_name ?? log.provider_id}</Badge>
           ) : null}
-          {log?.duration_ms != null ? (
-            <span className="text-slate-500">{formatDuration(log.duration_ms)}</span>
+          {log?.route_name ? (
+            <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-500">{log.route_name}</Badge>
+          ) : null}
+          {log?.api_key_name ? (
+            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">{log.api_key_name}</Badge>
+          ) : null}
+          {log?.upstream_model ? (
+            <span className="text-slate-500 font-mono">{log.upstream_model}</span>
+          ) : null}
+          {log?.latency_total_ms != null ? (
+            <span className="text-slate-500">{formatDuration(log.latency_total_ms)}</span>
           ) : null}
           {log ? (
             <span className="inline-flex items-center gap-2">
               <span className="inline-flex items-center gap-1 text-sky-600">
                 <span className="text-[10px] font-semibold tracking-wide">IN</span>
-                <span title={String(log.input_tokens)}>
-                  {formatTokenCount(log.input_tokens)}
-                </span>
+                <span title={String(log.input_tokens)}>{formatTokenCount(log.input_tokens)}</span>
               </span>
               <span className="inline-flex items-center gap-1 text-emerald-600">
                 <span className="text-[10px] font-semibold tracking-wide">OUT</span>
-                <span title={String(log.output_tokens)}>
-                  {formatTokenCount(log.output_tokens)}
-                </span>
+                <span title={String(log.output_tokens)}>{formatTokenCount(log.output_tokens)}</span>
               </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={handleDownload}
+                className="h-7 gap-1 px-2 text-xs"
+              >
+                {downloaded ? (
+                  <><Check className="h-3.5 w-3.5 text-green-600" /><span className="text-green-600">{isZh ? "已保存" : "Saved"}</span></>
+                ) : (
+                  <><Download className="h-3.5 w-3.5" />{isZh ? "下载" : "Download"}</>
+                )}
+              </Button>
             </span>
-          ) : null}
-          {log?.ingress_protocol || log?.egress_protocol ? (
-            <ProtocolLine ingress={log?.ingress_protocol} egress={log?.egress_protocol} />
           ) : null}
         </div>
 
-        {log?.error_message ? (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-            {log.error_message}
-          </div>
-        ) : null}
-
         <div className="flex-1 space-y-3 overflow-y-auto pr-1">
+          <SectionHeader
+            title={isZh ? "1. 客户端请求" : "1. Client Request"}
+            hint={isZh ? `协议：${protocolLabel(log?.client_protocol)}` : `Protocol: ${protocolLabel(log?.client_protocol)}`}
+          />
           <PayloadBlock
-            title={isZh ? "请求头" : "Request Headers"}
-            content={log?.request_headers}
+            title={isZh ? "客户端请求头" : "Client Request Headers"}
+            content={log?.client_request_headers}
             isZh={isZh}
           />
           <PayloadBlock
-            title={isZh ? "请求体" : "Request Body"}
-            content={log?.request_body}
+            title={isZh ? "客户端请求体" : "Client Request Body"}
+            content={log?.client_request_body}
+            isZh={isZh}
+          />
+
+          <SectionHeader
+            title={isZh ? "2. 上游请求" : "2. Upstream Request"}
+            hint={isCrossProtocol
+              ? (isZh
+                  ? `Nyro 转换输出 → ${protocolLabel(log?.upstream_protocol)}`
+                  : `Nyro converted → ${protocolLabel(log?.upstream_protocol)}`)
+              : undefined}
+          />
+          <PayloadBlock
+            title={isZh ? "上游请求头" : "Upstream Request Headers"}
+            content={log?.upstream_request_headers}
             isZh={isZh}
           />
           <PayloadBlock
-            title={isZh ? "响应头" : "Response Headers"}
-            content={log?.response_headers}
+            title={isZh ? "上游请求体" : "Upstream Request Body"}
+            content={log?.upstream_request_body}
+            isZh={isZh}
+          />
+
+          <SectionHeader
+            title={isZh ? "3. 上游响应" : "3. Upstream Response"}
+            hint={isZh ? `协议：${protocolLabel(log?.upstream_protocol)}` : `Protocol: ${protocolLabel(log?.upstream_protocol)}`}
+          />
+          <PayloadBlock
+            title={isZh ? "上游响应头" : "Upstream Response Headers"}
+            content={log?.upstream_response_headers}
             isZh={isZh}
           />
           <PayloadBlock
-            title={isZh ? "响应体" : "Response Body"}
-            content={log?.response_body}
+            title={isZh ? "上游响应体" : "Upstream Response Body"}
+            content={log?.upstream_response_body}
+            isZh={isZh}
+          />
+
+          <SectionHeader
+            title={isZh ? "4. 客户端响应" : "4. Client Response"}
+            hint={isCrossProtocol
+              ? (isZh
+                  ? `Nyro 转换输出 → ${protocolLabel(log?.client_protocol)}`
+                  : `Nyro converted → ${protocolLabel(log?.client_protocol)}`)
+              : undefined}
+          />
+          <PayloadBlock
+            title={isZh ? "客户端响应头" : "Client Response Headers"}
+            content={log?.client_response_headers}
+            isZh={isZh}
+          />
+          <PayloadBlock
+            title={isZh ? "客户端响应体" : "Client Response Body"}
+            content={log?.client_response_body}
             isZh={isZh}
           />
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function SectionHeader({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div className="flex items-center gap-2 pt-1">
+      <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">{title}</span>
+      {hint ? (
+        <span className="text-[10px] text-slate-400 font-normal normal-case tracking-normal shrink-0">{hint}</span>
+      ) : null}
+      <div className="flex-1 border-t border-slate-200" />
+    </div>
   );
 }
 
@@ -146,6 +287,7 @@ interface PayloadBlockProps {
 
 function PayloadBlock({ title, content, isZh }: PayloadBlockProps) {
   const [copied, setCopied] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
   const pretty = tryPrettyJson(content);
   const hasContent = !!(content && content.trim());
 
@@ -167,55 +309,48 @@ function PayloadBlock({ title, content, isZh }: PayloadBlockProps) {
 
   return (
     <div className="rounded-lg border border-slate-200 bg-slate-50/60">
-      <div className="flex items-center justify-between border-b border-slate-200 px-3 py-1.5">
+      <div
+        className="flex cursor-pointer items-center justify-between border-b border-slate-200 px-3 py-1.5"
+        onClick={() => setCollapsed((v) => !v)}
+      >
         <span className="text-xs font-medium text-slate-600">{title}</span>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          disabled={!hasContent}
-          onClick={handleCopy}
-          className="h-7 gap-1 px-2 text-xs"
-        >
-          {copied ? (
-            <>
-              <Check className="h-3.5 w-3.5" />
-              {isZh ? "已复制" : "Copied"}
-            </>
-          ) : (
-            <>
-              <Copy className="h-3.5 w-3.5" />
-              {isZh ? "复制" : "Copy"}
-            </>
-          )}
-        </Button>
+        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={!hasContent}
+            onClick={handleCopy}
+            className="h-7 gap-1 px-2 text-xs"
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5" />
+                {isZh ? "已复制" : "Copied"}
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                {isZh ? "复制" : "Copy"}
+              </>
+            )}
+          </Button>
+        </div>
       </div>
-      <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all px-3 py-2 font-mono text-[11px] leading-relaxed text-slate-700">
-        {hasContent ? pretty : <span className="text-slate-400">{isZh ? "（无内容）" : "(empty)"}</span>}
-      </pre>
+      {!collapsed && (
+        <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all px-3 py-2 font-mono text-[11px] leading-relaxed text-slate-700">
+          {hasContent ? pretty : <span className="text-slate-400">{isZh ? "（无内容）" : "(empty)"}</span>}
+        </pre>
+      )}
+      {collapsed && (
+        <div
+          className="cursor-pointer px-3 py-1.5 text-[11px] text-slate-400 hover:text-slate-600"
+          onClick={() => setCollapsed(false)}
+        >
+          {hasContent ? (isZh ? "点击展开" : "click to expand") : (isZh ? "（无内容）" : "(empty)")}
+        </div>
+      )}
     </div>
   );
 }
 
-function ProtocolLine({
-  ingress,
-  egress,
-}: {
-  ingress: string | null | undefined;
-  egress: string | null | undefined;
-}) {
-  const renderSide = (raw: string | null | undefined) => {
-    if (!raw) return <span className="text-slate-400">–</span>;
-    const label = prettyName(raw);
-    return (
-      <span className="font-medium text-slate-600">{label ?? raw}</span>
-    );
-  };
-  return (
-    <span className="inline-flex items-center gap-1.5 text-slate-500">
-      {renderSide(ingress)}
-      <span className="text-slate-300">→</span>
-      {renderSide(egress)}
-    </span>
-  );
-}

--- a/webui/src/lib/format.ts
+++ b/webui/src/lib/format.ts
@@ -6,11 +6,13 @@ export function formatDuration(ms: number | null | undefined): string {
   return `${(ms / 3_600_000).toFixed(1)} h`;
 }
 
-export function formatLogTime(createdAt: string | null | undefined): string {
-  if (!createdAt) return "–";
-  const normalized = createdAt.includes("T") ? createdAt : createdAt.replace(" ", "T") + "Z";
-  const date = new Date(normalized);
-  if (Number.isNaN(date.getTime())) return createdAt;
+export function formatLogTime(ts: number | string | null | undefined): string {
+  if (ts == null) return "–";
+  const date = typeof ts === "number" ? new Date(ts) : (() => {
+    const normalized = ts.includes("T") ? ts : ts.replace(" ", "T") + "Z";
+    return new Date(normalized);
+  })();
+  if (Number.isNaN(date.getTime())) return String(ts);
   const mm = String(date.getMonth() + 1).padStart(2, "0");
   const dd = String(date.getDate()).padStart(2, "0");
   const hh = String(date.getHours()).padStart(2, "0");

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -65,26 +65,45 @@ export interface ApiKey {
 
 export interface RequestLog {
   id: string;
-  created_at: string;
-  ingress_protocol?: string;
-  egress_protocol?: string;
-  request_model?: string;
-  actual_model?: string;
+  /** Unix 毫秒时间戳 */
+  created_at: number;
+  api_key_id?: string;
+  api_key_name?: string;
+
+  client_protocol?: string;
+  upstream_protocol?: string;
+  provider_id?: string;
   provider_name?: string;
-  status_code?: number;
-  duration_ms?: number;
-  input_tokens: number;
-  output_tokens: number;
-  is_stream: boolean;
-  is_tool_call: boolean;
-  error_message?: string;
-  response_preview?: string;
+  route_id?: string;
+  route_name?: string;
+  upstream_url?: string;
+  client_model?: string;
+  upstream_model?: string;
+
   method?: string;
   path?: string;
-  request_headers?: string;
-  request_body?: string;
-  response_headers?: string;
-  response_body?: string;
+
+  client_request_headers?: string;
+  client_request_body?: string;
+  client_response_headers?: string;
+  client_response_body?: string;
+
+  upstream_request_headers?: string;
+  upstream_request_body?: string;
+  upstream_response_headers?: string;
+  upstream_response_body?: string;
+
+  upstream_status_code?: number;
+  client_status_code?: number;
+
+  latency_total_ms?: number;
+  latency_upstream_ms?: number;
+  input_tokens: number;
+  output_tokens: number;
+
+  is_stream: boolean;
+  stream_chunks_count: number;
+  stream_first_chunk_ms?: number;
 }
 
 export function getRouteType(log: Pick<RequestLog, "path">): "chat" | "embedding" {

--- a/webui/src/pages/logs.tsx
+++ b/webui/src/pages/logs.tsx
@@ -163,7 +163,8 @@ export default function LogsPage() {
               <tbody>
                 {items.map((log) => {
                   const routeType = getRouteType(log);
-                  const statusOk = (log.status_code ?? 0) < 400;
+                  const statusOk = (log.client_status_code ?? 0) < 400;
+                  const isStream = log.is_stream ?? (log.stream_chunks_count ?? 0) > 0;
                   return (
                     <tr
                       key={log.id}
@@ -180,25 +181,25 @@ export default function LogsPage() {
                             statusOk ? "bg-green-50 text-green-700" : "bg-red-50 text-red-600",
                           )}
                         >
-                          {log.status_code ?? "–"}
+                          {log.client_status_code ?? "–"}
                         </span>
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-col leading-tight">
                           <span className="text-xs font-medium text-slate-800">
-                            {log.request_model ?? "–"}
+                            {log.client_model ?? "–"}
                           </span>
                           <span className="text-[11px] text-slate-500">
-                            {log.provider_name ?? "–"}
-                            {log.actual_model ? `: ${log.actual_model}` : ""}
+                            {log.provider_name ?? log.provider_id ?? "–"}
+                            {log.upstream_model ? `: ${log.upstream_model}` : ""}
                           </span>
                         </div>
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex items-center gap-1.5 text-xs text-slate-500">
                           <ProtocolLane
-                            ingress={log.ingress_protocol}
-                            egress={log.egress_protocol}
+                            ingress={log.client_protocol}
+                            egress={log.upstream_protocol}
                           />
                           {routeType === "embedding" ? (
                             <Badge variant="outline" className="text-[10px]">EMB</Badge>
@@ -206,7 +207,7 @@ export default function LogsPage() {
                         </div>
                       </td>
                       <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">
-                        {formatDuration(log.duration_ms)}
+                        {formatDuration(log.latency_total_ms)}
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-col items-start leading-tight text-[11px] tabular-nums">
@@ -227,7 +228,7 @@ export default function LogsPage() {
                         </div>
                       </td>
                       <td className="px-3 py-2">
-                        {log.is_stream ? (
+                        {isStream ? (
                           <Badge
                             variant="outline"
                             className="border-green-200 bg-green-50 text-[10px] text-green-700"


### PR DESCRIPTION
- LogEntry / RequestLog: add provider_name, api_key_name, route_id, route_name (snapshot names at log time); restore is_stream bool for reliable stream detection independent of stream_chunks_count
- ApiKeyAccessRecord: add name field; propagate through auth.rs so LogBuilder captures the key display name
- CallCtx / LogBuilder: carry route_name, api_key_name, is_stream; all from_dispatch call sites chain .stream_flag(is_stream)
- DB schema: add 5 new columns (api_key_name, provider_name, route_id, route_name, is_stream) to INIT_SQL and ensure_request_log_column migration
- storage/sqlite + postgres: sync INSERT / SELECT queries for all 5 new columns; fix stale column names in no-hours stats fallback branches (duration_ms → latency_total_ms, status_code → client_status_code, actual_model → upstream_model); stats_by_provider now uses COALESCE(provider_name, provider_id) for both branches
- postgres INIT_SQL: rewrite request_logs CREATE TABLE to match current 26-column schema; update indices to new column names