### PR TITLE
refactor(protocol): unify canonical Protocol slugs to descriptive identifiers

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -2598,7 +2598,8 @@ fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
 
     let base = provider.base_url.trim_end_matches('/');
     match provider.protocol.as_str() {
-        "openai" | "openai-compatible" | "openai-compat" | "openai-responses" | "openai-resps" | "anthropic" | "anthropic-messages" | "anthropic-msgs" => {
+        "openai" | "openai-compatible" | "openai-compat" | "openai-responses" | "openai-resps"
+        | "anthropic" | "anthropic-messages" | "anthropic-msgs" => {
             let has_base_path = reqwest::Url::parse(base)
                 .ok()
                 .map(|url| {

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -2598,7 +2598,7 @@ fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
 
     let base = provider.base_url.trim_end_matches('/');
     match provider.protocol.as_str() {
-        "openai" | "openai-compat" | "openai-resps" | "anthropic" | "anthropic-msgs" => {
+        "openai" | "openai-compatible" | "openai-compat" | "openai-responses" | "openai-resps" | "anthropic" | "anthropic-messages" | "anthropic-msgs" => {
             let has_base_path = reqwest::Url::parse(base)
                 .ok()
                 .map(|url| {
@@ -2612,7 +2612,7 @@ fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
                 Some(format!("{base}/v1/models"))
             }
         }
-        "gemini" | "google-genai" => Some(format!("{base}/v1beta/models")),
+        "gemini" | "google-gemini" | "google-genai" => Some(format!("{base}/v1beta/models")),
         _ => None,
     }
 }
@@ -3589,7 +3589,7 @@ mod tests {
         CreateProvider {
             name: name.to_string(),
             vendor: Some("openai".to_string()),
-            protocol: "openai-compat".to_string(),
+            protocol: "openai-compatible".to_string(),
             base_url: "https://api.openai.com/v1".to_string(),
             preset_key: Some("openai".to_string()),
             channel: Some("default".to_string()),

--- a/crates/nyro-core/src/auth/drivers/claude.rs
+++ b/crates/nyro-core/src/auth/drivers/claude.rs
@@ -21,7 +21,7 @@ use crate::provider::VendorRegistry;
 
 const ANTHROPIC_PRESET_ID: &str = "anthropic";
 const CLAUDE_CODE_CHANNEL_ID: &str = "claude-code";
-const ANTHROPIC_PROTOCOL_ID: &str = "anthropic-msgs";
+const ANTHROPIC_PROTOCOL_ID: &str = "anthropic-messages";
 
 /// User-Agent the official `claude` CLI sends; mirrored on both the
 /// OAuth token endpoint and the inference runtime. **Bump this** when
@@ -367,7 +367,7 @@ mod tests {
             id: "test".into(),
             name: "test".into(),
             vendor: Some("anthropic".into()),
-            protocol: "anthropic-msgs".into(),
+            protocol: "anthropic-messages".into(),
             base_url: String::new(),
             preset_key: Some("anthropic".into()),
             channel: Some("claude-code".into()),

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -109,7 +109,7 @@ pub async fn migrate(pool: &SqlitePool, vector_dimensions: usize) -> anyhow::Res
 }
 
 /// Rewrites legacy / alias protocol identifiers in `providers.protocol` into
-/// canonical protocol-suite strings (for example, `openai` -> `openai-compat`).
+/// canonical protocol-suite strings (for example, `openai` -> `openai-compatible`).
 async fn normalize_provider_protocols(pool: &SqlitePool) -> anyhow::Result<()> {
     let reg = ProtocolRegistry::global();
     let rows = sqlx::query("SELECT id, protocol FROM providers")

--- a/crates/nyro-core/src/protocol/ids.rs
+++ b/crates/nyro-core/src/protocol/ids.rs
@@ -2,7 +2,7 @@
 //!
 //! Canonical string form: `{protocol}/{name}/{version}`.
 //!
-//! - `protocol`: closed enum of protocol suites (`openai-compat` / `openai-resps` / `anthropic-msgs` / `google-genai`).
+//! - `protocol`: closed enum of protocol suites (`openai-compatible` / `openai-responses` / `anthropic-messages` / `google-gemini`).
 //! - `name`: wire-format endpoint name (`chat-completions` / `responses` / `messages` / `generate-content` / `embeddings`).
 //! - `version`: schema version as the vendor labels it (`v1`, `2023-06-01`, `v1beta`).
 //!
@@ -33,10 +33,10 @@ pub enum Protocol {
 impl Protocol {
     pub const fn as_str(&self) -> &'static str {
         match self {
-            Self::OpenAICompatible => "openai-compat",
-            Self::OpenAIResponses => "openai-resps",
-            Self::AnthropicMessages => "anthropic-msgs",
-            Self::GoogleGenerativeAI => "google-genai",
+            Self::OpenAICompatible => "openai-compatible",
+            Self::OpenAIResponses => "openai-responses",
+            Self::AnthropicMessages => "anthropic-messages",
+            Self::GoogleGenerativeAI => "google-gemini",
         }
     }
 
@@ -45,7 +45,7 @@ impl Protocol {
             Self::OpenAICompatible => "OpenAI Compatible",
             Self::OpenAIResponses => "OpenAI Responses",
             Self::AnthropicMessages => "Anthropic Messages",
-            Self::GoogleGenerativeAI => "Google Generative AI",
+            Self::GoogleGenerativeAI => "Google Gemini",
         }
     }
 }
@@ -61,12 +61,12 @@ impl FromStr for Protocol {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "openai-compat" | "openai-compatible" | "openai" => Ok(Self::OpenAICompatible),
-            "openai-resps" | "openai-responses" => Ok(Self::OpenAIResponses),
-            "anthropic-msgs" | "anthropic-messages" | "anthropic" | "claude" => {
+            "openai-compatible" | "openai-compat" | "openai" => Ok(Self::OpenAICompatible),
+            "openai-responses" | "openai-resps" | "responses" => Ok(Self::OpenAIResponses),
+            "anthropic-messages" | "anthropic-msgs" | "anthropic" | "claude" => {
                 Ok(Self::AnthropicMessages)
             }
-            "google-genai" | "google-generative-ai" | "gemini" | "google" => {
+            "google-gemini" | "google-genai" | "google-generative-ai" | "gemini" | "google" => {
                 Ok(Self::GoogleGenerativeAI)
             }
             other => anyhow::bail!("unknown protocol: {other}"),
@@ -76,7 +76,7 @@ impl FromStr for Protocol {
 
 /// Specific API endpoint within a `Protocol`.
 ///
-/// Canonical display: `{protocol}/{name}/{version}` (e.g. `openai-compat/chat-completions/v1`).
+/// Canonical display: `{protocol}/{name}/{version}` (e.g. `openai-compatible/chat-completions/v1`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ProtocolEndpoint {
     pub protocol: Protocol,
@@ -275,20 +275,20 @@ mod tests {
     fn display_canonical_form() {
         assert_eq!(
             OPENAI_CHAT_COMPLETIONS_V1.to_string(),
-            "openai-compat/chat-completions/v1"
+            "openai-compatible/chat-completions/v1"
         );
-        assert_eq!(OPENAI_RESPONSES_V1.to_string(), "openai-resps/responses/v1");
+        assert_eq!(OPENAI_RESPONSES_V1.to_string(), "openai-responses/responses/v1");
         assert_eq!(
             ANTHROPIC_MESSAGES_2023_06_01.to_string(),
-            "anthropic-msgs/messages/2023-06-01"
+            "anthropic-messages/messages/2023-06-01"
         );
         assert_eq!(
             GOOGLE_GENERATE_CONTENT_V1BETA.to_string(),
-            "google-genai/generate-content/v1beta"
+            "google-gemini/generate-content/v1beta"
         );
         assert_eq!(
             OPENAI_EMBEDDINGS_V1.to_string(),
-            "openai-compat/embeddings/v1"
+            "openai-compatible/embeddings/v1"
         );
     }
 

--- a/crates/nyro-core/src/protocol/ids.rs
+++ b/crates/nyro-core/src/protocol/ids.rs
@@ -277,7 +277,10 @@ mod tests {
             OPENAI_CHAT_COMPLETIONS_V1.to_string(),
             "openai-compatible/chat-completions/v1"
         );
-        assert_eq!(OPENAI_RESPONSES_V1.to_string(), "openai-responses/responses/v1");
+        assert_eq!(
+            OPENAI_RESPONSES_V1.to_string(),
+            "openai-responses/responses/v1"
+        );
         assert_eq!(
             ANTHROPIC_MESSAGES_2023_06_01.to_string(),
             "anthropic-messages/messages/2023-06-01"

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! Canonical form: `{protocol}/{name}/{version}`.
 //!
-//! - `protocol`: closed `Protocol` enum (`openai-compat` / `openai-resps` / `anthropic-msgs` / `google-genai`).
+//! - `protocol`: closed `Protocol` enum (`openai-compatible` / `openai-responses` / `anthropic-messages` / `google-gemini`).
 //! - `name`: wire-format endpoint name (`chat-completions`, `responses`, `messages`, `generate-content`).
 //! - `version`: schema version as the vendor labels it (`v1`, `2023-06-01`, `v1beta`).
 //!

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -255,24 +255,25 @@ fn default_endpoint_aliases() -> HashMap<&'static str, ProtocolEndpoint> {
 fn default_protocol_aliases() -> HashMap<&'static str, Protocol> {
     let mut m = HashMap::new();
 
-    // Canonical short names
-    m.insert("openai-compat", Protocol::OpenAICompatible);
-    m.insert("openai-resps", Protocol::OpenAIResponses);
-    m.insert("anthropic-msgs", Protocol::AnthropicMessages);
-    m.insert("google-genai", Protocol::GoogleGenerativeAI);
-
-    // Full names
+    // Canonical (new)
     m.insert("openai-compatible", Protocol::OpenAICompatible);
     m.insert("openai-responses", Protocol::OpenAIResponses);
     m.insert("anthropic-messages", Protocol::AnthropicMessages);
-    m.insert("google-generative-ai", Protocol::GoogleGenerativeAI);
+    m.insert("google-gemini", Protocol::GoogleGenerativeAI);
 
-    // Legacy brand names
+    // Short names
     m.insert("openai", Protocol::OpenAICompatible);
     m.insert("anthropic", Protocol::AnthropicMessages);
     m.insert("claude", Protocol::AnthropicMessages);
     m.insert("gemini", Protocol::GoogleGenerativeAI);
     m.insert("google", Protocol::GoogleGenerativeAI);
+
+    // Deprecated aliases (old canonical slugs, backward compat only)
+    m.insert("openai-compat", Protocol::OpenAICompatible);
+    m.insert("openai-resps", Protocol::OpenAIResponses);
+    m.insert("anthropic-msgs", Protocol::AnthropicMessages);
+    m.insert("google-genai", Protocol::GoogleGenerativeAI);
+    m.insert("google-generative-ai", Protocol::GoogleGenerativeAI);
 
     m
 }
@@ -297,19 +298,19 @@ mod tests {
         let reg = ProtocolRegistry::global();
         // New canonical form
         assert_eq!(
-            reg.resolve_alias("openai-compat/chat-completions/v1"),
+            reg.resolve_alias("openai-compatible/chat-completions/v1"),
             Some(OPENAI_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
-            reg.resolve_alias("openai-resps/responses/v1"),
+            reg.resolve_alias("openai-responses/responses/v1"),
             Some(OPENAI_RESPONSES_V1)
         );
         assert_eq!(
-            reg.resolve_alias("anthropic-msgs/messages/2023-06-01"),
+            reg.resolve_alias("anthropic-messages/messages/2023-06-01"),
             Some(ANTHROPIC_MESSAGES_2023_06_01)
         );
         assert_eq!(
-            reg.resolve_alias("google-genai/generate-content/v1beta"),
+            reg.resolve_alias("google-gemini/generate-content/v1beta"),
             Some(GOOGLE_GENERATE_CONTENT_V1BETA)
         );
     }
@@ -328,6 +329,24 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("google/generate/v1beta"),
+            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+        );
+
+        // Deprecated canonical (still resolves via FromStr)
+        assert_eq!(
+            reg.resolve_alias("openai-compat/chat-completions/v1"),
+            Some(OPENAI_CHAT_COMPLETIONS_V1)
+        );
+        assert_eq!(
+            reg.resolve_alias("openai-resps/responses/v1"),
+            Some(OPENAI_RESPONSES_V1)
+        );
+        assert_eq!(
+            reg.resolve_alias("anthropic-msgs/messages/2023-06-01"),
+            Some(ANTHROPIC_MESSAGES_2023_06_01)
+        );
+        assert_eq!(
+            reg.resolve_alias("google-genai/generate-content/v1beta"),
             Some(GOOGLE_GENERATE_CONTENT_V1BETA)
         );
 
@@ -414,7 +433,7 @@ mod tests {
     fn parse_protocol_resolves_aliases() {
         let reg = ProtocolRegistry::global();
         assert_eq!(
-            reg.parse_protocol("openai-compat"),
+            reg.parse_protocol("openai-compatible"),
             Some(Protocol::OpenAICompatible)
         );
         assert_eq!(
@@ -428,6 +447,19 @@ mod tests {
         assert_eq!(
             reg.parse_protocol("gemini"),
             Some(Protocol::GoogleGenerativeAI)
+        );
+        assert_eq!(
+            reg.parse_protocol("google-gemini"),
+            Some(Protocol::GoogleGenerativeAI)
+        );
+        // Deprecated aliases still resolve
+        assert_eq!(
+            reg.parse_protocol("openai-compat"),
+            Some(Protocol::OpenAICompatible)
+        );
+        assert_eq!(
+            reg.parse_protocol("anthropic-msgs"),
+            Some(Protocol::AnthropicMessages)
         );
         assert_eq!(
             reg.parse_protocol("google-genai"),

--- a/crates/nyro-core/src/provider/anthropic/mod.rs
+++ b/crates/nyro-core/src/provider/anthropic/mod.rs
@@ -26,7 +26,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Anthropic",
     },
     icon: "anthropic",
-    default_protocol: "anthropic-msgs",
+    default_protocol: "anthropic-messages",
     channels: &[
         ChannelDef {
             id: "default",
@@ -35,7 +35,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "Default",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "anthropic-msgs",
+                protocol: "anthropic-messages",
                 base_url: "https://api.anthropic.com",
             }],
             api_key: None,
@@ -53,7 +53,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "Claude Code",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "anthropic-msgs",
+                protocol: "anthropic-messages",
                 base_url: "https://api.anthropic.com",
             }],
             api_key: None,

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -72,7 +72,7 @@ where
     // `ctx.disable_default_auth`. Skipping unconditionally would break
     // every API-key path; gating here keeps the OAuth invariant
     // ("no leaked empty x-api-key") in a single seam shared by every
-    // openai-compat adapter.
+    // openai-compatible adapter.
     let mut headers = if ctx.disable_default_auth {
         HeaderMap::new()
     } else {

--- a/crates/nyro-core/src/provider/custom/mod.rs
+++ b/crates/nyro-core/src/provider/custom/mod.rs
@@ -23,7 +23,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Custom",
     },
     icon: "custom",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {

--- a/crates/nyro-core/src/provider/deepseek/mod.rs
+++ b/crates/nyro-core/src/provider/deepseek/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "DeepSeek",
     },
     icon: "deepseek",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -36,11 +36,11 @@ const METADATA: VendorMetadata = VendorMetadata {
         },
         base_urls: &[
             ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "https://api.deepseek.com/v1",
             },
             ProtocolBaseUrl {
-                protocol: "anthropic-msgs",
+                protocol: "anthropic-messages",
                 base_url: "https://api.deepseek.com/anthropic",
             },
         ],

--- a/crates/nyro-core/src/provider/google/mod.rs
+++ b/crates/nyro-core/src/provider/google/mod.rs
@@ -23,7 +23,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Google",
     },
     icon: "google",
-    default_protocol: "google-genai",
+    default_protocol: "google-gemini",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -32,11 +32,11 @@ const METADATA: VendorMetadata = VendorMetadata {
         },
         base_urls: &[
             ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
             },
             ProtocolBaseUrl {
-                protocol: "google-genai",
+                protocol: "google-gemini",
                 base_url: "https://generativelanguage.googleapis.com",
             },
         ],

--- a/crates/nyro-core/src/provider/minimax/mod.rs
+++ b/crates/nyro-core/src/provider/minimax/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "MiniMax",
     },
     icon: "minimax",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[
         ChannelDef {
             id: "default",
@@ -37,11 +37,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.minimax.io/v1",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.minimax.io/anthropic",
                 },
             ],
@@ -61,11 +61,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.minimaxi.com/v1",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.minimaxi.com/anthropic",
                 },
             ],

--- a/crates/nyro-core/src/provider/moonshotai/mod.rs
+++ b/crates/nyro-core/src/provider/moonshotai/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Moonshot AI",
     },
     icon: "kimi",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[
         ChannelDef {
             id: "default",
@@ -37,11 +37,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.moonshot.ai/v1",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.moonshot.ai/anthropic",
                 },
             ],
@@ -61,11 +61,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.moonshot.cn/v1",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.moonshot.cn/anthropic",
                 },
             ],

--- a/crates/nyro-core/src/provider/nvidia/mod.rs
+++ b/crates/nyro-core/src/provider/nvidia/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "NVIDIA",
     },
     icon: "nvidia",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -35,7 +35,7 @@ const METADATA: VendorMetadata = VendorMetadata {
             en: "Default",
         },
         base_urls: &[ProtocolBaseUrl {
-            protocol: "openai-compat",
+            protocol: "openai-compatible",
             base_url: "https://integrate.api.nvidia.com/v1",
         }],
         api_key: None,

--- a/crates/nyro-core/src/provider/ollama/mod.rs
+++ b/crates/nyro-core/src/provider/ollama/mod.rs
@@ -31,7 +31,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Ollama",
     },
     icon: "ollama",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -40,11 +40,11 @@ const METADATA: VendorMetadata = VendorMetadata {
         },
         base_urls: &[
             ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "http://127.0.0.1:11434/v1",
             },
             ProtocolBaseUrl {
-                protocol: "anthropic-msgs",
+                protocol: "anthropic-messages",
                 base_url: "http://127.0.0.1:11434",
             },
         ],

--- a/crates/nyro-core/src/provider/openai/mod.rs
+++ b/crates/nyro-core/src/provider/openai/mod.rs
@@ -30,7 +30,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "OpenAI",
     },
     icon: "openai",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[
         ChannelDef {
             id: "default",
@@ -39,7 +39,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "Default",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "https://api.openai.com/v1",
             }],
             api_key: None,
@@ -57,7 +57,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "Codex",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "openai-resps",
+                protocol: "openai-responses",
                 base_url: "https://chatgpt.com/backend-api/codex",
             }],
             api_key: None,

