### PR TITLE
feat(usage): capture chat-completions prompt-cache hit tokens

### DIFF
--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -106,6 +106,7 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
     ensure_request_log_column(pool, "provider_name", "TEXT").await?;
     ensure_request_log_column(pool, "route_id", "TEXT").await?;
     ensure_request_log_column(pool, "route_name", "TEXT").await?;
+    ensure_request_log_column(pool, "cache_read_tokens", "INTEGER DEFAULT 0").await?;
     Ok(())
 }
 
@@ -799,6 +800,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
     latency_upstream_ms       INTEGER,
     input_tokens              INTEGER DEFAULT 0,
     output_tokens             INTEGER DEFAULT 0,
+    cache_read_tokens         INTEGER DEFAULT 0,
     is_stream                 INTEGER DEFAULT 0,
     stream_chunks_count       INTEGER DEFAULT 0,
     stream_first_chunk_ms     INTEGER

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -270,6 +270,8 @@ pub struct RequestLog {
     pub latency_upstream_ms: Option<i64>,
     pub input_tokens: i32,
     pub output_tokens: i32,
+    #[serde(default)]
+    pub cache_read_tokens: i32,
 
     pub is_stream: bool,
     pub stream_chunks_count: i32,

--- a/crates/nyro-core/src/logging/mod.rs
+++ b/crates/nyro-core/src/logging/mod.rs
@@ -69,6 +69,10 @@ impl LogEntry {
     pub fn output_tokens(&self) -> i32 {
         self.usage.completion_tokens as i32
     }
+
+    pub fn cache_read_tokens(&self) -> i32 {
+        self.usage.cache_read_tokens.unwrap_or(0) as i32
+    }
 }
 
 pub async fn run_collector(mut rx: mpsc::Receiver<LogEntry>, storage: DynStorage) {

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs
@@ -499,9 +499,28 @@ fn extract_usage(v: &Value) -> Usage {
     )
     .unwrap_or(0);
 
+    // Cache-hit tokens are reported by different providers under different
+    // keys. Whichever shape we see, surface it under `Usage.cache_read_tokens`
+    // so downstream cost analytics stop treating cached prompt tokens as
+    // full-price input.
+    //
+    // - DeepSeek native:  `usage.prompt_cache_hit_tokens`
+    // - OpenAI newer fmt: `usage.prompt_tokens_details.cached_tokens`
+    // - Gemini-compat:    `usage.cached_content_token_count`
+    let cache_read = u
+        .get("prompt_cache_hit_tokens")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            u.get("prompt_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+                .and_then(Value::as_u64)
+        })
+        .or_else(|| u.get("cached_content_token_count").and_then(Value::as_u64));
+
     Usage {
         prompt_tokens: input as u32,
         completion_tokens: output as u32,
+        cache_read_tokens: cache_read.map(|v| v as u32),
         ..Usage::default()
     }
 }
@@ -550,6 +569,64 @@ mod tests {
 
     fn data_sse(json: &str) -> String {
         format!("data: {json}\n\n")
+    }
+
+    // ── extract_usage cache-token variants ──
+
+    #[test]
+    fn extract_usage_deepseek_prompt_cache_hit_tokens() {
+        let resp = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 50,
+                "prompt_cache_hit_tokens": 800,
+                "prompt_cache_miss_tokens": 200
+            }
+        });
+        let u = extract_usage(&resp);
+        assert_eq!(u.prompt_tokens, 1000);
+        assert_eq!(u.completion_tokens, 50);
+        assert_eq!(u.cache_read_tokens, Some(800));
+    }
+
+    #[test]
+    fn extract_usage_openai_prompt_tokens_details_cached() {
+        let resp = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 1500,
+                "completion_tokens": 100,
+                "prompt_tokens_details": { "cached_tokens": 1200 }
+            }
+        });
+        let u = extract_usage(&resp);
+        assert_eq!(u.prompt_tokens, 1500);
+        assert_eq!(u.cache_read_tokens, Some(1200));
+    }
+
+    #[test]
+    fn extract_usage_gemini_cached_content_token_count() {
+        let resp = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 2000,
+                "completion_tokens": 200,
+                "cached_content_token_count": 1700
+            }
+        });
+        let u = extract_usage(&resp);
+        assert_eq!(u.cache_read_tokens, Some(1700));
+    }
+
+    #[test]
+    fn extract_usage_no_cache_field_yields_none() {
+        let resp = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 50
+            }
+        });
+        let u = extract_usage(&resp);
+        assert_eq!(u.prompt_tokens, 500);
+        assert_eq!(u.cache_read_tokens, None);
     }
 
     // ── OpenAIResponseParser ──

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -978,9 +978,9 @@ impl LogStore for PostgresLogStore {
                      upstream_response_headers, upstream_response_body,
                      upstream_status_code, client_status_code,
                      latency_total_ms, latency_upstream_ms,
-                     input_tokens, output_tokens,
+                     input_tokens, output_tokens, cache_read_tokens,
                      is_stream, stream_chunks_count, stream_first_chunk_ms)
