### PR TITLE
fix(logging): record ingress decode failures in log module

### DIFF
--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -57,7 +57,7 @@ use crate::provider::vendor::ProviderCtx;
 use crate::provider::{VendorCtx, VendorRegistry};
 use crate::proxy::client::ProxyClient;
 use crate::proxy::context::RequestContext;
-use crate::proxy::observability::{LogExtras, headers_to_json, send_log};
+use crate::proxy::observability::{LogExtras, send_log};
 use crate::proxy::planner::{ProtocolMode, negotiate};
 use crate::router::TargetSelector;
 
@@ -662,9 +662,6 @@ pub async fn dispatch(
     path: &'static str,
     _ctx: &mut RequestContext,
 ) -> Response {
-    let request_headers_str = headers_to_json(&headers);
-    let request_body_str = serde_json::to_string(&body).ok();
-
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -678,25 +675,7 @@ pub async fn dispatch(
     let decoder = ingress.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => {
-            let ingress_str = ingress.to_string();
-            let msg = format!("invalid request: {e}");
-            // dispatch() has no start Instant; use a zero-duration sentinel.
-            let decode_start = Instant::now();
-            LogBuilder::from_dispatch(&gw, &ingress_str, "", None, decode_start)
-                .status(400)
-                .with_req_extras(&RequestExtras {
-                    method: method.to_string(),
-                    path: path.to_string(),
-                    headers: request_headers_str.clone(),
-                    body: request_body_str.clone(),
-                })
-                .resp_body(Some(
-                    serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
-                ))
-                .emit();
-            return error_response(400, &msg);
-        }
+        Err(e) => return log_decode_error(&gw, &envelope, ingress, e),
     };
 
     dispatch_pipeline(gw, headers, envelope, request, ingress).await
@@ -1213,6 +1192,38 @@ async fn finalize_singleflight(
     };
     let _ = tx.send(payload);
     gw.cache_in_flight.remove(key);
+}
+
+/// Emit a `LogEntry` for a request that failed to decode at the ingress
+/// boundary (before `dispatch_pipeline` runs) and return the corresponding
+/// 400 `Response`. Ensures decode failures show up in the in-app log module
+/// rather than only in stdout tracing.
+pub(crate) fn log_decode_error(
+    gw: &Gateway,
+    envelope: &RawEnvelope,
+    ingress: ProtocolId,
+    err: impl std::fmt::Display,
+) -> Response {
+    let msg = format!("invalid request: {err}");
+    let request_body_str = envelope
+        .body
+        .as_ref()
+        .and_then(|b| serde_json::to_string(b).ok());
+    let request_headers_str = serde_json::to_string(&envelope.headers).ok();
+    let ingress_str = ingress.to_string();
+    LogBuilder::from_dispatch(gw, &ingress_str, "", None, Instant::now())
+        .status(400)
+        .with_req_extras(&RequestExtras {
+            method: envelope.method.clone(),
+            path: envelope.path.clone(),
+            headers: request_headers_str,
+            body: request_body_str,
+        })
+        .resp_body(Some(
+            serde_json::json!({ "error": { "message": msg.clone() } }).to_string(),
+        ))
+        .emit();
+    error_response(400, &msg)
 }
 
 pub(crate) fn error_response(status: u16, message: &str) -> Response {

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
@@ -10,7 +10,7 @@ use crate::Gateway;
 use crate::protocol::ids::ANTHROPIC_MESSAGES_2023_06_01;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
-use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
+use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
 
 pub async fn handler(
     State(gw): State<Gateway>,
@@ -33,7 +33,7 @@ pub async fn handler(
         .make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid request: {e}")),
+        Err(e) => return log_decode_error(&gw, &envelope, ANTHROPIC_MESSAGES_2023_06_01, e),
     };
     dispatch_pipeline(
         gw,

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -11,7 +11,7 @@ use crate::protocol::codec::google_generative::decoder::GoogleDecoder;
 use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
-use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
+use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
 
 pub async fn handler(
     State(gw): State<Gateway>,
@@ -38,7 +38,14 @@ pub async fn handler(
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", &path);
     let request = match GoogleDecoder.decode_with_model(body, &model, is_stream) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid Gemini request: {e}")),
+        Err(e) => {
+            return log_decode_error(
+                &gw,
+                &envelope,
+                GOOGLE_GENERATE_CONTENT_V1BETA,
+                format!("Gemini decode error: {e}"),
+            );
+        }
     };
     dispatch_pipeline(
         gw,

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -10,7 +10,7 @@ use crate::Gateway;
 use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
-use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
+use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
 
 pub async fn handler(
     State(gw): State<Gateway>,
@@ -36,7 +36,7 @@ pub async fn handler(
     let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid request: {e}")),
+        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_CHAT_COMPLETIONS_V1, e),
     };
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_CHAT_COMPLETIONS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -10,7 +10,7 @@ use crate::Gateway;
 use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
-use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
+use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
 
 pub async fn handler(
     State(gw): State<Gateway>,
@@ -31,7 +31,7 @@ pub async fn handler(
     let decoder = OPENAI_EMBEDDINGS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid request: {e}")),
+        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_EMBEDDINGS_V1, e),
     };
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_EMBEDDINGS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
@@ -10,7 +10,7 @@ use crate::Gateway;
 use crate::protocol::ids::OPENAI_RESPONSES_V1;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
-use crate::proxy::dispatcher::{dispatch_pipeline, error_response};
+use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
 
 pub async fn handler(
     State(gw): State<Gateway>,
@@ -31,7 +31,7 @@ pub async fn handler(
     let decoder = OPENAI_RESPONSES_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return error_response(400, &format!("invalid request: {e}")),
+        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_RESPONSES_V1, e),
     };
     dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1).await
 }


### PR DESCRIPTION
Ingress shells returned 400 directly on request-decode failure, bypassing dispatch_pipeline and the in-app log module (only tower_http stdout traced them). Add dispatcher::log_decode_error() that emits a LogEntry with request headers/body + 400 response, and route all 5 ingress entry points (anthropic-messages, openai chat-completions/embeddings/responses, google generate-content) thrcollapse the duplicate decode-error logging in dispatcher::dispatch() to the same helper.