--- a/crates/nyro-core/src/provider/openrouter/mod.rs
+++ b/crates/nyro-core/src/provider/openrouter/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "OpenRouter",
     },
     icon: "openrouter",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -36,11 +36,11 @@ const METADATA: VendorMetadata = VendorMetadata {
         },
         base_urls: &[
             ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "https://openrouter.ai/api/v1",
             },
             ProtocolBaseUrl {
-                protocol: "anthropic-msgs",
+                protocol: "anthropic-messages",
                 base_url: "https://openrouter.ai/api",
             },
         ],

--- a/crates/nyro-core/src/provider/vertexai/mod.rs
+++ b/crates/nyro-core/src/provider/vertexai/mod.rs
@@ -41,7 +41,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Vertex AI",
     },
     icon: "googlecloud",
-    default_protocol: "google-genai",
+    default_protocol: "google-gemini",
     channels: &[
         ChannelDef {
             id: "native",
@@ -50,7 +50,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "Native Gemini",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "google-genai",
+                protocol: "google-gemini",
                 base_url: "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global",
             }],
             api_key: None,
@@ -74,7 +74,7 @@ const METADATA: VendorMetadata = VendorMetadata {
                 en: "OpenAI Compatible",
             },
             base_urls: &[ProtocolBaseUrl {
-                protocol: "openai-compat",
+                protocol: "openai-compatible",
                 base_url: "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi",
             }],
             api_key: None,