-                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32)"#,
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33)"#,
             )
             .bind(&id)
             .bind(entry.created_at)
@@ -1011,6 +1011,7 @@ impl LogStore for PostgresLogStore {
             .bind(entry.latency_upstream_ms)
             .bind(entry.input_tokens())
             .bind(entry.output_tokens())
+            .bind(entry.cache_read_tokens())
             .bind(entry.is_stream)
             .bind(entry.stream_chunks_count)
             .bind(entry.stream_first_chunk_ms)
@@ -1033,7 +1034,7 @@ impl LogStore for PostgresLogStore {
              NULL::text AS upstream_response_headers, NULL::text AS upstream_response_body, \
              upstream_status_code, client_status_code, \
              latency_total_ms, latency_upstream_ms, \
-             input_tokens, output_tokens, \
+             input_tokens, output_tokens, COALESCE(cache_read_tokens, 0) AS cache_read_tokens, \
              COALESCE(is_stream, FALSE) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
              FROM request_logs WHERE 1=1",
         );
@@ -1097,7 +1098,7 @@ impl LogStore for PostgresLogStore {
              upstream_response_headers, upstream_response_body, \
              upstream_status_code, client_status_code, \
              latency_total_ms, latency_upstream_ms, \
-             input_tokens, output_tokens, \
+             input_tokens, output_tokens, COALESCE(cache_read_tokens, 0) AS cache_read_tokens, \
              COALESCE(is_stream, FALSE) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
              FROM request_logs WHERE id = $1",
         )
@@ -1400,6 +1401,11 @@ END $$;"#,
         sqlx::query("ALTER TABLE routes DROP COLUMN IF EXISTS route_type")
             .execute(self.adapter.pool())
             .await?;
+        sqlx::query(
+            "ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS cache_read_tokens INTEGER DEFAULT 0",
+        )
+        .execute(self.adapter.pool())
+        .await?;
         Ok(())
     }
 
@@ -1727,6 +1733,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
     latency_upstream_ms       BIGINT,
     input_tokens              INTEGER DEFAULT 0,
     output_tokens             INTEGER DEFAULT 0,
+    cache_read_tokens         INTEGER DEFAULT 0,
     is_stream                 BOOLEAN DEFAULT FALSE,
     stream_chunks_count       INTEGER DEFAULT 0,
     stream_first_chunk_ms     BIGINT

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -1079,9 +1079,9 @@ impl LogStore for SqliteLogStore {
                      upstream_response_headers, upstream_response_body,
                      upstream_status_code, client_status_code,
                      latency_total_ms, latency_upstream_ms,
-                     input_tokens, output_tokens,
+                     input_tokens, output_tokens, cache_read_tokens,
                      is_stream, stream_chunks_count, stream_first_chunk_ms)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
             )
             .bind(&id)
             .bind(entry.created_at)
