### PR TITLE
fix(protocol): bridge Anthropic thinking blocks to OpenAI reasoning_content

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
@@ -266,6 +266,7 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
             let mut content_blocks: Vec<ContentBlock> = Vec::new();
             let mut tcs: Vec<ToolCall> = Vec::new();
             let mut tc_id: Option<String> = None;
+            let mut thinking_texts: Vec<String> = Vec::new();
 
             for block in blocks {
                 match block {
@@ -284,6 +285,9 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
                         signature,
                         ..
                     } => {
+                        if role == Role::Assistant && !thinking.is_empty() {
+                            thinking_texts.push(thinking.clone());
+                        }
                         content_blocks.push(ContentBlock::Thinking {
                             thinking,
                             signature,
@@ -359,6 +363,8 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
 
             let tool_calls_opt = if tcs.is_empty() { None } else { Some(tcs) };
 
+            let meta = build_reasoning_meta(&thinking_texts);
+
             if content_blocks.len() == 1
                 && let ContentBlock::Text { text, .. } = &content_blocks[0]
             {
@@ -367,15 +373,17 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
                     content: MessageContent::Text(text.clone()),
                     tool_calls: tool_calls_opt,
                     tool_call_id: tc_id,
-                    meta: None,
+                    meta,
                 }]);
             }
 
-            (
-                MessageContent::Blocks(content_blocks),
-                tool_calls_opt,
-                tc_id,
-            )
+            return Ok(vec![Message {
+                role,
+                content: MessageContent::Blocks(content_blocks),
+                tool_calls: tool_calls_opt,
+                tool_call_id: tc_id,
+                meta,
+            }]);
         }
     };
 
@@ -386,6 +394,20 @@ fn decode_message(msg: AnthropicMessage) -> Result<Vec<Message>> {
         tool_call_id,
         meta: None,
     }])