@@ -321,7 +321,7 @@ mod tests {
             id: "test".into(),
             name: "test".into(),
             vendor: Some("vertexai".into()),
-            protocol: "openai-compat".into(),
+            protocol: "openai-compatible".into(),
             base_url: "https://aiplatform.googleapis.com/v1/projects/demo/locations/global/endpoints/openapi".into(),
             preset_key: None,
             channel: None,

--- a/crates/nyro-core/src/provider/xai/mod.rs
+++ b/crates/nyro-core/src/provider/xai/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "xAI",
     },
     icon: "xai",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[ChannelDef {
         id: "default",
         label: Label {
@@ -35,7 +35,7 @@ const METADATA: VendorMetadata = VendorMetadata {
             en: "Default",
         },
         base_urls: &[ProtocolBaseUrl {
-            protocol: "openai-compat",
+            protocol: "openai-compatible",
             base_url: "https://api.x.ai/v1",
         }],
         api_key: None,

--- a/crates/nyro-core/src/provider/zai/mod.rs
+++ b/crates/nyro-core/src/provider/zai/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Z.ai",
     },
     icon: "zai",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[
         ChannelDef {
             id: "default",
@@ -37,11 +37,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.z.ai/api/paas/v4",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.z.ai/api/anthropic",
                 },
             ],
@@ -61,11 +61,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://api.z.ai/api/coding/paas/v4",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://api.z.ai/api/anthropic",
                 },
             ],

--- a/crates/nyro-core/src/provider/zhipuai/mod.rs
+++ b/crates/nyro-core/src/provider/zhipuai/mod.rs
@@ -27,7 +27,7 @@ const METADATA: VendorMetadata = VendorMetadata {
         en: "Zhipu AI",
     },
     icon: "zhipu",
-    default_protocol: "openai-compat",
+    default_protocol: "openai-compatible",
     channels: &[
         ChannelDef {
             id: "default",
@@ -37,11 +37,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://open.bigmodel.cn/api/paas/v4",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://open.bigmodel.cn/api/anthropic",
                 },
             ],
@@ -61,11 +61,11 @@ const METADATA: VendorMetadata = VendorMetadata {
             },
             base_urls: &[
                 ProtocolBaseUrl {
-                    protocol: "openai-compat",
+                    protocol: "openai-compatible",
                     base_url: "https://open.bigmodel.cn/api/coding/paas/v4",
                 },
                 ProtocolBaseUrl {
-                    protocol: "anthropic-msgs",
+                    protocol: "anthropic-messages",
                     base_url: "https://open.bigmodel.cn/api/anthropic",
                 },
             ],

