### PR TITLE
fix(anthropic): accept context-management beta request shape

### DIFF
--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/decoder.rs
@@ -192,10 +192,8 @@ impl RequestDecoder for AnthropicDecoder {
         {
             ingress.insert("__anthropic_thinking".into(), v);
         }
-        if let Some(ref cm) = req.context_management
-            && let Ok(v) = serde_json::to_value(cm)
-        {
-            ingress.insert("__anthropic_context_management".into(), v);
+        if let Some(ref cm) = req.context_management {
+            ingress.insert("__anthropic_context_management".into(), cm.clone());
         }
         if let Some(ref c) = req.container {
             ingress.insert("__anthropic_container".into(), Value::String(c.clone()));

--- a/crates/nyro-core/src/protocol/codec/anthropic_messages/types.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic_messages/types.rs
@@ -17,14 +17,6 @@ pub struct ThinkingConfig {
     pub budget_tokens: Option<u32>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ContextManagement {
-    #[serde(rename = "type")]
-    pub kind: String, // "enabled"
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
-}
-
 // ── Top-level request ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -43,7 +35,7 @@ pub struct AnthropicRequest {
 
     // PR-10 additions ─────────────────────────────────────────────────────────
     pub thinking: Option<ThinkingConfig>,
-    pub context_management: Option<ContextManagement>,
+    pub context_management: Option<Value>,
     pub container: Option<String>,
     pub service_tier: Option<String>,
     pub metadata: Option<Value>,


### PR DESCRIPTION
Claude Code with CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=0 sends context_management as {"edits":[{"type":"clear_thinking_20251015",...}]} per the Anthropic context-management-2025-06-27 beta. Our strong schema required an outer "type" field and failed serde decoding with `missing field \`type\``, returning 400. Since the field is only pass-through (stashed into __anthropic_context_management extension and never read by non-anthropic egress), switch context_management to Option<Value> and drop the obsolete ContextManagement struct.