+}
+
+/// Build `meta = {"reasoning_content": ...}` so the OpenAI-compat encoder can
+/// re-emit thinking text as a top-level `reasoning_content` field on assistant
+/// messages (required by providers like Xiaomi Mimo / DeepSeek thinking mode).
+fn build_reasoning_meta(thinking_texts: &[String]) -> Option<Value> {
+    if thinking_texts.is_empty() {
+        return None;
+    }
+    let joined = thinking_texts.join("\n\n");
+    if joined.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({ "reasoning_content": joined }))
 }
 
 fn decode_user_blocks(blocks: Vec<AnthropicContentBlock>) -> Result<Vec<Message>> {

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/encoder.rs
@@ -445,8 +445,22 @@ fn encode_message(msg: &Message) -> Result<Value> {
             map.insert("content".into(), Value::String(t.clone()));
         }
         MessageContent::Blocks(blocks) => {
+            // Strip Thinking blocks for assistant messages — they are surfaced
+            // via the top-level `reasoning_content` field carried in `meta`
+            // (see anthropic_messages decoder). Emitting them as plain text
+            // would duplicate reasoning into the visible content and break
+            // upstreams like Xiaomi Mimo that require strict thinking-mode
+            // round-tripping via `reasoning_content`.
+            let filter_thinking = msg.role == Role::Assistant;
             let parts: Vec<Value> = blocks
                 .iter()
+                .filter(|b| {
+                    !(filter_thinking
+                        && matches!(
+                            b,
+                            ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
+                        ))
+                })
                 .map(|b| encode_content_block_for_openai(b))
                 .collect();
             map.insert("content".into(), Value::Array(parts));

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -1240,6 +1240,122 @@ fn openai_encoder_preserves_reasoning_content_across_parallel_tool_calls() {
 }
 
 #[test]
+fn anthropic_to_openai_thinking_round_trip_carries_reasoning_content() {
+    // Regression for cross-protocol Anthropic Messages → OpenAI chat/completions:
+    // when the client (Claude Code) re-sends an assistant turn containing
+    // `thinking` + parallel `tool_use` blocks followed by `tool_result`s,
+    // upstreams in thinking mode (Xiaomi Mimo / DeepSeek / etc.) require the
+    // assistant message that carries `tool_calls` to also carry the original
+    // `reasoning_content`. Otherwise they return:
+    //   400 "The reasoning_content in the thinking mode must be passed back."
+    //
+    // The thinking text must be bridged through `meta.reasoning_content` so the
+    // OpenAI encoder emits it on every split assistant message produced by
+    // `normalize_messages_for_openai`.
+    let raw = serde_json::json!({
+        "model": "mimo-v2.5-pro",
+        "max_tokens": 1024,
+        "stream": true,
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "ls the project"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "The user wants me to list the project.",
+                        "signature": ""
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "call_a",
+                        "name": "Bash",
+                        "input": {"command": "ls -la"}
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "call_b",
+                        "name": "Bash",
+                        "input": {"command": "find . -maxdepth 2"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_a", "content": "out-a"},
+                    {"type": "tool_result", "tool_use_id": "call_b", "content": "out-b"}
+                ]
+            }
+        ]
+    });
+
+    let ir = AnthropicDecoder
+        .decode_request(raw)
+        .expect("decode anthropic request");
+
+    let asst_idx = ir
+        .messages
+        .iter()
+        .position(|m| m.role == IrRole::Assistant)
+        .expect("assistant message present");
+    let asst_meta = ir.messages[asst_idx]
+        .meta
+        .as_ref()
+        .and_then(|v| v.get("reasoning_content"))
+        .and_then(|v| v.as_str());
+    assert_eq!(
+        asst_meta,
+        Some("The user wants me to list the project."),
+        "anthropic decoder must surface thinking text as meta.reasoning_content; \
+         got meta={:?}",
+        ir.messages[asst_idx].meta,
+    );
+
+    let (body, _) = OpenAIEncoder
+        .encode_request(&ir)
+        .expect("encode openai body");
+    let msgs = body
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .expect("messages array");
+
+    let assistant_msgs: Vec<&serde_json::Value> = msgs
+        .iter()
+        .filter(|m| m.get("role").and_then(|v| v.as_str()) == Some("assistant"))
+        .collect();
+    assert!(
+        !assistant_msgs.is_empty(),
+        "expected at least one assistant message in encoded body, got: {:?}",
+        msgs
+    );
+
+    for (i, m) in assistant_msgs.iter().enumerate() {
+        let rc = m.get("reasoning_content").and_then(|v| v.as_str());
+        assert_eq!(
+            rc,
+            Some("The user wants me to list the project."),
+            "assistant[{}] missing or wrong reasoning_content: {:?}",
+            i,
+            m
+        );
+
+        // Thinking block must NOT also leak into content as plain text — that
+        // would duplicate reasoning across two channels.
+        if let Some(arr) = m.get("content").and_then(|v| v.as_array()) {
+            for part in arr {
+                let text = part.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                assert!(
+                    !text.contains("The user wants me to list the project."),
+                    "thinking text leaked into content array: {:?}",
+                    m
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn openai_encoder_drops_orphan_assistant_tool_calls_without_results() {
     let messages = vec![
         Message {


### PR DESCRIPTION
When an Anthropic Messages client (e.g. Claude Code) re-sends an assistant turn that contains `thinking` + parallel `tool_use` blocks followed by `tool_result`s, the cross-protocol pipeline dropped the thinking text on the way to OpenAI-compatible upstreams. Providers running in thinking mode (Xiaomi Mimo, DeepSeek, etc.) reject the call with `400 The reasoning_content in the thinking mode must be passed back`.

Root cause: the Anthropic decoder only kept thinking as a content block, and `normalize_messages_for_openai` split the assistant message into synthetic per-tool-call messages, pruning the original (since its `to_text()` was empty after thinking was filtered out) and leaving the splits with no `reasoning_content` to inherit.

Fix:
- Anthropic decoder surfaces concatenated thinking text on assistant messages via `meta.reasoning_content`, so the existing meta passthrough in the OpenAI encoder re-emits it on every split assistant message.
- OpenAI encoder strips Thinking/RedactedThinking blocks from assistant content arrays to avoid duplicating reasoning as plain text alongside the dedicated `reasoning_content` field.

Adds regression test `anthropic_to_openai_thinking_round_trip_carries_reasoning_content`.