--- a/crates/nyro-core/tests/fixtures/providers_legacy.json
+++ b/crates/nyro-core/tests/fixtures/providers_legacy.json
@@ -6,7 +6,7 @@
       "en": "Custom"
     },
     "icon": "custom",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -25,7 +25,7 @@
       "en": "OpenAI"
     },
     "icon": "openai",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -34,7 +34,7 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.openai.com/v1"
+          "openai-compatible": "https://api.openai.com/v1"
         },
         "modelsSource": "https://api.openai.com/v1/models",
         "authMode": "apikey"
@@ -46,7 +46,7 @@
           "en": "Codex"
         },
         "baseUrls": {
-          "openai-resps": "https://chatgpt.com/backend-api/codex"
+          "openai-responses": "https://chatgpt.com/backend-api/codex"
         },
         "modelsSource": "https://chatgpt.com/backend-api/codex/models",
         "authMode": "oauth",
@@ -73,7 +73,7 @@
       "en": "Anthropic"
     },
     "icon": "anthropic",
-    "defaultProtocol": "anthropic-msgs",
+    "defaultProtocol": "anthropic-messages",
     "channels": [
       {
         "id": "default",
@@ -82,7 +82,7 @@
           "en": "Default"
         },
         "baseUrls": {
-          "anthropic-msgs": "https://api.anthropic.com"
+          "anthropic-messages": "https://api.anthropic.com"
         },
         "modelsSource": "https://api.anthropic.com/v1/models",
         "authMode": "apikey"
@@ -94,7 +94,7 @@
           "en": "Claude Code"
         },
         "baseUrls": {
-          "anthropic-msgs": "https://api.anthropic.com"
+          "anthropic-messages": "https://api.anthropic.com"
         },
         "modelsSource": "ai://models.dev/anthropic",
         "staticModels": [
@@ -127,7 +127,7 @@
       "en": "Google"
     },
     "icon": "google",
-    "defaultProtocol": "google-genai",
+    "defaultProtocol": "google-gemini",
     "channels": [
       {
         "id": "default",
@@ -136,8 +136,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://generativelanguage.googleapis.com/v1beta/openai",
-          "google-genai": "https://generativelanguage.googleapis.com"
+          "openai-compatible": "https://generativelanguage.googleapis.com/v1beta/openai",
+          "google-gemini": "https://generativelanguage.googleapis.com"
         },
         "modelsSource": "https://generativelanguage.googleapis.com/v1beta/openai/models",
         "authMode": "apikey"
@@ -151,7 +151,7 @@
       "en": "Vertex AI"
     },
     "icon": "googlecloud",
-    "defaultProtocol": "google-genai",
+    "defaultProtocol": "google-gemini",
     "channels": [
       {
         "id": "native",
@@ -160,7 +160,7 @@
           "en": "Native Gemini"
         },
         "baseUrls": {
-          "google-genai": "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global"
+          "google-gemini": "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global"
         },
         "staticModels": [
           "gemini-2.5-pro",
@@ -178,7 +178,7 @@
           "en": "OpenAI Compatible"
         },
         "baseUrls": {
-          "openai-compat": "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi"
+          "openai-compatible": "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi"
         },
         "staticModels": [
           "google/gemini-2.5-pro",
@@ -196,7 +196,7 @@
       "en": "xAI"
     },
     "icon": "xai",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -205,7 +205,7 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.x.ai/v1"
+          "openai-compatible": "https://api.x.ai/v1"
         },
         "modelsSource": "https://api.x.ai/v1/models",
         "authMode": "apikey"
@@ -219,7 +219,7 @@
       "en": "DeepSeek"
     },
     "icon": "deepseek",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -228,8 +228,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.deepseek.com/v1",
-          "anthropic-msgs": "https://api.deepseek.com/anthropic"
+          "openai-compatible": "https://api.deepseek.com/v1",
+          "anthropic-messages": "https://api.deepseek.com/anthropic"
         },
         "modelsSource": "https://api.deepseek.com/v1/models",
         "authMode": "apikey"
@@ -243,7 +243,7 @@
       "en": "Moonshot AI"
     },
     "icon": "kimi",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -252,8 +252,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.moonshot.ai/v1",
-          "anthropic-msgs": "https://api.moonshot.ai/anthropic"
+          "openai-compatible": "https://api.moonshot.ai/v1",
+          "anthropic-messages": "https://api.moonshot.ai/anthropic"
         },
         "modelsSource": "https://api.moonshot.ai/v1/models",
         "authMode": "apikey"
@@ -265,8 +265,8 @@
           "en": "China"
         },
         "baseUrls": {
-          "openai-compat": "https://api.moonshot.cn/v1",
-          "anthropic-msgs": "https://api.moonshot.cn/anthropic"
+          "openai-compatible": "https://api.moonshot.cn/v1",
+          "anthropic-messages": "https://api.moonshot.cn/anthropic"
         },
         "modelsSource": "https://api.moonshot.cn/v1/models",
         "authMode": "apikey"
@@ -280,7 +280,7 @@
       "en": "MiniMax"
     },
     "icon": "minimax",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -289,8 +289,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.minimax.io/v1",
-          "anthropic-msgs": "https://api.minimax.io/anthropic"
+          "openai-compatible": "https://api.minimax.io/v1",
+          "anthropic-messages": "https://api.minimax.io/anthropic"
         },
         "modelsSource": "ai://models.dev/minimax",
         "staticModels": [],
@@ -303,8 +303,8 @@
           "en": "China"
         },
         "baseUrls": {
-          "openai-compat": "https://api.minimaxi.com/v1",
-          "anthropic-msgs": "https://api.minimaxi.com/anthropic"
+          "openai-compatible": "https://api.minimaxi.com/v1",
+          "anthropic-messages": "https://api.minimaxi.com/anthropic"
         },
         "modelsSource": "ai://models.dev/minimax",
         "staticModels": [],
@@ -319,7 +319,7 @@
       "en": "Zhipu AI"
     },
     "icon": "zhipu",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -328,8 +328,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://open.bigmodel.cn/api/paas/v4",
-          "anthropic-msgs": "https://open.bigmodel.cn/api/anthropic"
+          "openai-compatible": "https://open.bigmodel.cn/api/paas/v4",
+          "anthropic-messages": "https://open.bigmodel.cn/api/anthropic"
         },
         "modelsSource": "https://open.bigmodel.cn/api/paas/v4/models",
         "authMode": "apikey"
@@ -341,8 +341,8 @@
           "en": "Coding Plan"
         },
         "baseUrls": {
-          "openai-compat": "https://open.bigmodel.cn/api/coding/paas/v4",
-          "anthropic-msgs": "https://open.bigmodel.cn/api/anthropic"
+          "openai-compatible": "https://open.bigmodel.cn/api/coding/paas/v4",
+          "anthropic-messages": "https://open.bigmodel.cn/api/anthropic"
         },
         "modelsSource": "https://open.bigmodel.cn/api/coding/paas/v4/models",
         "authMode": "apikey"
@@ -356,7 +356,7 @@
       "en": "Z.ai"
     },
     "icon": "zai",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -365,8 +365,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://api.z.ai/api/paas/v4",
-          "anthropic-msgs": "https://api.z.ai/api/anthropic"
+          "openai-compatible": "https://api.z.ai/api/paas/v4",
+          "anthropic-messages": "https://api.z.ai/api/anthropic"
         },
         "modelsSource": "https://api.z.ai/api/paas/v4/models",
         "authMode": "apikey"