@@ -1112,6 +1112,7 @@ impl LogStore for SqliteLogStore {
             .bind(entry.latency_upstream_ms)
             .bind(entry.input_tokens())
             .bind(entry.output_tokens())
+            .bind(entry.cache_read_tokens())
             .bind(entry.is_stream)
             .bind(entry.stream_chunks_count)
             .bind(entry.stream_first_chunk_ms)
@@ -1134,7 +1135,7 @@ impl LogStore for SqliteLogStore {
              NULL AS upstream_response_headers, NULL AS upstream_response_body, \
              upstream_status_code, client_status_code, \
              CAST(latency_total_ms AS INTEGER) AS latency_total_ms, latency_upstream_ms, \
-             input_tokens, output_tokens, \
+             input_tokens, output_tokens, COALESCE(cache_read_tokens, 0) AS cache_read_tokens, \
              COALESCE(is_stream, 0) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
              FROM request_logs WHERE 1=1",
         );
@@ -1187,7 +1188,7 @@ impl LogStore for SqliteLogStore {
              upstream_response_headers, upstream_response_body, \
              upstream_status_code, client_status_code, \
              CAST(latency_total_ms AS INTEGER) AS latency_total_ms, latency_upstream_ms, \
-             input_tokens, output_tokens, \
+             input_tokens, output_tokens, COALESCE(cache_read_tokens, 0) AS cache_read_tokens, \
              COALESCE(is_stream, 0) AS is_stream, stream_chunks_count, stream_first_chunk_ms \
              FROM request_logs WHERE id = ?",
         )


### PR DESCRIPTION
## Summary

The chat-completions decoder previously dropped provider-specific cache-hit fields, so `request_logs` showed every prompt token at full price even when 90%+ was actually served from the prefix cache. Anthropic ingress and OpenAI Responses already plumbed `Usage.cache_read_tokens` end-to-end; only the openai-compatible ingress was missing.

(Re-do of #155 against the post-IR-refactor master — old branch was too far behind to rebase.)

## What it captures

Whichever shape the provider returns:

| Provider | Field |
|---|---|
| DeepSeek native | `usage.prompt_cache_hit_tokens` |
| OpenAI newer fmt | `usage.prompt_tokens_details.cached_tokens` |
| Gemini-compat | `usage.cached_content_token_count` |

All three land in `ir::Usage.cache_read_tokens` and persist to a new `request_logs.cache_read_tokens` column.

## Scope (explicit)

This PR only restores cache-info capture for analytics / cost telemetry. Downstream re-emission to clients (Responses `input_tokens_details.cached_tokens`, chat-completions `prompt_tokens_details.cached_tokens`) is intentionally out of scope — currently only the Anthropic Messages ingress re-emits cache info to clients; the other formatters strip it on output and that is left unchanged here.

## Verification

Deployed to a dev gateway and ran against DeepSeek:

```
two identical prompts (~132 prompt_tokens):
  cold:  input_tokens=132 output_tokens=50  cache_read_tokens=0    (initial run)
  warm:  input_tokens=132 output_tokens=50  cache_read_tokens=128  ← 97% hit
in-flight codex agent run (10k-token growing prefix):
         input_tokens=11283 cache_read_tokens=11136                ← 98.7% hit
```

Both rows are read straight out of `request_logs` after the migration runs.

## Files touched

- `crates/nyro-core/src/protocol/codec/openai_compatible/stream.rs` — `extract_usage()` now reads the 3 cache field variants and writes them into `Usage.cache_read_tokens`, plus 4 unit tests
- `crates/nyro-core/src/logging/mod.rs` — adds `LogEntry::cache_read_tokens()` accessor mirroring `input_tokens()` / `output_tokens()`
- `crates/nyro-core/src/db/mod.rs` — SQLite `CREATE TABLE` + `ensure_request_log_column` migration
- `crates/nyro-core/src/db/models.rs` — `RequestLog` struct adds `cache_read_tokens: i32` with `#[serde(default)]`
- `crates/nyro-core/src/storage/sqlite/mod.rs` — INSERT binds new column; both SELECTs project it
- `crates/nyro-core/src/storage/postgres/mod.rs` — CREATE + `ALTER TABLE IF NOT EXISTS` + INSERT binding + 2 SELECT projections

## Test plan

- [x] Existing SQLite gateway.db upgrades cleanly (idempotent `ensure_request_log_column`)
- [x] Existing Postgres deployment upgrades cleanly (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`)
- [x] DeepSeek warm request → `cache_read_tokens > 0` in `request_logs`
- [x] 4 unit tests cover all three field variants + absent-field case
- [x] Existing `request_logs` rows still deserialize (serde default fills 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)