### PR TITLE
feat(provider): add provider copy workflow

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -576,6 +576,70 @@ impl AdminService {
             .await
     }
 
+    pub async fn copy_provider(&self, id: &str) -> anyhow::Result<Provider> {
+        let original = self.get_provider(id).await?;
+        let name = self.next_provider_copy_name(&original.name).await?;
+        let copied = self
+            .create_provider(CreateProvider {
+                name,
+                vendor: original.vendor.clone(),
+                protocol: original.protocol.clone(),
+                base_url: original.base_url.clone(),
+                preset_key: original.preset_key.clone(),
+                channel: original.channel.clone(),
+                models_source: original.models_source.clone(),
+                static_models: original.static_models.clone(),
+                api_key: original.api_key.clone(),
+                auth_mode: original.auth_mode.clone(),
+                use_proxy: original.use_proxy,
+            })
+            .await?;
+
+        let copied = if original.effective_auth_mode() == "oauth" {
+            match self
+                .gw
+                .storage
+                .oauth_credentials()
+                .get(&original.id)
+                .await?
+            {
+                Some(credential) => {
+                    let credential_input = upsert_credential_from_oauth(&credential);
+                    let provisioned = async {
+                        self.gw
+                            .storage
+                            .oauth_credentials()
+                            .upsert(&copied.id, credential_input)
+                            .await?;
+                        let driver_key = credential.driver_key.clone();
+                        let stored = stored_credential_from_oauth(&credential, &driver_key);
+                        self.sync_provider_runtime_fields(&copied, &stored).await
+                    }
+                    .await;
+
+                    match provisioned {
+                        Ok(provider) => provider,
+                        Err(error) => {
+                            if let Err(cleanup_error) = self.delete_provider(&copied.id).await {
+                                tracing::warn!(
+                                    "failed to rollback copied oauth provider {} after provisioning error: {}",
+                                    copied.id,
+                                    cleanup_error
+                                );
+                            }
+                            return Err(error.context("copy oauth provider"));
+                        }
+                    }
+                }
+                None => copied,
+            }
+        } else {
+            copied
+        };
+
+        Ok(copied)
+    }
+
     pub async fn update_provider(
         &self,
         id: &str,
@@ -1569,6 +1633,34 @@ impl AdminService {
         Ok(())
     }
 
+    async fn next_provider_copy_name(&self, original_name: &str) -> anyhow::Result<String> {
+        let base = format!("{}_复制", normalize_name(original_name, "provider name")?);
+        if !self
+            .gw
+            .storage
+            .providers()
+            .exists_by_name(&base, None)
+            .await?
+        {
+            return Ok(base);
+        }
+
+        for index in 2.. {
+            let candidate = format!("{base}{index}");
+            if !self
+                .gw
+                .storage
+                .providers()
+                .exists_by_name(&candidate, None)
+                .await?
+            {
+                return Ok(candidate);
+            }
+        }
+
+        unreachable!("unbounded provider copy name search must return");
+    }
+
     async fn ensure_route_name_unique(
         &self,
         exclude_id: Option<&str>,
@@ -2111,6 +2203,20 @@ fn upsert_credential_from_bundle(
         subject_id: bundle.subject_id.clone(),
         scopes: Some(scopes_json),
         meta: Some(meta_json),
+    }
+}
+
+fn upsert_credential_from_oauth(oauth: &OAuthCredential) -> UpsertOAuthCredential {
+    UpsertOAuthCredential {
+        driver_key: oauth.driver_key.clone(),
+        scheme: oauth.scheme.clone(),
+        access_token: oauth.access_token.clone(),
+        refresh_token: oauth.refresh_token.clone(),
+        expires_at: oauth.expires_at.clone(),
+        resource_url: oauth.resource_url.clone(),
+        subject_id: oauth.subject_id.clone(),
+        scopes: Some(oauth.scopes.clone()),
+        meta: Some(oauth.meta.clone()),
     }
 }
 
@@ -3170,6 +3276,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn copy_provider_creates_provider_with_copy_suffix() -> anyhow::Result<()> {
+        let gw = build_gateway().await?;
+        let original = gw
+            .admin()
+            .create_provider(api_key_provider_input("source-provider"))
+            .await?;
+
+        let copied = gw.admin().copy_provider(&original.id).await?;
+
+        assert_ne!(copied.id, original.id);
+        assert_eq!(copied.name, "source-provider_复制");
+        assert_eq!(copied.vendor, original.vendor);
+        assert_eq!(copied.protocol, original.protocol);
+        assert_eq!(copied.base_url, original.base_url);
+        assert_eq!(copied.preset_key, original.preset_key);
+        assert_eq!(copied.channel, original.channel);
+        assert_eq!(copied.models_source, original.models_source);
+        assert_eq!(copied.static_models, original.static_models);
+        assert_eq!(copied.api_key, original.api_key);
+        assert_eq!(copied.auth_mode, original.auth_mode);
+        assert_eq!(copied.use_proxy, original.use_proxy);
+        assert_eq!(copied.is_enabled, original.is_enabled);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn copy_provider_uses_numbered_suffix_when_copy_name_exists() -> anyhow::Result<()> {
+        let gw = build_gateway().await?;
+        let original = gw
+            .admin()
+            .create_provider(api_key_provider_input("source-provider"))
+            .await?;
+        gw.admin().copy_provider(&original.id).await?;
+
+        let second_copy = gw.admin().copy_provider(&original.id).await?;
+
+        assert_eq!(second_copy.name, "source-provider_复制2");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn copy_oauth_provider_copies_credential_binding() -> anyhow::Result<()> {
+        let gw = build_gateway().await?;
+
+        let init = gw.admin().init_oauth_session("codex", false).await?;
+        seed_ready_session(
+            &gw.admin(),
+            &init.session_id,
+            CredentialBundle {
+                access_token: Some("copy-access-token".to_string()),
+                refresh_token: Some("copy-refresh-token".to_string()),
+                expires_at: Some(FAR_FUTURE_RFC3339.to_string()),
+                resource_url: Some(CODEX_RUNTIME_URL.to_string()),
+                subject_id: Some("acct_copy".to_string()),
+                scopes: vec!["openid".to_string(), "offline_access".to_string()],
+                raw: json!({ "access_token": "copy-access-token" }),
+            },
+        )
+        .await?;
+        let original = gw
+            .admin()
+            .create_provider_with_oauth_session(&init.session_id, oauth_provider_input())
+            .await?;
+
+        let copied = gw.admin().copy_provider(&original.id).await?;
+        let copied_credential = gw.storage.oauth_credentials().get(&copied.id).await?;
+
+        assert_eq!(copied.name, format!("{}_复制", original.name));
+        assert_eq!(copied.auth_mode, "oauth");
+        assert!(copied.api_key.is_empty());
+        assert_eq!(
+            copied_credential
+                .as_ref()
+                .map(|cred| cred.access_token.as_str()),
+            Some("copy-access-token"),
+        );
+
+        let runtime = gw.admin().resolve_provider_runtime(&copied).await?;
+        assert_eq!(runtime.access_token, "copy-access-token");
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn failed_complete_deletes_session() -> anyhow::Result<()> {
         let gw = build_gateway().await?;
 
@@ -3390,6 +3582,22 @@ mod tests {
             api_key: String::new(),
             auth_mode: "oauth".to_string(),
             use_proxy: false,
+        }
+    }
+
+    fn api_key_provider_input(name: &str) -> CreateProvider {
+        CreateProvider {
+            name: name.to_string(),
+            vendor: Some("openai".to_string()),
+            protocol: "openai-compat".to_string(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            preset_key: Some("openai".to_string()),
+            channel: Some("default".to_string()),
+            models_source: Some("https://api.openai.com/v1/models".to_string()),
+            static_models: Some("gpt-test\ntext-test".to_string()),
+            api_key: "sk-test".to_string(),
+            auth_mode: "apikey".to_string(),
+            use_proxy: true,
         }
     }
 

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -3313,7 +3313,7 @@ mod tests {
 
         let second_copy = gw.admin().copy_provider(&original.id).await?;
 
-        assert_eq!(second_copy.name, "source-provider_复制2");
+        assert_eq!(second_copy.name, "source-provider_Copy2");
 
         Ok(())
     }

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -3286,7 +3286,7 @@ mod tests {
         let copied = gw.admin().copy_provider(&original.id).await?;
 
         assert_ne!(copied.id, original.id);
-        assert_eq!(copied.name, "source-provider_复制");
+        assert_eq!(copied.name, "source-provider_Copy");
         assert_eq!(copied.vendor, original.vendor);
         assert_eq!(copied.protocol, original.protocol);
         assert_eq!(copied.base_url, original.base_url);

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -1634,7 +1634,7 @@ impl AdminService {
     }
 
     async fn next_provider_copy_name(&self, original_name: &str) -> anyhow::Result<String> {
-        let base = format!("{}_复制", normalize_name(original_name, "provider name")?);
+        let base = format!("{}_Copy", normalize_name(original_name, "provider name")?);
         if !self
             .gw
             .storage

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -3345,7 +3345,7 @@ mod tests {
         let copied = gw.admin().copy_provider(&original.id).await?;
         let copied_credential = gw.storage.oauth_credentials().get(&copied.id).await?;
 
-        assert_eq!(copied.name, format!("{}_复制", original.name));
+        assert_eq!(copied.name, format!("{}_Copy", original.name));
         assert_eq!(copied.auth_mode, "oauth");
         assert!(copied.api_key.is_empty());
         assert_eq!(

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -56,6 +56,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
             "/providers",
             get(list_providers).post(create_provider_handler),
         )
+        .route("/providers/:id/copy", post(copy_provider_handler))
         .route("/providers/:id", providers_item)
         .route("/providers/:id/test", get(test_provider_handler))
         .route(
@@ -172,6 +173,16 @@ async fn create_provider_handler(
     Json(input): Json<CreateProvider>,
 ) -> impl IntoResponse {
     match gw.admin().create_provider(input).await {
+        Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
+        Err(e) => err(e),
+    }
+}
+
+async fn copy_provider_handler(
+    State(gw): State<Gateway>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match gw.admin().copy_provider(&id).await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
         Err(e) => err(e),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -46,6 +46,14 @@ pub async fn create_provider(
 }
 
 #[tauri::command]
+pub async fn copy_provider(gw: State<'_, Gateway>, id: String) -> Result<Provider, String> {
+    gw.admin()
+        .copy_provider(&id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn update_provider(
     gw: State<'_, Gateway>,
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ pub fn run() {
             commands::get_provider,
             commands::get_provider_presets,
             commands::create_provider,
+            commands::copy_provider,
             commands::update_provider,
             commands::delete_provider,
             commands::test_provider,

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -66,6 +66,8 @@ function resolveHTTP(cmd: string, args?: Record<string, unknown>): HTTPMapping {
       return { method: "GET", url: `${base}/providers/presets` };
     case "create_provider":
       return { method: "POST", url: `${base}/providers`, body: args?.input as Record<string, unknown> };
+    case "copy_provider":
+      return { method: "POST", url: `${base}/providers/${args?.id}/copy` };
     case "update_provider":
       return { method: "PUT", url: `${base}/providers/${args?.id}`, body: args?.input as Record<string, unknown> };
     case "delete_provider":

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -31,6 +31,7 @@ import {
   Info,
   ToggleRight,
   ToggleLeft,
+  Copy,
 } from "lucide-react";
 import { useLocale } from "@/lib/i18n";
 import { ProviderIcon } from "@/components/ui/provider-icon";
@@ -263,6 +264,17 @@ function mergeProviderOAuthStatus(provider: Provider, status: ProviderOAuthStatu
   };
 }
 
+function nextProviderCopyName(providers: Provider[], originalName: string) {
+  const base = `${originalName}_复制`;
+  const existingNames = new Set(providers.map((provider) => provider.name));
+  if (!existingNames.has(base)) return base;
+
+  for (let index = 2; ; index += 1) {
+    const candidate = `${base}${index}`;
+    if (!existingNames.has(candidate)) return candidate;
+  }
+}
+
 function resolvePresetConfig(
   preset: ProviderPreset,
   protocol: ProviderProtocol,
@@ -376,6 +388,7 @@ export default function ProvidersPage() {
   const [isTestRunning, setIsTestRunning] = useState(false);
   const [testTarget, setTestTarget] = useState<Provider | null>(null);
   const [providerToDelete, setProviderToDelete] = useState<Provider | null>(null);
+  const [providerToCopy, setProviderToCopy] = useState<Provider | null>(null);
   const [selectedPresetId, setSelectedPresetId] = useState(DEFAULT_PRESET_ID);
   const [showCreateApiKey, setShowCreateApiKey] = useState(true);
   const [showEditApiKey, setShowEditApiKey] = useState(false);
@@ -538,6 +551,16 @@ export default function ProvidersPage() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["providers"] }),
     onError: (error: unknown) => {
       showErrorDialog("删除提供商失败", "Failed to delete provider", error);
+    },
+  });
+
+  const copyMut = useMutation({
+    mutationFn: (id: string) => backend<Provider>("copy_provider", { id }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["providers"] });
+    },
+    onError: (error: unknown) => {
+      showErrorDialog("复制提供商失败", "Failed to copy provider", error);
     },
   });
 
@@ -2372,12 +2395,26 @@ export default function ProvidersPage() {
                     </button>
                     <button
                       onClick={() => startEdit(p)}
+                      title={isZh ? "编辑" : "Edit"}
                       className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-500 cursor-pointer"
                     >
                       <Pencil className="h-4 w-4" />
                     </button>
                     <button
+                      onClick={() => setProviderToCopy(p)}
+                      disabled={copyMut.isPending}
+                      title={isZh ? "复制" : "Copy"}
+                      className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-emerald-50 hover:text-emerald-500 cursor-pointer disabled:opacity-50"
+                    >
+                      {copyMut.isPending && providerToCopy?.id === p.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </button>
+                    <button
                       onClick={() => setProviderToDelete(p)}
+                      title={isZh ? "删除" : "Delete"}
                       className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500 cursor-pointer"
                     >
                       <Trash2 className="h-4 w-4" />
@@ -2481,6 +2518,29 @@ export default function ProvidersPage() {
           if (!providerToDisable) return;
           toggleEnabledMut.mutate({ id: providerToDisable.id, is_enabled: false });
           setProviderToDisable(null);
+        }}
+      />
+      <ConfirmDialog
+        open={Boolean(providerToCopy)}
+        onOpenChange={(open) => {
+          if (!open && !copyMut.isPending) setProviderToCopy(null);
+        }}
+        title={isZh ? "确认复制提供商" : "Confirm provider copy"}
+        description={
+          providerToCopy
+            ? (isZh
+              ? `确认复制「${providerToCopy.name}」吗？新提供商名称将为「${nextProviderCopyName(providers, providerToCopy.name)}」。`
+              : `Copy "${providerToCopy.name}"? The new provider name will be "${nextProviderCopyName(providers, providerToCopy.name)}".`)
+            : undefined
+        }
+        cancelText={isZh ? "取消" : "Cancel"}
+        confirmText={copyMut.isPending ? (isZh ? "复制中..." : "Copying...") : (isZh ? "确认复制" : "Copy")}
+        confirmClassName="bg-slate-900 text-white hover:bg-slate-800"
+        onConfirm={() => {
+          if (!providerToCopy || copyMut.isPending) return;
+          copyMut.mutate(providerToCopy.id, {
+            onSuccess: () => setProviderToCopy(null),
+          });
         }}
       />
       <ConfirmDialog

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -265,7 +265,7 @@ function mergeProviderOAuthStatus(provider: Provider, status: ProviderOAuthStatu
 }
 
 function nextProviderCopyName(providers: Provider[], originalName: string) {
-  const base = `${originalName}_复制`;
+  const base = `${originalName}_Copy`;
   const existingNames = new Set(providers.map((provider) => provider.name));
   if (!existingNames.has(base)) return base;
 


### PR DESCRIPTION
## Summary
- Add backend provider duplication that preserves API-key settings and OAuth credential bindings.
- Expose copy through REST and Tauri command surfaces.
- Add a Providers page copy button with confirmation and list refresh.

## Test Plan
- [x] cargo test -p nyro-core copy_provider -- --nocapture
- [x] cargo test -p nyro-core copy_oauth_provider -- --nocapture
- [x] cargo check --workspace
- [x] pnpm exec eslint src/pages/providers.tsx src/lib/backend.ts
- [x] pnpm build

## Notes
- Full `pnpm lint` still reports pre-existing unrelated lint failures outside the changed files.