@@ -378,8 +378,8 @@
           "en": "Coding Plan"
         },
         "baseUrls": {
-          "openai-compat": "https://api.z.ai/api/coding/paas/v4",
-          "anthropic-msgs": "https://api.z.ai/api/anthropic"
+          "openai-compatible": "https://api.z.ai/api/coding/paas/v4",
+          "anthropic-messages": "https://api.z.ai/api/anthropic"
         },
         "modelsSource": "https://api.z.ai/api/coding/paas/v4/models",
         "authMode": "apikey"
@@ -393,7 +393,7 @@
       "en": "NVIDIA"
     },
     "icon": "nvidia",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -402,7 +402,7 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://integrate.api.nvidia.com/v1"
+          "openai-compatible": "https://integrate.api.nvidia.com/v1"
         },
         "modelsSource": "https://integrate.api.nvidia.com/v1/models",
         "authMode": "apikey"
@@ -416,7 +416,7 @@
       "en": "OpenRouter"
     },
     "icon": "openrouter",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -425,8 +425,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "https://openrouter.ai/api/v1",
-          "anthropic-msgs": "https://openrouter.ai/api"
+          "openai-compatible": "https://openrouter.ai/api/v1",
+          "anthropic-messages": "https://openrouter.ai/api"
         },
         "modelsSource": "https://openrouter.ai/api/v1/models",
         "authMode": "apikey"
@@ -440,7 +440,7 @@
       "en": "Ollama"
     },
     "icon": "ollama",
-    "defaultProtocol": "openai-compat",
+    "defaultProtocol": "openai-compatible",
     "channels": [
       {
         "id": "default",
@@ -449,8 +449,8 @@
           "en": "Default"
         },
         "baseUrls": {
-          "openai-compat": "http://127.0.0.1:11434/v1",
-          "anthropic-msgs": "http://127.0.0.1:11434"
+          "openai-compatible": "http://127.0.0.1:11434/v1",
+          "anthropic-messages": "http://127.0.0.1:11434"
         },
         "apiKey": "sk-ollama",
         "modelsSource": "http://127.0.0.1:11434/v1/models",

--- a/crates/nyro-core/tests/protocol_gate.rs
+++ b/crates/nyro-core/tests/protocol_gate.rs
@@ -5,7 +5,7 @@
 //! exists at the DB / protocol-negotiation layer. These tests document the new
 //! invariants:
 //!
-//! 1. A provider declaring the `openai-compat` *protocol* suite automatically
+//! 1. A provider declaring the `openai-compatible` *protocol* suite automatically
 //!    exposes **all** endpoints in that suite — including embeddings — without
 //!    any subset filtering.
 //! 2. Endpoint-keyed legacy protocol values are still resolved to their parent
@@ -37,20 +37,20 @@ fn provider(protocol: &str) -> Provider {
     }
 }
 
-/// A provider declaring the `openai-compat` protocol *suite* must expose every
+/// A provider declaring the `openai-compatible` protocol *suite* must expose every
 /// endpoint registered under that suite, including embeddings.
 #[test]
 fn openai_compat_protocol_suite_includes_embeddings() {
-    let p = provider("openai-compat");
+    let p = provider("openai-compatible");
     let pp = ProviderProtocols::from_provider(&p);
 
     assert!(
         pp.supports(OPENAI_CHAT_COMPLETIONS_V1),
-        "chat-completions must be included in openai-compat suite"
+        "chat-completions must be included in openai-compatible suite"
     );
     assert!(
         pp.supports(OPENAI_EMBEDDINGS_V1),
-        "embeddings must be included in openai-compat suite"
+        "embeddings must be included in openai-compatible suite"
     );
 }
 

--- a/crates/nyro-core/tests/protocol_migration.rs
+++ b/crates/nyro-core/tests/protocol_migration.rs
@@ -42,7 +42,7 @@ async fn migration_collapses_legacy_columns_and_is_idempotent() {
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<String, _>("protocol"), "anthropic-msgs");
+    assert_eq!(row.get::<String, _>("protocol"), "anthropic-messages");
     assert_eq!(row.get::<String, _>("base_url"), "https://b.example/v1");
 
     let columns = sqlx::query("PRAGMA table_info(providers)")

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -83,7 +83,7 @@ fn resolve_egress_exact_match_skips_conversion() {
 
 #[test]
 fn resolve_egress_responses_falls_back_to_provider_default() {
-    // OpenAI Responses (openai-resps) and OpenAI Compatible (openai-compat) are
+    // OpenAI Responses (`openai-responses`) and OpenAI Compatible (`openai-compatible`) are
     // separate protocols; there is no same-protocol Tier-2 fallback between them.
     // A client speaking Responses API falls through to Tier 3 (provider default).
     let provider = provider_with_protocol("openai", "https://a.example/v1");

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -97,9 +97,10 @@ fn vertex_vendor_is_registered_with_native_and_openai_channels() {
         "vertex must expose native google-gemini endpoint"
     );
     assert!(
-        meta.channels
+        meta.channels.iter().any(|c| c
+            .base_urls
             .iter()
-            .any(|c| c.base_urls.iter().any(|b| b.protocol == "openai-compatible")),
+            .any(|b| b.protocol == "openai-compatible")),
         "vertex must expose OpenAI-compatible endpoint"
     );
 }

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -89,17 +89,17 @@ fn resolve_falls_back_to_vendor_when_channel_unknown() {
 fn vertex_vendor_is_registered_with_native_and_openai_channels() {
     let reg = VendorRegistry::global();
     let meta = reg.metadata("vertexai").expect("vertex metadata");
-    assert_eq!(meta.default_protocol, "google-genai");
+    assert_eq!(meta.default_protocol, "google-gemini");
     assert!(
         meta.channels
             .iter()
-            .any(|c| c.base_urls.iter().any(|b| b.protocol == "google-genai")),
-        "vertex must expose native google-genai endpoint"
+            .any(|c| c.base_urls.iter().any(|b| b.protocol == "google-gemini")),
+        "vertex must expose native google-gemini endpoint"
     );
     assert!(
         meta.channels
             .iter()
-            .any(|c| c.base_urls.iter().any(|b| b.protocol == "openai-compat")),
+            .any(|c| c.base_urls.iter().any(|b| b.protocol == "openai-compatible")),
         "vertex must expose OpenAI-compatible endpoint"
     );
 }
@@ -108,7 +108,7 @@ fn vertex_vendor_is_registered_with_native_and_openai_channels() {
 fn vertex_build_url_rewrites_google_generate_content_to_vertex_resource() {
     let reg = VendorRegistry::global();
     let mut p = make_provider(Some("vertexai"), None);
-    p.protocol = "google-genai".into();
+    p.protocol = "google-gemini".into();
     p.base_url = "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global".into();
     p.api_key = r#"{"project_id":"demo-project"}"#.into();
     let ext = reg
@@ -138,7 +138,7 @@ fn vertex_build_url_rewrites_google_generate_content_to_vertex_resource() {
 fn vertex_build_url_rewrites_openai_compat_path_without_double_version() {
     let reg = VendorRegistry::global();
     let mut p = make_provider(Some("vertexai"), None);
-    p.protocol = "openai-compat".into();
+    p.protocol = "openai-compatible".into();
     p.base_url = "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi".into();
     p.api_key = r#"{"project_id":"demo-project"}"#.into();
     let ext = reg

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -591,7 +591,7 @@ providers:
         let providers = build_providers(&cfg);
         assert_eq!(providers.len(), 1);
         let p = &providers[0];
-        assert_eq!(p.protocol, "openai-compat");
+        assert_eq!(p.protocol, "openai-compatible");
         assert_eq!(p.base_url, "https://a.example/v1");
     }
 

--- a/webui/src/lib/protocol.ts
+++ b/webui/src/lib/protocol.ts
@@ -2,7 +2,7 @@
  * Protocol utilities — mirrors the backend three-layer identity model.
  *
  * Three orthogonal concepts:
- *   Protocol  — suite / wire-format family  (e.g. "openai-compat")
+ *   Protocol  — suite / wire-format family  (e.g. "openai-compatible")
  *   Endpoint  — specific API path           (e.g. "chat-completions")
  *   Vendor    — provider organisation       (e.g. "openai")
  *
@@ -13,13 +13,13 @@
  *   crates/nyro-core/src/protocol/registry.rs::default_protocol_aliases
  */
 
-// ── Protocol enum (canonical short names) ─────────────────────────────────
+// ── Protocol enum (canonical identifiers) ──────────────────────────────────
 
 export type Protocol =
-  | "openai-compat"
-  | "openai-resps"
-  | "anthropic-msgs"
-  | "google-genai";
+  | "openai-compatible"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-gemini";
 
 export interface ProtocolMeta {
   id: Protocol;
@@ -31,23 +31,23 @@ export interface ProtocolMeta {
 
 export const PROTOCOL_TABLE: ProtocolMeta[] = [
   {
-    id: "openai-compat",
+    id: "openai-compatible",
     displayName: "OpenAI Compatible",
     defaultBaseUrl: "https://api.openai.com/v1",
   },
   {
-    id: "openai-resps",
+    id: "openai-responses",
     displayName: "OpenAI Responses",
     defaultBaseUrl: "https://api.openai.com/v1",
   },
   {
-    id: "anthropic-msgs",
+    id: "anthropic-messages",
     displayName: "Anthropic Messages",
     defaultBaseUrl: "https://api.anthropic.com",
   },
   {
-    id: "google-genai",
-    displayName: "Google Generative AI",
+    id: "google-gemini",
+    displayName: "Google Gemini",
     defaultBaseUrl: "https://generativelanguage.googleapis.com",
   },
 ];
@@ -56,48 +56,56 @@ export const PROTOCOL_TABLE: ProtocolMeta[] = [
 
 /** Maps any known string (old canonical, short alias, legacy brand) → Protocol. */
 const PROTOCOL_ALIASES: Record<string, Protocol> = {
-  // New canonical short names (idempotent)
-  "openai-compat": "openai-compat",
-  "openai-resps": "openai-resps",
-  "anthropic-msgs": "anthropic-msgs",
-  "google-genai": "google-genai",
+  // Canonical (new)
+  "openai-compatible": "openai-compatible",
+  "openai-responses": "openai-responses",
+  "anthropic-messages": "anthropic-messages",
+  "google-gemini": "google-gemini",
 
-  // Full names
-  "openai-compatible": "openai-compat",
-  "openai-responses": "openai-resps",
-  "anthropic-messages": "anthropic-msgs",
-  "google-generative-ai": "google-genai",
+  // Short names
+  openai: "openai-compatible",
+  openai_responses: "openai-responses",
+  responses: "openai-responses",
+  anthropic: "anthropic-messages",
+  claude: "anthropic-messages",
+  gemini: "google-gemini",
+  google: "google-gemini",
 
-  // Legacy brand names
-  openai: "openai-compat",
-  openai_responses: "openai-resps",
-  responses: "openai-resps",
-  anthropic: "anthropic-msgs",
-  claude: "anthropic-msgs",
-  gemini: "google-genai",
-  google: "google-genai",
+  // Deprecated aliases (old canonical slugs)
+  "openai-compat": "openai-compatible",
+  "openai-resps": "openai-responses",
+  "anthropic-msgs": "anthropic-messages",
+  "google-genai": "google-gemini",
+  "google-generative-ai": "google-gemini",
 
   // Old canonical endpoint strings (Tier-1 backward compat)
-  "openai/chat/v1": "openai-compat",
-  "openai/embeddings/v1": "openai-compat",
-  "openai/responses/v1": "openai-resps",
-  "anthropic/messages/2023-06-01": "anthropic-msgs",
-  "google/generate/v1beta": "google-genai",
+  "openai/chat/v1": "openai-compatible",
+  "openai/embeddings/v1": "openai-compatible",
+  "openai/responses/v1": "openai-responses",
+  "anthropic/messages/2023-06-01": "anthropic-messages",
+  "google/generate/v1beta": "google-gemini",
+
+  // Deprecated canonical endpoint strings
+  "openai-compat/chat-completions/v1": "openai-compatible",
+  "openai-compat/embeddings/v1": "openai-compatible",
+  "openai-resps/responses/v1": "openai-responses",
+  "anthropic-msgs/messages/2023-06-01": "anthropic-messages",
+  "google-genai/generate-content/v1beta": "google-gemini",
 
   // New canonical endpoint strings
-  "openai-compat/chat-completions/v1": "openai-compat",
-  "openai-compat/embeddings/v1": "openai-compat",
-  "openai-resps/responses/v1": "openai-resps",
-  "anthropic-msgs/messages/2023-06-01": "anthropic-msgs",
-  "google-genai/generate-content/v1beta": "google-genai",
+  "openai-compatible/chat-completions/v1": "openai-compatible",
+  "openai-compatible/embeddings/v1": "openai-compatible",
+  "openai-responses/responses/v1": "openai-responses",
+  "anthropic-messages/messages/2023-06-01": "anthropic-messages",
+  "google-gemini/generate-content/v1beta": "google-gemini",
 };
 
 /**
  * Resolve any raw protocol string to a canonical `Protocol`, or `null` if unknown.
  *
- * Accepts: new canonical keys (`"openai-compat"`), legacy aliases (`"openai"`),
+ * Accepts: new canonical keys (`"openai-compatible"`), legacy aliases (`"openai"`),
  * old endpoint canonical strings (`"openai/chat/v1"`), and new endpoint
- * canonical strings (`"openai-compat/chat-completions/v1"`).
+ * canonical strings (`"openai-compatible/chat-completions/v1"`).
  */
 export function resolveProtocol(raw: string | null | undefined): Protocol | null {
   if (!raw) return null;
@@ -147,7 +155,7 @@ export function parseProtocolEndpoint(raw: string | null | undefined): ProtocolE
 /** Returns true when the raw string resolves to an OpenAI-family protocol. */
 export function isOpenAiProtocol(raw: string | null | undefined): boolean {
   const p = resolveProtocol(raw);
-  return p === "openai-compat" || p === "openai-resps";
+  return p === "openai-compatible" || p === "openai-responses";
 }
 
 /**

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -169,10 +169,10 @@ export interface ModelCapabilities {
 }
 
 export type ProviderProtocol =
-  | "openai-compat"
-  | "openai-resps"
-  | "anthropic-msgs"
-  | "google-genai";
+  | "openai-compatible"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-gemini";
 
 export interface ProviderChannelPreset {
   id: string;

--- a/webui/src/pages/connect.tsx
+++ b/webui/src/pages/connect.tsx
@@ -17,7 +17,7 @@ const CodeHighlighter = lazy(() => import("@/components/ui/code-highlighter"));
 
 type CodeLanguage = "python" | "typescript" | "curl";
 type CliToolId = "claude-code" | "codex-cli" | "gemini-cli" | "opencode";
-type GatewayProtocol = "openai-compat" | "anthropic-msgs" | "google-genai";
+type GatewayProtocol = "openai-compatible" | "anthropic-messages" | "google-gemini";
 type CodeProtocol = GatewayProtocol;
 type RouteKind = "chat" | "embedding";
 
@@ -41,37 +41,37 @@ const CLI_TOOLS: CliTool[] = [
     id: "claude-code",
     name: "Claude Code",
     iconKey: "claude",
-    protocol: "anthropic-msgs",
+    protocol: "anthropic-messages",
     desc: { zh: "Anthropic 官方命令行编程助手", en: "Anthropic official coding CLI assistant" },
   },
   {
     id: "codex-cli",
     name: "Codex CLI",
     iconKey: "openai",
-    protocol: "openai-compat",
+    protocol: "openai-compatible",
     desc: { zh: "OpenAI 命令行编程工具", en: "OpenAI coding CLI tool" },
   },
   {
     id: "gemini-cli",
     name: "Gemini CLI",
     iconKey: "gemini",
-    protocol: "google-genai",
+    protocol: "google-gemini",
     desc: { zh: "Google Gemini 命令行工具", en: "Google Gemini command line tool" },
   },
   {
     id: "opencode",
     name: "OpenCode",
     iconKey: "opencode-logo-light",
-    protocol: "openai-compat",
+    protocol: "openai-compatible",
     desc: { zh: "开源 AI 编程命令行工具", en: "Open-source AI coding CLI tool" },
   },
 ];
 
 const CODE_LANGS: CodeLanguage[] = ["python", "typescript", "curl"];
 const CODE_PROTOCOLS: CodeProtocolOption[] = [
-  { id: "openai-compat", name: "OpenAI Compatible", iconKey: "openai", apiPath: "/v1/chat/completions" },
-  { id: "anthropic-msgs", name: "Anthropic Messages", iconKey: "anthropic", apiPath: "/v1/messages" },
-  { id: "google-genai", name: "Google Generative AI", iconKey: "gemini", apiPath: "/v1beta/models/{model}:generateContent" },
+  { id: "openai-compatible", name: "OpenAI Compatible", iconKey: "openai", apiPath: "/v1/chat/completions" },
+  { id: "anthropic-messages", name: "Anthropic Messages", iconKey: "anthropic", apiPath: "/v1/messages" },
+  { id: "google-gemini", name: "Google Gemini", iconKey: "gemini", apiPath: "/v1beta/models/{model}:generateContent" },
 ];
 const OPTIONAL_KEY_PLACEHOLDER = "sk-00000000000000000000000000000000";
 const UNSELECTED_KEY_PLACEHOLDER = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
@@ -83,14 +83,14 @@ function maskApiKey(key: string) {
 }
 
 function protocolLabel(protocol: GatewayProtocol, _isZh: boolean) {
-  if (protocol === "openai-compat") return "OpenAI Compatible";
-  if (protocol === "anthropic-msgs") return "Anthropic Messages";
-  return "Google Generative AI";
+  if (protocol === "openai-compatible") return "OpenAI Compatible";
+  if (protocol === "anthropic-messages") return "Anthropic Messages";
+  return "Google Gemini";
 }
 
 function protocolApiPath(protocol: CodeProtocol) {
-  if (protocol === "openai-compat") return "/v1/chat/completions";
-  if (protocol === "anthropic-msgs") return "/v1/messages";
+  if (protocol === "openai-compatible") return "/v1/chat/completions";
+  if (protocol === "anthropic-messages") return "/v1/messages";
   return "/v1beta/models/{model}:generateContent";
 }
 
@@ -160,7 +160,7 @@ return response.data[0].embedding;`;
   }
 
   if (language === "curl") {
-    if (protocol === "openai-compat") {
+    if (protocol === "openai-compatible") {
       return `curl ${host}/v1/chat/completions \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Content-Type: application/json" \\
@@ -169,7 +169,7 @@ return response.data[0].embedding;`;
     messages: [{ role: "user", content: "Hello" }],
   })}'`;
     }
-    if (protocol === "anthropic-msgs") {
+    if (protocol === "anthropic-messages") {
       return `curl ${host}/v1/messages \\
   -H "x-api-key: ${apiKey}" \\
   -H "anthropic-version: 2023-06-01" \\
@@ -189,7 +189,7 @@ return response.data[0].embedding;`;
   }
 
   if (language === "python") {
-    if (protocol === "openai-compat") {
+    if (protocol === "openai-compatible") {
       return `# pip install openai
 from openai import OpenAI
 
@@ -205,7 +205,7 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)`;
     }
-    if (protocol === "anthropic-msgs") {
+    if (protocol === "anthropic-messages") {
       return `# pip install anthropic
 from anthropic import Anthropic
 
@@ -238,7 +238,7 @@ response = client.models.generate_content(
 print(response.text)`;
   }
 
-  if (protocol === "openai-compat") {
+  if (protocol === "openai-compatible") {
     return `// npm install openai
 import OpenAI from "openai";
 
@@ -255,7 +255,7 @@ const response = await client.chat.completions.create({
 const content = response.choices[0]?.message?.content;
 return content;`;
   }
-  if (protocol === "anthropic-msgs") {
+  if (protocol === "anthropic-messages") {
     return `// npm install @anthropic-ai/sdk
 import Anthropic from "@anthropic-ai/sdk";
 
@@ -395,7 +395,7 @@ export default function ConnectPage() {
 
   const [tab, setTab] = useState<"code" | "cli">("cli");
   const [codeLang, setCodeLang] = useState<CodeLanguage>("python");
-  const [selectedCodeProtocol, setSelectedCodeProtocol] = useState<CodeProtocol>("openai-compat");
+  const [selectedCodeProtocol, setSelectedCodeProtocol] = useState<CodeProtocol>("openai-compatible");
   const [selectedCodeRouteId, setSelectedCodeRouteId] = useState("");
   const [selectedCliRouteId, setSelectedCliRouteId] = useState("");
   const [selectedCodeKeyId, setSelectedCodeKeyId] = useState("");

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -69,7 +69,7 @@ function protocolUrl(protocol: string) {
 const emptyCreate: CreateProvider = {
   name: "",
   vendor: undefined,
-  protocol: "openai-compat",
+  protocol: "openai-compatible",
   base_url: "https://api.openai.com/v1",
   use_proxy: false,
   auth_mode: "apikey",
@@ -82,10 +82,10 @@ const emptyCreate: CreateProvider = {
 const PAGE_SIZE = 7;
 const DEFAULT_PRESET_ID = "nyro";
 const protocolOptions = [
-  { label: "OpenAI Compatible", value: "openai-compat" },
-  { label: "OpenAI Responses",  value: "openai-resps"  },
-  { label: "Anthropic Messages", value: "anthropic-msgs" },
-  { label: "Google Generative AI", value: "google-genai" },
+  { label: "OpenAI Compatible", value: "openai-compatible" },
+  { label: "OpenAI Responses",  value: "openai-responses"  },
+  { label: "Anthropic Messages", value: "anthropic-messages" },
+  { label: "Google Gemini", value: "google-gemini" },
 ] as const satisfies ReadonlyArray<{ label: string; value: ProviderProtocol }>;
 
 function validateProviderEndpoint(
@@ -141,7 +141,7 @@ function resolvePresetProtocol(
   preferred?: ProviderProtocol,
 ): ProviderProtocol {
   const available = availableProtocolsForPreset(preset, channelId);
-  const canonicalDefault = (resolveProtocol(preset.defaultProtocol) ?? "openai-compat") as ProviderProtocol;
+  const canonicalDefault = (resolveProtocol(preset.defaultProtocol) ?? "openai-compatible") as ProviderProtocol;
   if (preferred && available.includes(preferred)) return preferred;
   if (available.includes(canonicalDefault)) return canonicalDefault;
   return available[0] ?? canonicalDefault;
@@ -176,7 +176,7 @@ function defaultModelsEndpoint(baseUrl: string, protocol: ProviderProtocol) {
     parsed = null;
   }
 
-  if (protocol === "openai-compat" || protocol === "openai-resps" || protocol === "anthropic-msgs") {
+  if (protocol === "openai-compatible" || protocol === "openai-responses" || protocol === "anthropic-messages") {
     // OpenRouter model discovery endpoint should be /api/v1/models.
     if (parsed?.host === "openrouter.ai") {
       const pathname = parsed.pathname.replace(/\/+$/, "");
@@ -193,7 +193,7 @@ function defaultModelsEndpoint(baseUrl: string, protocol: ProviderProtocol) {
     }
   }
 
-  if (protocol === "google-genai") {
+  if (protocol === "google-gemini") {
     return `${normalized}/v1beta/models`;
   }
 
@@ -208,7 +208,7 @@ function isVertexProviderSelection(value?: Pick<CreateProvider, "vendor" | "pres
 
 function defaultVertexBaseUrl(protocol: ProviderProtocol | string) {
   const base = "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global";
-  return protocol === "openai-compat" ? `${base}/endpoints/openapi` : base;
+  return protocol === "openai-compatible" ? `${base}/endpoints/openapi` : base;
 }
 
 function joinStaticModels(models?: string[]) {
@@ -227,7 +227,7 @@ function fallbackProviderPreset(): ProviderPreset {
   return {
     id: DEFAULT_PRESET_ID,
     label: { zh: "自定义", en: "Custom" },
-    defaultProtocol: "openai-compat",
+    defaultProtocol: "openai-compatible",
     channels: [],
   };
 }
@@ -992,7 +992,7 @@ export default function ProvidersPage() {
     };
 
     try {
-      const protocol = (resolveProtocol(provider.protocol || "openai") ?? "openai-compat") as ProviderProtocol;
+      const protocol = (resolveProtocol(provider.protocol || "openai") ?? "openai-compatible") as ProviderProtocol;
       const baseUrl = provider.base_url?.trim() ?? "";
 
       appendTestLog("info", isZh ? `开始测试 ${provider.name}...` : `Start testing ${provider.name}...`);
@@ -1087,7 +1087,7 @@ export default function ProvidersPage() {
       (item) => item.id === (p.preset_key || DEFAULT_PRESET_ID),
     );
     const channel = p.channel || "default";
-    const savedProtocol = (resolveProtocol(p.protocol) ?? "openai-compat") as ProviderProtocol;
+    const savedProtocol = (resolveProtocol(p.protocol) ?? "openai-compatible") as ProviderProtocol;
     const safeProtocol = presetForEdit
       ? resolvePresetProtocol(presetForEdit, channel, savedProtocol)
       : savedProtocol;
@@ -1115,7 +1115,7 @@ export default function ProvidersPage() {
     if (!preset) return;
 
     const nextChannelId = preset.channels?.[0]?.id ?? "";
-    const nextProtocol = resolvePresetProtocol(preset, nextChannelId, (resolveProtocol(preset.defaultProtocol) ?? "openai-compat") as ProviderProtocol);
+    const nextProtocol = resolvePresetProtocol(preset, nextChannelId, (resolveProtocol(preset.defaultProtocol) ?? "openai-compatible") as ProviderProtocol);
     const config = resolvePresetConfig(preset, nextProtocol, nextChannelId);
     const nextBaseUrl = config.baseUrl || protocolUrl(nextProtocol);
 
@@ -1184,7 +1184,7 @@ export default function ProvidersPage() {
             const nextProtocol = resolvePresetProtocol(
               preset,
               nextChannelId,
-              (prev.protocol as ProviderProtocol) || (resolveProtocol(preset.defaultProtocol) ?? "openai-compat") as ProviderProtocol,
+              (prev.protocol as ProviderProtocol) || (resolveProtocol(preset.defaultProtocol) ?? "openai-compatible") as ProviderProtocol,
             );
             const config = resolvePresetConfig(preset, nextProtocol, nextChannelId);
             const nextBaseUrl = config.baseUrl || protocolUrl(nextProtocol);
@@ -1726,7 +1726,7 @@ export default function ProvidersPage() {
               <div className="flex gap-3">
                 <Button
                   onClick={() => {
-                    const protocol = form.protocol || "openai-compat";
+                    const protocol = form.protocol || "openai-compatible";
                     const baseUrl = toGatewayBaseUrl(form.base_url ?? "");
                     const validation = validateProviderEndpoint(protocol, baseUrl, isZh);
                     if (validation) {
@@ -1790,7 +1790,7 @@ export default function ProvidersPage() {
             const editingPresetId = editForm.preset_key || DEFAULT_PRESET_ID;
             const editingPreset =
               providerPresets.find((preset) => preset.id === editingPresetId) ?? providerPresets[0] ?? null;
-            const protocolLabels = [(resolveProtocol(p.protocol || "openai") ?? "openai-compat") as ProviderProtocol];
+            const protocolLabels = [(resolveProtocol(p.protocol || "openai") ?? "openai-compatible") as ProviderProtocol];
             const selectedPreset = providerPresets.find((preset) => preset.id === (p.preset_key || p.vendor || ""));
             const selectedProviderName = selectedPreset
               ? presetLabel(selectedPreset, isZh)
@@ -1894,7 +1894,7 @@ export default function ProvidersPage() {
                           const resolvedProtocol = resolvePresetProtocol(
                             editingPreset,
                             value,
-                            (editForm.protocol as ProviderProtocol) || (resolveProtocol(editingPreset.defaultProtocol) ?? "openai-compat") as ProviderProtocol,
+                            (editForm.protocol as ProviderProtocol) || (resolveProtocol(editingPreset.defaultProtocol) ?? "openai-compatible") as ProviderProtocol,
                           );
                           const config = resolvePresetConfig(
                             editingPreset,
@@ -2253,7 +2253,7 @@ export default function ProvidersPage() {
                     <Button
                       onClick={() => {
                         setEditError(null);
-                        const protocol = editForm.protocol || "openai-compat";
+                        const protocol = editForm.protocol || "openai-compatible";
                         const baseUrl = toGatewayBaseUrl(editForm.base_url ?? "");
                         const validation = validateProviderEndpoint(protocol, baseUrl, isZh);
                         if (validation) {
@@ -2323,13 +2323,13 @@ export default function ProvidersPage() {
                           <Badge
                             key={`${p.id}-${protocol}`}
                             variant={
-                              protocol === "anthropic-msgs"
+                              protocol === "anthropic-messages"
                                 ? "warning"
-                                : protocol === "google-genai"
+                                : protocol === "google-gemini"
                                   ? "secondary"
                                   : "success"
                             }
-                            className={`connect-label-badge ${protocol === "google-genai" ? "bg-violet-50 text-violet-700" : ""}`}
+                            className={`connect-label-badge ${protocol === "google-gemini" ? "bg-violet-50 text-violet-700" : ""}`}
                           >
                             {PROTOCOL_TABLE.find((pt) => pt.id === protocol)?.displayName ?? protocol}
                           </Badge>


### PR DESCRIPTION
Rename canonical protocol identifiers from short abbreviations to self-descriptive slugs: `openai-compat` → `openai-compatible`, `openai-resps` → `openai-responses`, `anthropic-msgs` → `anthropic-messages`, `google-genai` → `google-gemini`. Display name for Google updated from "Google Generative AI" to "Google Gemini".

Old slugs are preserved as deprecated aliases in FromStr and the registry alias table, ensuring full backward compatibility with existing YAML configs, DB rows, and API inputs. The existing normalize_provider_protocols() function automatically upgrades stored values to the new canonical slugs on next startup.