### PR TITLE
refactor(protocol): rename GoogleGenerativeAI to GoogleGemini and unify endpoint constants

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -17,8 +17,8 @@ use crate::auth::types::{
 };
 use crate::db::models::*;
 use crate::protocol::ProviderProtocols;
-use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
+use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+use crate::protocol::ids::OPENAI_COMPATIBLE_EMBEDDINGS_V1;
 use crate::provider::metadata::CapabilitiesSource;
 use crate::provider::{VendorCtx, VendorRegistry, vertexai};
 use crate::proxy::client::ProxyClient;
@@ -1006,7 +1006,7 @@ impl AdminService {
             } else {
                 target.model.clone()
             };
-            let extension = match VendorRegistry::global().resolve(&provider, OPENAI_EMBEDDINGS_V1)
+            let extension = match VendorRegistry::global().resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1)
             {
                 Some(ext) => ext.clone(),
                 None => continue,
@@ -1017,7 +1017,7 @@ impl AdminService {
             {
                 let ctx = VendorCtx {
                     provider: &provider,
-                    protocol_id: OPENAI_EMBEDDINGS_V1,
+                    protocol_id: OPENAI_COMPATIBLE_EMBEDDINGS_V1,
                     api_key: &credential,
                     actual_model: &actual_model,
                     credential: None,
@@ -2620,10 +2620,10 @@ fn resolve_models_endpoint(provider: &Provider) -> Option<String> {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(OPENAI_CHAT_COMPLETIONS_V1) {
+    if !protocols.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
+    let resolved = protocols.resolve_egress(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         return None;

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -1006,7 +1006,8 @@ impl AdminService {
             } else {
                 target.model.clone()
             };
-            let extension = match VendorRegistry::global().resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1)
+            let extension = match VendorRegistry::global()
+                .resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1)
             {
                 Some(ext) => ext.clone(),
                 None => continue,

--- a/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/decoder.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::RequestDecoder;
-use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
+use crate::protocol::ids::GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
 use crate::protocol::ir::{
     AiRequest, ContentBlock, GenerationConfig, GoogleExt, MediaSource, Message, MessageContent,
     ProtocolExt, ReasoningConfig, Role, SafetySettings, StreamConfig, ToolCall, ToolSpec,
@@ -233,7 +233,7 @@ impl GoogleDecoder {
         ai_req.reasoning = reasoning;
         ai_req.safety_settings = safety_settings;
         ai_req.ext = Some(ProtocolExt::Google(google_ext));
-        ai_req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+        ai_req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
         ai_req.meta.vendor.ingress = ingress;
 
         Ok(ai_req)

--- a/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/protocol/codec/google_generative/generate_content.rs
@@ -6,7 +6,7 @@
 //! in the request body / URL path rather than a top-level `model` field.
 
 use crate::protocol::ids::{
-    EndpointCapabilities, GOOGLE_GENERATE_CONTENT_V1BETA, ProtocolEndpoint,
+    EndpointCapabilities, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, ProtocolEndpoint,
 };
 use crate::protocol::registry::EndpointRegistration;
 use crate::protocol::traits::*;
@@ -26,7 +26,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
 
 impl EndpointHandler for GoogleGenerateContentV1Beta {
     fn id(&self) -> ProtocolEndpoint {
-        GOOGLE_GENERATE_CONTENT_V1BETA
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA
     }
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
@@ -3,7 +3,9 @@
 //! `EndpointHandler` registration shell — wraps
 //! [`super::decoder`], [`super::encoder`], and [`super::stream`] codecs.
 
-use crate::protocol::ids::{EndpointCapabilities, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
+use crate::protocol::ids::{
+    EndpointCapabilities, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolEndpoint,
+};
 use crate::protocol::registry::EndpointRegistration;
 use crate::protocol::traits::*;
 

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/chat_completions.rs
@@ -3,7 +3,7 @@
 //! `EndpointHandler` registration shell — wraps
 //! [`super::decoder`], [`super::encoder`], and [`super::stream`] codecs.
 
-use crate::protocol::ids::{EndpointCapabilities, OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
+use crate::protocol::ids::{EndpointCapabilities, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
 use crate::protocol::registry::EndpointRegistration;
 use crate::protocol::traits::*;
 
@@ -22,7 +22,7 @@ const CAPS: EndpointCapabilities = EndpointCapabilities {
 
 impl EndpointHandler for OpenAIChatCompletionsV1 {
     fn id(&self) -> ProtocolEndpoint {
-        OPENAI_CHAT_COMPLETIONS_V1
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
     }
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/decoder.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::protocol::RequestDecoder;
-use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
 use crate::protocol::ir::{
     AiRequest, ContentBlock, GenerationConfig, MediaSource, Message, MessageContent, OpenAIChatExt,
     ProtocolExt, ReasoningConfig, ReasoningEffort, ResponseFormat, Role, StreamConfig, ToolCall,
@@ -206,7 +206,7 @@ impl RequestDecoder for OpenAIDecoder {
         ai_req.reasoning = reasoning;
         ai_req.response_format = response_format;
         ai_req.ext = Some(ProtocolExt::OpenAiChat(oai_ext));
-        ai_req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+        ai_req.meta.source_protocol = Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
         ai_req.meta.vendor.ingress = ingress;
 
         Ok(ai_req)

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
@@ -32,7 +32,9 @@ use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::protocol::SseEvent;
-use crate::protocol::ids::{EndpointCapabilities, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolEndpoint};
+use crate::protocol::ids::{
+    EndpointCapabilities, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolEndpoint,
+};
 use crate::protocol::ir::Usage;
 use crate::protocol::ir::{AiRequest, GenerationConfig, Message, StreamConfig};
 use crate::protocol::registry::EndpointRegistration;

--- a/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai_compatible/embeddings.rs
@@ -32,7 +32,7 @@ use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::protocol::SseEvent;
-use crate::protocol::ids::{EndpointCapabilities, OPENAI_EMBEDDINGS_V1, ProtocolEndpoint};
+use crate::protocol::ids::{EndpointCapabilities, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolEndpoint};
 use crate::protocol::ir::Usage;
 use crate::protocol::ir::{AiRequest, GenerationConfig, Message, StreamConfig};
 use crate::protocol::registry::EndpointRegistration;
@@ -69,7 +69,7 @@ pub struct OpenAIEmbeddingsV1;
 
 impl EndpointHandler for OpenAIEmbeddingsV1 {
     fn id(&self) -> ProtocolEndpoint {
-        OPENAI_EMBEDDINGS_V1
+        OPENAI_COMPATIBLE_EMBEDDINGS_V1
     }
     fn capabilities(&self) -> &'static EndpointCapabilities {
         &CAPS
@@ -152,7 +152,7 @@ impl RequestDecoder for EmbeddingsDecoder {
             enabled: false,
             include_usage: false,
         };
-        ai_req.meta.source_protocol = Some(OPENAI_EMBEDDINGS_V1);
+        ai_req.meta.source_protocol = Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1);
         ai_req.meta.vendor.ingress = ingress;
 
         Ok(ai_req)

--- a/crates/nyro-core/src/protocol/ids.rs
+++ b/crates/nyro-core/src/protocol/ids.rs
@@ -27,7 +27,7 @@ pub enum Protocol {
     /// Anthropic Messages protocol (`/v1/messages`).
     AnthropicMessages,
     /// Google Generative AI (Gemini) protocol.
-    GoogleGenerativeAI,
+    GoogleGemini,
 }
 
 impl Protocol {
@@ -36,7 +36,7 @@ impl Protocol {
             Self::OpenAICompatible => "openai-compatible",
             Self::OpenAIResponses => "openai-responses",
             Self::AnthropicMessages => "anthropic-messages",
-            Self::GoogleGenerativeAI => "google-gemini",
+            Self::GoogleGemini => "google-gemini",
         }
     }
 
@@ -45,7 +45,7 @@ impl Protocol {
             Self::OpenAICompatible => "OpenAI Compatible",
             Self::OpenAIResponses => "OpenAI Responses",
             Self::AnthropicMessages => "Anthropic Messages",
-            Self::GoogleGenerativeAI => "Google Gemini",
+            Self::GoogleGemini => "Google Gemini",
         }
     }
 }
@@ -67,7 +67,7 @@ impl FromStr for Protocol {
                 Ok(Self::AnthropicMessages)
             }
             "google-gemini" | "google-genai" | "google-generative-ai" | "gemini" | "google" => {
-                Ok(Self::GoogleGenerativeAI)
+                Ok(Self::GoogleGemini)
             }
             other => anyhow::bail!("unknown protocol: {other}"),
         }
@@ -114,13 +114,10 @@ impl fmt::Display for ProtocolEndpoint {
 
 // ── Canonical const `ProtocolEndpoint` values ────────────────────────────────
 
-pub const OPENAI_CHAT_COMPLETIONS_V1: ProtocolEndpoint =
+pub const OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1: ProtocolEndpoint =
     ProtocolEndpoint::new(Protocol::OpenAICompatible, "chat-completions", "v1");
 
-#[deprecated(since = "0.1.0", note = "use `OPENAI_CHAT_COMPLETIONS_V1` instead")]
-pub const OPENAI_CHAT_V1: ProtocolEndpoint = OPENAI_CHAT_COMPLETIONS_V1;
-
-pub const OPENAI_EMBEDDINGS_V1: ProtocolEndpoint =
+pub const OPENAI_COMPATIBLE_EMBEDDINGS_V1: ProtocolEndpoint =
     ProtocolEndpoint::new(Protocol::OpenAICompatible, "embeddings", "v1");
 
 pub const OPENAI_RESPONSES_V1: ProtocolEndpoint =
@@ -129,11 +126,8 @@ pub const OPENAI_RESPONSES_V1: ProtocolEndpoint =
 pub const ANTHROPIC_MESSAGES_2023_06_01: ProtocolEndpoint =
     ProtocolEndpoint::new(Protocol::AnthropicMessages, "messages", "2023-06-01");
 
-pub const GOOGLE_GENERATE_CONTENT_V1BETA: ProtocolEndpoint =
-    ProtocolEndpoint::new(Protocol::GoogleGenerativeAI, "generate-content", "v1beta");
-
-#[deprecated(since = "0.1.0", note = "use `GOOGLE_GENERATE_CONTENT_V1BETA` instead")]
-pub const GOOGLE_GENERATE_V1BETA: ProtocolEndpoint = GOOGLE_GENERATE_CONTENT_V1BETA;
+pub const GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA: ProtocolEndpoint =
+    ProtocolEndpoint::new(Protocol::GoogleGemini, "generate-content", "v1beta");
 
 // ── Backward-compat type alias ────────────────────────────────────────────────
 
@@ -274,7 +268,7 @@ mod tests {
     #[test]
     fn display_canonical_form() {
         assert_eq!(
-            OPENAI_CHAT_COMPLETIONS_V1.to_string(),
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1.to_string(),
             "openai-compatible/chat-completions/v1"
         );
         assert_eq!(
@@ -286,11 +280,11 @@ mod tests {
             "anthropic-messages/messages/2023-06-01"
         );
         assert_eq!(
-            GOOGLE_GENERATE_CONTENT_V1BETA.to_string(),
+            GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA.to_string(),
             "google-gemini/generate-content/v1beta"
         );
         assert_eq!(
-            OPENAI_EMBEDDINGS_V1.to_string(),
+            OPENAI_COMPATIBLE_EMBEDDINGS_V1.to_string(),
             "openai-compatible/embeddings/v1"
         );
     }
@@ -301,7 +295,7 @@ mod tests {
             Protocol::OpenAICompatible,
             Protocol::OpenAIResponses,
             Protocol::AnthropicMessages,
-            Protocol::GoogleGenerativeAI,
+            Protocol::GoogleGemini,
         ] {
             assert_eq!(p.as_str().parse::<Protocol>().unwrap(), p);
         }
@@ -310,18 +304,11 @@ mod tests {
     #[test]
     fn protocol_endpoint_is_copy_and_hashable() {
         use std::collections::HashSet;
-        let id = OPENAI_CHAT_COMPLETIONS_V1;
+        let id = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
         let copied = id;
         let mut set = HashSet::new();
         set.insert(id);
         set.insert(copied);
         assert_eq!(set.len(), 1);
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn backward_compat_aliases() {
-        assert_eq!(OPENAI_CHAT_V1, OPENAI_CHAT_COMPLETIONS_V1);
-        assert_eq!(GOOGLE_GENERATE_V1BETA, GOOGLE_GENERATE_CONTENT_V1BETA);
     }
 }

--- a/crates/nyro-core/src/protocol/mod.rs
+++ b/crates/nyro-core/src/protocol/mod.rs
@@ -39,7 +39,7 @@ pub mod traits;
 use reqwest::header::HeaderMap;
 
 use crate::db::models::Provider;
-use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
+use crate::protocol::ids::{OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolEndpoint};
 
 // ── Client → Gateway ──
 
@@ -140,7 +140,7 @@ impl ProviderProtocols {
     /// Build from a provider DB row.
     pub fn from_provider(provider: &Provider) -> Self {
         let default = Self::parse_protocol_key(provider.protocol.trim())
-            .unwrap_or(OPENAI_CHAT_COMPLETIONS_V1);
+            .unwrap_or(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 
         Self {
             default,

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
 use crate::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
-    OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolEndpoint,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolEndpoint,
 };
 use crate::protocol::traits::EndpointHandler;
 
@@ -221,32 +221,32 @@ fn default_endpoint_aliases() -> HashMap<&'static str, ProtocolEndpoint> {
     let mut m = HashMap::new();
 
     // ── Tier 1: Old canonical (backward compat) ───────────────────────────────
-    m.insert("openai/chat/v1", OPENAI_CHAT_COMPLETIONS_V1);
-    m.insert("openai/embeddings/v1", OPENAI_EMBEDDINGS_V1);
+    m.insert("openai/chat/v1", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
+    m.insert("openai/embeddings/v1", OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     m.insert("openai/responses/v1", OPENAI_RESPONSES_V1);
     m.insert(
         "anthropic/messages/2023-06-01",
         ANTHROPIC_MESSAGES_2023_06_01,
     );
-    m.insert("google/generate/v1beta", GOOGLE_GENERATE_CONTENT_V1BETA);
+    m.insert("google/generate/v1beta", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     // ── Tier 2: Canonical short names ─────────────────────────────────────────
-    m.insert("openai-chat", OPENAI_CHAT_COMPLETIONS_V1);
-    m.insert("openai-chat-completions", OPENAI_CHAT_COMPLETIONS_V1);
+    m.insert("openai-chat", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
+    m.insert("openai-chat-completions", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     m.insert("openai-responses", OPENAI_RESPONSES_V1);
-    m.insert("openai-embeddings", OPENAI_EMBEDDINGS_V1);
+    m.insert("openai-embeddings", OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     m.insert("anthropic-messages", ANTHROPIC_MESSAGES_2023_06_01);
-    m.insert("google-generate", GOOGLE_GENERATE_CONTENT_V1BETA);
-    m.insert("google-generate-content", GOOGLE_GENERATE_CONTENT_V1BETA);
+    m.insert("google-generate", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
+    m.insert("google-generate-content", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     // ── Tier 3: Legacy brand / friendly aliases ────────────────────────────────
-    m.insert("openai", OPENAI_CHAT_COMPLETIONS_V1);
+    m.insert("openai", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     m.insert("openai_responses", OPENAI_RESPONSES_V1);
     m.insert("responses", OPENAI_RESPONSES_V1);
-    m.insert("embeddings", OPENAI_EMBEDDINGS_V1);
+    m.insert("embeddings", OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     m.insert("anthropic", ANTHROPIC_MESSAGES_2023_06_01);
     m.insert("claude", ANTHROPIC_MESSAGES_2023_06_01);
-    m.insert("gemini", GOOGLE_GENERATE_CONTENT_V1BETA);
+    m.insert("gemini", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     m
 }
@@ -259,21 +259,21 @@ fn default_protocol_aliases() -> HashMap<&'static str, Protocol> {
     m.insert("openai-compatible", Protocol::OpenAICompatible);
     m.insert("openai-responses", Protocol::OpenAIResponses);
     m.insert("anthropic-messages", Protocol::AnthropicMessages);
-    m.insert("google-gemini", Protocol::GoogleGenerativeAI);
+    m.insert("google-gemini", Protocol::GoogleGemini);
 
     // Short names
     m.insert("openai", Protocol::OpenAICompatible);
     m.insert("anthropic", Protocol::AnthropicMessages);
     m.insert("claude", Protocol::AnthropicMessages);
-    m.insert("gemini", Protocol::GoogleGenerativeAI);
-    m.insert("google", Protocol::GoogleGenerativeAI);
+    m.insert("gemini", Protocol::GoogleGemini);
+    m.insert("google", Protocol::GoogleGemini);
 
     // Deprecated aliases (old canonical slugs, backward compat only)
     m.insert("openai-compat", Protocol::OpenAICompatible);
     m.insert("openai-resps", Protocol::OpenAIResponses);
     m.insert("anthropic-msgs", Protocol::AnthropicMessages);
-    m.insert("google-genai", Protocol::GoogleGenerativeAI);
-    m.insert("google-generative-ai", Protocol::GoogleGenerativeAI);
+    m.insert("google-genai", Protocol::GoogleGemini);
+    m.insert("google-generative-ai", Protocol::GoogleGemini);
 
     m
 }
@@ -285,11 +285,11 @@ mod tests {
     #[test]
     fn registers_five_handlers() {
         let reg = ProtocolRegistry::global();
-        assert!(reg.get(&OPENAI_CHAT_COMPLETIONS_V1).is_some());
+        assert!(reg.get(&OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).is_some());
         assert!(reg.get(&OPENAI_RESPONSES_V1).is_some());
-        assert!(reg.get(&OPENAI_EMBEDDINGS_V1).is_some());
+        assert!(reg.get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1).is_some());
         assert!(reg.get(&ANTHROPIC_MESSAGES_2023_06_01).is_some());
-        assert!(reg.get(&GOOGLE_GENERATE_CONTENT_V1BETA).is_some());
+        assert!(reg.get(&GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA).is_some());
         assert_eq!(reg.list().len(), 5);
     }
 
@@ -299,7 +299,7 @@ mod tests {
         // New canonical form
         assert_eq!(
             reg.resolve_alias("openai-compatible/chat-completions/v1"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("openai-responses/responses/v1"),
@@ -311,7 +311,7 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("google-gemini/generate-content/v1beta"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
     }
 
@@ -321,7 +321,7 @@ mod tests {
         // Old canonical (tier 1)
         assert_eq!(
             reg.resolve_alias("openai/chat/v1"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("anthropic/messages/2023-06-01"),
@@ -329,13 +329,13 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("google/generate/v1beta"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
 
         // Deprecated canonical (still resolves via FromStr)
         assert_eq!(
             reg.resolve_alias("openai-compat/chat-completions/v1"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("openai-resps/responses/v1"),
@@ -347,17 +347,17 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("google-genai/generate-content/v1beta"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
 
         // Canonical short (tier 2)
         assert_eq!(
             reg.resolve_alias("openai-chat"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("openai-chat-completions"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("anthropic-messages"),
@@ -365,17 +365,17 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("google-generate"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
         assert_eq!(
             reg.resolve_alias("google-generate-content"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
 
         // Legacy brand (tier 3)
         assert_eq!(
             reg.resolve_alias("openai"),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("anthropic"),
@@ -387,7 +387,7 @@ mod tests {
         );
         assert_eq!(
             reg.resolve_alias("gemini"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
     }
 
@@ -396,11 +396,11 @@ mod tests {
         let reg = ProtocolRegistry::global();
         assert_eq!(
             reg.resolve_alias("  OpenAI  "),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.resolve_alias("GEMINI"),
-            Some(GOOGLE_GENERATE_CONTENT_V1BETA)
+            Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         );
     }
 
@@ -420,13 +420,13 @@ mod tests {
         assert!(
             openai_compat
                 .iter()
-                .any(|h| h.id() == OPENAI_CHAT_COMPLETIONS_V1)
+                .any(|h| h.id() == OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
-        assert!(openai_compat.iter().any(|h| h.id() == OPENAI_EMBEDDINGS_V1));
+        assert!(openai_compat.iter().any(|h| h.id() == OPENAI_COMPATIBLE_EMBEDDINGS_V1));
 
         assert_eq!(reg.list_by_protocol(Protocol::OpenAIResponses).len(), 1);
         assert_eq!(reg.list_by_protocol(Protocol::AnthropicMessages).len(), 1);
-        assert_eq!(reg.list_by_protocol(Protocol::GoogleGenerativeAI).len(), 1);
+        assert_eq!(reg.list_by_protocol(Protocol::GoogleGemini).len(), 1);
     }
 
     #[test]
@@ -446,11 +446,11 @@ mod tests {
         );
         assert_eq!(
             reg.parse_protocol("gemini"),
-            Some(Protocol::GoogleGenerativeAI)
+            Some(Protocol::GoogleGemini)
         );
         assert_eq!(
             reg.parse_protocol("google-gemini"),
-            Some(Protocol::GoogleGenerativeAI)
+            Some(Protocol::GoogleGemini)
         );
         // Deprecated aliases still resolve
         assert_eq!(
@@ -463,7 +463,7 @@ mod tests {
         );
         assert_eq!(
             reg.parse_protocol("google-genai"),
-            Some(Protocol::GoogleGenerativeAI)
+            Some(Protocol::GoogleGemini)
         );
     }
 
@@ -475,7 +475,7 @@ mod tests {
         assert!(protocols.contains(&Protocol::OpenAICompatible));
         assert!(protocols.contains(&Protocol::OpenAIResponses));
         assert!(protocols.contains(&Protocol::AnthropicMessages));
-        assert!(protocols.contains(&Protocol::GoogleGenerativeAI));
+        assert!(protocols.contains(&Protocol::GoogleGemini));
     }
 
     #[test]
@@ -484,7 +484,7 @@ mod tests {
         assert_eq!(
             reg.find_by_ingress_route("POST", "/v1/chat/completions")
                 .map(|h| h.id()),
-            Some(OPENAI_CHAT_COMPLETIONS_V1)
+            Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
         assert_eq!(
             reg.find_by_ingress_route("POST", "/v1/responses")
@@ -499,7 +499,7 @@ mod tests {
         assert_eq!(
             reg.find_by_ingress_route("POST", "/v1/embeddings")
                 .map(|h| h.id()),
-            Some(OPENAI_EMBEDDINGS_V1)
+            Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)
         );
         assert!(
             reg.find_by_ingress_route("GET", "/v1/chat/completions")
@@ -510,9 +510,9 @@ mod tests {
     #[test]
     fn capabilities_match_legacy_special_cases() {
         let reg = ProtocolRegistry::global();
-        let chat = reg.get(&OPENAI_CHAT_COMPLETIONS_V1).unwrap();
+        let chat = reg.get(&OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).unwrap();
         let responses = reg.get(&OPENAI_RESPONSES_V1).unwrap();
-        let google = reg.get(&GOOGLE_GENERATE_CONTENT_V1BETA).unwrap();
+        let google = reg.get(&GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA).unwrap();
 
         assert!(!chat.capabilities().force_upstream_stream);
         assert!(responses.capabilities().force_upstream_stream);

--- a/crates/nyro-core/src/protocol/registry.rs
+++ b/crates/nyro-core/src/protocol/registry.rs
@@ -9,8 +9,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
 use crate::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolEndpoint,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+    Protocol, ProtocolEndpoint,
 };
 use crate::protocol::traits::EndpointHandler;
 
@@ -228,16 +229,25 @@ fn default_endpoint_aliases() -> HashMap<&'static str, ProtocolEndpoint> {
         "anthropic/messages/2023-06-01",
         ANTHROPIC_MESSAGES_2023_06_01,
     );
-    m.insert("google/generate/v1beta", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
+    m.insert(
+        "google/generate/v1beta",
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    );
 
     // ── Tier 2: Canonical short names ─────────────────────────────────────────
     m.insert("openai-chat", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
-    m.insert("openai-chat-completions", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
+    m.insert(
+        "openai-chat-completions",
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    );
     m.insert("openai-responses", OPENAI_RESPONSES_V1);
     m.insert("openai-embeddings", OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     m.insert("anthropic-messages", ANTHROPIC_MESSAGES_2023_06_01);
     m.insert("google-generate", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
-    m.insert("google-generate-content", GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
+    m.insert(
+        "google-generate-content",
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    );
 
     // ── Tier 3: Legacy brand / friendly aliases ────────────────────────────────
     m.insert("openai", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
@@ -422,7 +432,11 @@ mod tests {
                 .iter()
                 .any(|h| h.id() == OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         );
-        assert!(openai_compat.iter().any(|h| h.id() == OPENAI_COMPATIBLE_EMBEDDINGS_V1));
+        assert!(
+            openai_compat
+                .iter()
+                .any(|h| h.id() == OPENAI_COMPATIBLE_EMBEDDINGS_V1)
+        );
 
         assert_eq!(reg.list_by_protocol(Protocol::OpenAIResponses).len(), 1);
         assert_eq!(reg.list_by_protocol(Protocol::AnthropicMessages).len(), 1);
@@ -444,10 +458,7 @@ mod tests {
             reg.parse_protocol("claude"),
             Some(Protocol::AnthropicMessages)
         );
-        assert_eq!(
-            reg.parse_protocol("gemini"),
-            Some(Protocol::GoogleGemini)
-        );
+        assert_eq!(reg.parse_protocol("gemini"), Some(Protocol::GoogleGemini));
         assert_eq!(
             reg.parse_protocol("google-gemini"),
             Some(Protocol::GoogleGemini)

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -216,7 +216,7 @@ mod tests {
     use crate::db::models::Provider;
     use crate::error::GatewayError;
     use crate::protocol::ids::{
-        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1, ProtocolId,
+        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolId,
     };
     use crate::protocol::ir::{AiRequest, AiResponse};
     use crate::provider::inbound::InboundResponse;
@@ -255,7 +255,7 @@ mod tests {
             "fake-test"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_COMPLETIONS_V1]
+            &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -302,7 +302,7 @@ mod tests {
             "fake-bearer"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_COMPLETIONS_V1]
+            &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -355,7 +355,7 @@ mod tests {
             meta: None,
         }];
         let mut req = AiRequest::new("ignored-by-actual-model", messages);
-        req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+        req.meta.source_protocol = Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
         req
     }
 
@@ -374,7 +374,7 @@ mod tests {
         let mut req = minimal_chat_request();
         let ctx = ProviderCtx {
             provider: &provider,
-            protocol: OPENAI_CHAT_COMPLETIONS_V1,
+            protocol: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
             egress_base_url: "https://upstream.local",
             api_key: &provider.api_key,
             actual_model: "gpt-test",
@@ -399,7 +399,7 @@ mod tests {
         let mut req = minimal_chat_request();
         let ctx = ProviderCtx {
             provider: &provider,
-            protocol: OPENAI_CHAT_COMPLETIONS_V1,
+            protocol: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
             egress_base_url: "https://upstream.local",
             api_key: &provider.api_key,
             actual_model: "gpt-test",

--- a/crates/nyro-core/src/provider/custom/mod.rs
+++ b/crates/nyro-core/src/provider/custom/mod.rs
@@ -63,8 +63,8 @@ impl Vendor for CustomVendor {
         "custom"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/deepseek/mod.rs
+++ b/crates/nyro-core/src/provider/deepseek/mod.rs
@@ -76,8 +76,8 @@ impl Vendor for DeepseekVendor {
         "deepseek"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/google/mod.rs
+++ b/crates/nyro-core/src/provider/google/mod.rs
@@ -74,8 +74,8 @@ impl Vendor for GoogleVendor {
         "google"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
-        &[GOOGLE_GENERATE_CONTENT_V1BETA]
+        use crate::protocol::ids::GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
+        &[GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/minimax/mod.rs
+++ b/crates/nyro-core/src/provider/minimax/mod.rs
@@ -102,8 +102,13 @@ impl Vendor for MinimaxVendor {
         "minimax"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::{
+            ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        };
+        &[
+            ANTHROPIC_MESSAGES_2023_06_01,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        ]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/minimax/mod.rs
+++ b/crates/nyro-core/src/provider/minimax/mod.rs
@@ -102,8 +102,8 @@ impl Vendor for MinimaxVendor {
         "minimax"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1};
+        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/moonshotai/mod.rs
+++ b/crates/nyro-core/src/provider/moonshotai/mod.rs
@@ -102,8 +102,8 @@ impl Vendor for MoonshotaiVendor {
         "moonshotai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/nvidia/mod.rs
+++ b/crates/nyro-core/src/provider/nvidia/mod.rs
@@ -70,8 +70,8 @@ impl Vendor for NvidiaVendor {
         "nvidia"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/ollama/mod.rs
+++ b/crates/nyro-core/src/provider/ollama/mod.rs
@@ -113,8 +113,8 @@ impl Vendor for OllamaVendor {
         "ollama"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     async fn build_request(
         &self,

--- a/crates/nyro-core/src/provider/openai/mod.rs
+++ b/crates/nyro-core/src/provider/openai/mod.rs
@@ -105,12 +105,12 @@ impl Vendor for OpenAiVendor {
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
         use crate::protocol::ids::{
-            OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
         };
         &[
-            OPENAI_CHAT_COMPLETIONS_V1,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
             OPENAI_RESPONSES_V1,
-            OPENAI_EMBEDDINGS_V1,
+            OPENAI_COMPATIBLE_EMBEDDINGS_V1,
         ]
     }
     fn declared_request_mutations(&self) -> bool {

--- a/crates/nyro-core/src/provider/openai/mod.rs
+++ b/crates/nyro-core/src/provider/openai/mod.rs
@@ -105,7 +105,8 @@ impl Vendor for OpenAiVendor {
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
         use crate::protocol::ids::{
-            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1,
+            OPENAI_RESPONSES_V1,
         };
         &[
             OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,

--- a/crates/nyro-core/src/provider/openrouter/mod.rs
+++ b/crates/nyro-core/src/provider/openrouter/mod.rs
@@ -76,8 +76,8 @@ impl Vendor for OpenrouterVendor {
         "openrouter"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/registry.rs
+++ b/crates/nyro-core/src/provider/registry.rs
@@ -44,7 +44,7 @@ pub fn protocol_default_vendor(protocol: Protocol) -> &'static str {
     match protocol {
         Protocol::OpenAICompatible | Protocol::OpenAIResponses => "openai",
         Protocol::AnthropicMessages => "anthropic",
-        Protocol::GoogleGenerativeAI => "google",
+        Protocol::GoogleGemini => "google",
     }
 }
 

--- a/crates/nyro-core/src/provider/vertexai/mod.rs
+++ b/crates/nyro-core/src/provider/vertexai/mod.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::GatewayError;
 use crate::protocol::ids::{
-    GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, Protocol,
+    GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, Protocol,
     ProtocolId,
 };
 use crate::protocol::ir::{AiRequest, AiResponse};
@@ -128,9 +128,9 @@ impl Vendor for VertexVendor {
 
     fn supported_protocols(&self) -> &'static [ProtocolId] {
         &[
-            GOOGLE_GENERATE_CONTENT_V1BETA,
-            OPENAI_CHAT_COMPLETIONS_V1,
-            OPENAI_EMBEDDINGS_V1,
+            GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            OPENAI_COMPATIBLE_EMBEDDINGS_V1,
         ]
     }
 
@@ -218,7 +218,7 @@ pub fn expand_vertex_base_url(base_url: &str, service_account_json: &str) -> Str
 fn vertex_build_url(ctx: &VendorCtx<'_>, base_url: &str, path: &str) -> String {
     let base = expand_vertex_base_url(base_url, ctx.api_key);
     match ctx.protocol_id.protocol {
-        Protocol::GoogleGenerativeAI => vertex_google_generate_url(&base, path),
+        Protocol::GoogleGemini => vertex_google_generate_url(&base, path),
         Protocol::OpenAICompatible => vertex_openai_url(&base, path),
         _ => format!("{}{}", base.trim_end_matches('/'), path),
     }
@@ -338,7 +338,7 @@ mod tests {
         };
         let ctx = VendorCtx {
             provider: &provider,
-            protocol_id: OPENAI_CHAT_COMPLETIONS_V1,
+            protocol_id: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
             api_key: "ya29.test-token",
             actual_model: "google/gemini-2.5-flash",
             credential: None,

--- a/crates/nyro-core/src/provider/vertexai/mod.rs
+++ b/crates/nyro-core/src/provider/vertexai/mod.rs
@@ -17,8 +17,8 @@ use sha2::{Digest, Sha256};
 
 use crate::error::GatewayError;
 use crate::protocol::ids::{
-    GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, Protocol,
-    ProtocolId,
+    GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    OPENAI_COMPATIBLE_EMBEDDINGS_V1, Protocol, ProtocolId,
 };
 use crate::protocol::ir::{AiRequest, AiResponse};
 use crate::provider::common::{openai::openai_map_error, pipeline};

--- a/crates/nyro-core/src/provider/xai/mod.rs
+++ b/crates/nyro-core/src/provider/xai/mod.rs
@@ -68,8 +68,8 @@ impl Vendor for XaiVendor {
         "xai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/zai/mod.rs
+++ b/crates/nyro-core/src/provider/zai/mod.rs
@@ -100,8 +100,8 @@ impl Vendor for ZaiVendor {
         "zai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/zhipuai/mod.rs
+++ b/crates/nyro-core/src/provider/zhipuai/mod.rs
@@ -102,8 +102,13 @@ impl Vendor for ZhipuaiVendor {
         "zhipuai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::{
+            ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        };
+        &[
+            ANTHROPIC_MESSAGES_2023_06_01,
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        ]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/provider/zhipuai/mod.rs
+++ b/crates/nyro-core/src/provider/zhipuai/mod.rs
@@ -102,8 +102,8 @@ impl Vendor for ZhipuaiVendor {
         "zhipuai"
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1};
-        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1]
+        use crate::protocol::ids::{ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1};
+        &[ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false

--- a/crates/nyro-core/src/proxy/context.rs
+++ b/crates/nyro-core/src/proxy/context.rs
@@ -280,8 +280,8 @@ pub async fn inject_context(mut request: Request, next: Next) -> Response {
     // We don't know the ingress protocol at middleware time; it will be
     // overwritten by the ingress handler via `inject_context_with_protocol`.
     // Use a sentinel until then.
-    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
-    let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(300));
+    use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
+    let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(300));
     request.extensions_mut().insert(ctx);
     next.run(request).await
 }
@@ -297,19 +297,19 @@ pub fn stamp_ingress_protocol(ctx: &mut RequestContext, protocol: ProtocolId) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+    use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
 
     #[test]
     fn request_id_is_unique() {
-        let a = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
-        let b = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let a = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let b = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         assert_ne!(a.request_id, b.request_id);
         assert!(a.request_id.starts_with("req-"));
     }
 
     #[test]
     fn outcome_write_once() {
-        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         ctx.set_outcome(RequestOutcome::Success);
         ctx.set_outcome(RequestOutcome::ClientCancelled); // second write ignored
         assert_eq!(ctx.get_outcome(), Some(&RequestOutcome::Success));
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn cancellation_token_shared() {
-        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         let token = ctx.cancellation.clone();
         assert!(!token.is_cancelled());
         ctx.cancellation.cancel();
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn trace_sink_push_snapshot() {
-        let ctx = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
         ctx.trace("intake", "body parsed");
         ctx.trace("security", "api_key validated");
         let events = ctx.trace.snapshot();

--- a/crates/nyro-core/src/proxy/context.rs
+++ b/crates/nyro-core/src/proxy/context.rs
@@ -281,7 +281,10 @@ pub async fn inject_context(mut request: Request, next: Next) -> Response {
     // overwritten by the ingress handler via `inject_context_with_protocol`.
     // Use a sentinel until then.
     use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
-    let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(300));
+    let ctx = RequestContext::new(
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        Duration::from_secs(300),
+    );
     request.extensions_mut().insert(ctx);
     next.run(request).await
 }
@@ -301,15 +304,24 @@ mod tests {
 
     #[test]
     fn request_id_is_unique() {
-        let a = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
-        let b = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let a = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        );
+        let b = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        );
         assert_ne!(a.request_id, b.request_id);
         assert!(a.request_id.starts_with("req-"));
     }
 
     #[test]
     fn outcome_write_once() {
-        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        );
         ctx.set_outcome(RequestOutcome::Success);
         ctx.set_outcome(RequestOutcome::ClientCancelled); // second write ignored
         assert_eq!(ctx.get_outcome(), Some(&RequestOutcome::Success));
@@ -317,7 +329,10 @@ mod tests {
 
     #[test]
     fn cancellation_token_shared() {
-        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        );
         let token = ctx.cancellation.clone();
         assert!(!token.is_cancelled());
         ctx.cancellation.cancel();
@@ -333,7 +348,10 @@ mod tests {
 
     #[test]
     fn trace_sink_push_snapshot() {
-        let ctx = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30));
+        let ctx = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        );
         ctx.trace("intake", "body parsed");
         ctx.trace("security", "api_key validated");
         let events = ctx.trace.snapshot();

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -50,7 +50,7 @@ use crate::cache::key::{build_cache_key, build_semantic_partition};
 use crate::db::models::Provider;
 use crate::error::{AuthFailure, GatewayError};
 use crate::protocol::ProviderProtocols;
-use crate::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1, ProtocolId};
+use crate::protocol::ids::{OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolId};
 use crate::protocol::ir::Usage;
 use crate::protocol::ir::{AiRequest, AiResponse, RawEnvelope};
 use crate::provider::vendor::ProviderCtx;
@@ -1352,7 +1352,7 @@ async fn compute_embedding(gw: &Gateway, text: &str) -> anyhow::Result<Vec<f32>>
         } else {
             target.model.clone()
         };
-        let extension = match VendorRegistry::global().resolve(&provider, OPENAI_EMBEDDINGS_V1) {
+        let extension = match VendorRegistry::global().resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1) {
             Some(ext) => ext.clone(),
             None => continue,
         };
@@ -1362,7 +1362,7 @@ async fn compute_embedding(gw: &Gateway, text: &str) -> anyhow::Result<Vec<f32>>
         {
             let ctx = VendorCtx {
                 provider: &provider,
-                protocol_id: OPENAI_EMBEDDINGS_V1,
+                protocol_id: OPENAI_COMPATIBLE_EMBEDDINGS_V1,
                 api_key: &credential,
                 actual_model: &actual_model,
                 credential: None,
@@ -1416,10 +1416,10 @@ fn parse_embedding_vector(payload: &Value) -> Option<Vec<f32>> {
 
 fn resolve_openai_base_url(provider: &Provider) -> Option<String> {
     let protocols = ProviderProtocols::from_provider(provider);
-    if !protocols.supports(OPENAI_CHAT_COMPLETIONS_V1) {
+    if !protocols.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1) {
         return None;
     }
-    let resolved = protocols.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
+    let resolved = protocols.resolve_egress(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     let trimmed = resolved.base_url.trim();
     if trimmed.is_empty() {
         None

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -50,7 +50,9 @@ use crate::cache::key::{build_cache_key, build_semantic_partition};
 use crate::db::models::Provider;
 use crate::error::{AuthFailure, GatewayError};
 use crate::protocol::ProviderProtocols;
-use crate::protocol::ids::{OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolId};
+use crate::protocol::ids::{
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, ProtocolId,
+};
 use crate::protocol::ir::Usage;
 use crate::protocol::ir::{AiRequest, AiResponse, RawEnvelope};
 use crate::provider::vendor::ProviderCtx;
@@ -1352,10 +1354,11 @@ async fn compute_embedding(gw: &Gateway, text: &str) -> anyhow::Result<Vec<f32>>
         } else {
             target.model.clone()
         };
-        let extension = match VendorRegistry::global().resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1) {
-            Some(ext) => ext.clone(),
-            None => continue,
-        };
+        let extension =
+            match VendorRegistry::global().resolve(&provider, OPENAI_COMPATIBLE_EMBEDDINGS_V1) {
+                Some(ext) => ext.clone(),
+                None => continue,
+            };
         let credential = provider_runtime.access_token.clone();
         let upstream_url;
         let mut request_headers;

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::Gateway;
 use crate::protocol::codec::google_generative::decoder::GoogleDecoder;
-use crate::protocol::ids::GOOGLE_GENERATE_CONTENT_V1BETA;
+use crate::protocol::ids::GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
@@ -20,7 +20,7 @@ pub async fn handler(
     Path(model_action): Path<String>,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = GOOGLE_GENERATE_CONTENT_V1BETA;
+    ctx.ingress_protocol = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
     let (model, action) = match model_action.rsplit_once(':') {
         Some((m, a)) => (m.to_string(), a.to_string()),
         None => (model_action.clone(), "generateContent".to_string()),
@@ -42,7 +42,7 @@ pub async fn handler(
             return log_decode_error(
                 &gw,
                 &envelope,
-                GOOGLE_GENERATE_CONTENT_V1BETA,
+                GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
                 format!("Gemini decode error: {e}"),
             );
         }
@@ -52,7 +52,7 @@ pub async fn handler(
         headers,
         envelope,
         request,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     )
     .await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -33,10 +33,21 @@ pub async fn handler(
         "POST",
         "/v1/chat/completions",
     );
-    let decoder = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1.handler().make_request_decoder();
+    let decoder = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
+        .handler()
+        .make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, e),
+        Err(e) => {
+            return log_decode_error(&gw, &envelope, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, e);
+        }
     };
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).await
+    dispatch_pipeline(
+        gw,
+        headers,
+        envelope,
+        request,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    )
+    .await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -7,7 +7,7 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
@@ -18,7 +18,7 @@ pub async fn handler(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = OPENAI_CHAT_COMPLETIONS_V1;
+    ctx.ingress_protocol = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -33,10 +33,10 @@ pub async fn handler(
         "POST",
         "/v1/chat/completions",
     );
-    let decoder = OPENAI_CHAT_COMPLETIONS_V1.handler().make_request_decoder();
+    let decoder = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_CHAT_COMPLETIONS_V1, e),
+        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, e),
     };
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_CHAT_COMPLETIONS_V1).await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -7,7 +7,7 @@ use axum::response::Response;
 use serde_json::Value;
 
 use crate::Gateway;
-use crate::protocol::ids::OPENAI_EMBEDDINGS_V1;
+use crate::protocol::ids::OPENAI_COMPATIBLE_EMBEDDINGS_V1;
 use crate::protocol::ir::RawEnvelope;
 use crate::proxy::context::RequestContext;
 use crate::proxy::dispatcher::{dispatch_pipeline, log_decode_error};
@@ -18,7 +18,7 @@ pub async fn handler(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    ctx.ingress_protocol = OPENAI_EMBEDDINGS_V1;
+    ctx.ingress_protocol = OPENAI_COMPATIBLE_EMBEDDINGS_V1;
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -28,10 +28,10 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
-    let decoder = OPENAI_EMBEDDINGS_V1.handler().make_request_decoder();
+    let decoder = OPENAI_COMPATIBLE_EMBEDDINGS_V1.handler().make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
-        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_EMBEDDINGS_V1, e),
+        Err(e) => return log_decode_error(&gw, &envelope, OPENAI_COMPATIBLE_EMBEDDINGS_V1, e),
     };
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_EMBEDDINGS_V1).await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_COMPATIBLE_EMBEDDINGS_V1).await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -28,10 +28,19 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", "/v1/embeddings");
-    let decoder = OPENAI_COMPATIBLE_EMBEDDINGS_V1.handler().make_request_decoder();
+    let decoder = OPENAI_COMPATIBLE_EMBEDDINGS_V1
+        .handler()
+        .make_request_decoder();
     let request = match decoder.decode_request(body) {
         Ok(r) => r,
         Err(e) => return log_decode_error(&gw, &envelope, OPENAI_COMPATIBLE_EMBEDDINGS_V1, e),
     };
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_COMPATIBLE_EMBEDDINGS_V1).await
+    dispatch_pipeline(
+        gw,
+        headers,
+        envelope,
+        request,
+        OPENAI_COMPATIBLE_EMBEDDINGS_V1,
+    )
+    .await
 }

--- a/crates/nyro-core/src/proxy/planner/negotiator.rs
+++ b/crates/nyro-core/src/proxy/planner/negotiator.rs
@@ -198,7 +198,8 @@ pub fn negotiate(
 mod tests {
     use super::*;
     use crate::protocol::ids::{
-        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1,
+        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_EMBEDDINGS_V1,
     };
     use std::time::Duration;
 
@@ -210,14 +211,26 @@ mod tests {
     }
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
+        RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        )
     }
 
     #[test]
     fn native_when_ingress_exact_match() {
-        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            "https://api.openai.com",
+        );
         let mut c = ctx();
-        let plan = negotiate(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut c).unwrap();
+        let plan = negotiate(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            None,
+            Some(&decl),
+            &mut c,
+        )
+        .unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
         assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
         assert!(!plan.needs_conversion);
@@ -225,7 +238,10 @@ mod tests {
 
     #[test]
     fn native_when_same_protocol_family() {
-        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            "https://api.openai.com",
+        );
         let mut c = ctx();
         let plan = negotiate(OPENAI_COMPATIBLE_EMBEDDINGS_V1, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
@@ -235,7 +251,10 @@ mod tests {
 
     #[test]
     fn route_pref_in_same_protocol_wins_over_ingress_match() {
-        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            "https://api.openai.com",
+        );
         let mut c = ctx();
         let plan = negotiate(
             OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
@@ -257,7 +276,10 @@ mod tests {
 
     #[test]
     fn different_protocol_falls_back_to_default() {
-        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            "https://api.openai.com",
+        );
         let mut c = ctx();
         let plan = negotiate(ANTHROPIC_MESSAGES_2023_06_01, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);

--- a/crates/nyro-core/src/proxy/planner/negotiator.rs
+++ b/crates/nyro-core/src/proxy/planner/negotiator.rs
@@ -198,7 +198,7 @@ pub fn negotiate(
 mod tests {
     use super::*;
     use crate::protocol::ids::{
-        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1,
+        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1,
     };
     use std::time::Duration;
 
@@ -210,57 +210,57 @@ mod tests {
     }
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
+        RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
     }
 
     #[test]
     fn native_when_ingress_exact_match() {
-        let decl = make_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
         let mut c = ctx();
-        let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut c).unwrap();
+        let plan = negotiate(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
-        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
+        assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
         assert!(!plan.needs_conversion);
     }
 
     #[test]
     fn native_when_same_protocol_family() {
-        let decl = make_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
         let mut c = ctx();
-        let plan = negotiate(OPENAI_EMBEDDINGS_V1, None, Some(&decl), &mut c).unwrap();
+        let plan = negotiate(OPENAI_COMPATIBLE_EMBEDDINGS_V1, None, Some(&decl), &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
-        assert_eq!(plan.egress, OPENAI_EMBEDDINGS_V1);
+        assert_eq!(plan.egress, OPENAI_COMPATIBLE_EMBEDDINGS_V1);
         assert!(!plan.needs_conversion);
     }
 
     #[test]
     fn route_pref_in_same_protocol_wins_over_ingress_match() {
-        let decl = make_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
         let mut c = ctx();
         let plan = negotiate(
-            OPENAI_CHAT_COMPLETIONS_V1,
-            Some(OPENAI_EMBEDDINGS_V1),
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1),
             Some(&decl),
             &mut c,
         )
         .unwrap();
-        assert_eq!(plan.egress, OPENAI_EMBEDDINGS_V1);
+        assert_eq!(plan.egress, OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     }
 
     #[test]
     fn no_decl_returns_native() {
         let mut c = ctx();
-        let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, None, &mut c).unwrap();
+        let plan = negotiate(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, None, None, &mut c).unwrap();
         assert_eq!(plan.mode, ProtocolMode::Native);
-        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
+        assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     }
 
     #[test]
     fn different_protocol_falls_back_to_default() {
-        let decl = make_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+        let decl = make_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
         let mut c = ctx();
         let plan = negotiate(ANTHROPIC_MESSAGES_2023_06_01, None, Some(&decl), &mut c).unwrap();
-        assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
+        assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
         assert_eq!(plan.mode, ProtocolMode::Transform);
         assert!(plan.needs_conversion);
     }

--- a/crates/nyro-core/src/proxy/stream.rs
+++ b/crates/nyro-core/src/proxy/stream.rs
@@ -281,13 +281,13 @@ impl Drop for StreamBridge<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ids::OPENAI_CHAT_COMPLETIONS_V1;
+    use crate::protocol::ids::OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1;
     use crate::proxy::context::RequestContext;
     use std::sync::Arc;
     use std::time::Duration;
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
+        RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
     }
 
     // ── Fault 1: read interrupt ───────────────────────────────────────────────
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn fault_timeout_detected_in_push_chunk() {
-        let c = RequestContext::new(OPENAI_CHAT_COMPLETIONS_V1, Duration::from_nanos(1));
+        let c = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_nanos(1));
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut b = StreamBridge::new(&c);
         b.on_connected();

--- a/crates/nyro-core/src/proxy/stream.rs
+++ b/crates/nyro-core/src/proxy/stream.rs
@@ -287,7 +287,10 @@ mod tests {
     use std::time::Duration;
 
     fn ctx() -> RequestContext {
-        RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_secs(30))
+        RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_secs(30),
+        )
     }
 
     // ── Fault 1: read interrupt ───────────────────────────────────────────────
@@ -352,7 +355,10 @@ mod tests {
 
     #[test]
     fn fault_timeout_detected_in_push_chunk() {
-        let c = RequestContext::new(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, Duration::from_nanos(1));
+        let c = RequestContext::new(
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            Duration::from_nanos(1),
+        );
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mut b = StreamBridge::new(&c);
         b.on_connected();

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -25,7 +25,7 @@ use nyro_core::db::models::Provider;
 use nyro_core::error::GatewayError;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::protocol::ir::{AiRequest, AiResponse};
@@ -83,7 +83,7 @@ impl Vendor for BearerVendor {
         self.0
     }
     fn supported_protocols(&self) -> &'static [ProtocolId] {
-        &[OPENAI_CHAT_COMPLETIONS_V1]
+        &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
     }
     fn declared_request_mutations(&self) -> bool {
         false
@@ -136,11 +136,11 @@ fn fake_provider(api_key: &str) -> Provider {
 
 #[test]
 fn diagonal_chat_chat_is_native() {
-    let decl = single_decl(OPENAI_CHAT_COMPLETIONS_V1, "https://api.openai.com");
-    let mut ctx = req_ctx(OPENAI_CHAT_COMPLETIONS_V1);
-    let plan = negotiate(OPENAI_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut ctx).unwrap();
+    let decl = single_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+    let mut ctx = req_ctx(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
+    let plan = negotiate(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut ctx).unwrap();
     assert_eq!(plan.mode, ProtocolMode::Native, "chat→chat must be Native");
-    assert_eq!(plan.egress, OPENAI_CHAT_COMPLETIONS_V1);
+    assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert!(!plan.needs_conversion);
 }
 
@@ -175,17 +175,17 @@ fn diagonal_messages_messages_is_native() {
 #[test]
 fn diagonal_generate_generate_is_native() {
     let decl = single_decl(
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
         "https://generativelanguage.googleapis.com",
     );
-    let mut ctx = req_ctx(GOOGLE_GENERATE_CONTENT_V1BETA);
-    let plan = negotiate(GOOGLE_GENERATE_CONTENT_V1BETA, None, Some(&decl), &mut ctx).unwrap();
+    let mut ctx = req_ctx(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
+    let plan = negotiate(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, None, Some(&decl), &mut ctx).unwrap();
     assert_eq!(
         plan.mode,
         ProtocolMode::Native,
         "generate→generate must be Native"
     );
-    assert_eq!(plan.egress, GOOGLE_GENERATE_CONTENT_V1BETA);
+    assert_eq!(plan.egress, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
     assert!(!plan.needs_conversion);
 }
 
@@ -216,24 +216,24 @@ macro_rules! off_diagonal_test {
 
 off_diagonal_test!(
     chat_to_responses_is_transform,
-    ingress = OPENAI_CHAT_COMPLETIONS_V1,
+    ingress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     egress = OPENAI_RESPONSES_V1
 );
 off_diagonal_test!(
     chat_to_messages_is_transform,
-    ingress = OPENAI_CHAT_COMPLETIONS_V1,
+    ingress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     egress = ANTHROPIC_MESSAGES_2023_06_01
 );
 off_diagonal_test!(
     chat_to_generate_is_transform,
-    ingress = OPENAI_CHAT_COMPLETIONS_V1,
-    egress = GOOGLE_GENERATE_CONTENT_V1BETA
+    ingress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    egress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     responses_to_chat_is_transform,
     ingress = OPENAI_RESPONSES_V1,
-    egress = OPENAI_CHAT_COMPLETIONS_V1
+    egress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     responses_to_messages_is_transform,
@@ -243,13 +243,13 @@ off_diagonal_test!(
 off_diagonal_test!(
     responses_to_generate_is_transform,
     ingress = OPENAI_RESPONSES_V1,
-    egress = GOOGLE_GENERATE_CONTENT_V1BETA
+    egress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     messages_to_chat_is_transform,
     ingress = ANTHROPIC_MESSAGES_2023_06_01,
-    egress = OPENAI_CHAT_COMPLETIONS_V1
+    egress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     messages_to_responses_is_transform,
@@ -259,22 +259,22 @@ off_diagonal_test!(
 off_diagonal_test!(
     messages_to_generate_is_transform,
     ingress = ANTHROPIC_MESSAGES_2023_06_01,
-    egress = GOOGLE_GENERATE_CONTENT_V1BETA
+    egress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA
 );
 
 off_diagonal_test!(
     generate_to_chat_is_transform,
-    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
-    egress = OPENAI_CHAT_COMPLETIONS_V1
+    ingress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    egress = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
 );
 off_diagonal_test!(
     generate_to_responses_is_transform,
-    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
+    ingress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     egress = OPENAI_RESPONSES_V1
 );
 off_diagonal_test!(
     generate_to_messages_is_transform,
-    ingress = GOOGLE_GENERATE_CONTENT_V1BETA,
+    ingress = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     egress = ANTHROPIC_MESSAGES_2023_06_01
 );
 
@@ -297,7 +297,7 @@ async fn passthrough_run_preserves_vendor_specific_fields() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_COMPLETIONS_V1,
+        protocol: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "gpt-4o",
@@ -350,7 +350,7 @@ async fn passthrough_run_rewrites_model_to_actual_model() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_COMPLETIONS_V1,
+        protocol: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "glm-4-flash",
@@ -378,7 +378,7 @@ async fn passthrough_run_sets_stream_path_for_streaming_body() {
 
     let ctx = ProviderCtx {
         provider: &provider,
-        protocol: OPENAI_CHAT_COMPLETIONS_V1,
+        protocol: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         egress_base_url: "https://api.openai.com",
         api_key: &provider.api_key,
         actual_model: "gpt-4o",
@@ -415,7 +415,7 @@ fn vendor_declared_mutations_defaults_are_conservative() {
             "default"
         }
         fn supported_protocols(&self) -> &'static [ProtocolId] {
-            &[OPENAI_CHAT_COMPLETIONS_V1]
+            &[OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1]
         }
         async fn build_request(
             &self,
@@ -451,10 +451,10 @@ fn vendor_declared_mutations_defaults_are_conservative() {
 #[test]
 fn each_protocol_provider_selects_own_native() {
     for proto in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         let decl = single_decl(proto, "https://upstream.example.com");
         let mut ctx = req_ctx(proto);

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -25,8 +25,8 @@ use nyro_core::db::models::Provider;
 use nyro_core::error::GatewayError;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_RESPONSES_V1, ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::protocol::ir::{AiRequest, AiResponse};
 use nyro_core::provider::inbound::InboundResponse;
@@ -136,9 +136,18 @@ fn fake_provider(api_key: &str) -> Provider {
 
 #[test]
 fn diagonal_chat_chat_is_native() {
-    let decl = single_decl(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "https://api.openai.com");
+    let decl = single_decl(
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        "https://api.openai.com",
+    );
     let mut ctx = req_ctx(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
-    let plan = negotiate(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, None, Some(&decl), &mut ctx).unwrap();
+    let plan = negotiate(
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        None,
+        Some(&decl),
+        &mut ctx,
+    )
+    .unwrap();
     assert_eq!(plan.mode, ProtocolMode::Native, "chat→chat must be Native");
     assert_eq!(plan.egress, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert!(!plan.needs_conversion);
@@ -179,7 +188,13 @@ fn diagonal_generate_generate_is_native() {
         "https://generativelanguage.googleapis.com",
     );
     let mut ctx = req_ctx(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
-    let plan = negotiate(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, None, Some(&decl), &mut ctx).unwrap();
+    let plan = negotiate(
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+        None,
+        Some(&decl),
+        &mut ctx,
+    )
+    .unwrap();
     assert_eq!(
         plan.mode,
         ProtocolMode::Native,

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -14,7 +14,7 @@ use nyro_core::protocol::codec::openai_responses::parser::{
 use nyro_core::protocol::codec::reasoning::normalize_response_reasoning;
 use nyro_core::protocol::codec::tool_correlation::normalize_request_tool_results;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::ir::usage::Usage;
@@ -224,7 +224,7 @@ fn gemini_tool_result_correlation_success() {
         enabled: false,
         include_usage: false,
     };
-    ai_req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+    ai_req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     normalize_request_tool_results(&mut ai_req);
     assert_eq!(
@@ -285,7 +285,7 @@ fn gemini_tool_result_id_hint_matches_out_of_order_calls() {
         enabled: false,
         include_usage: false,
     };
-    ai_req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+    ai_req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     normalize_request_tool_results(&mut ai_req);
     assert_eq!(ai_req.messages[1].tool_call_id.as_deref(), Some("call_b"));
@@ -907,7 +907,7 @@ fn anthropic_encoder_normalizes_tool_use_ids_for_tool_and_result() {
     };
     req.generation.max_tokens = Some(256);
     req.tools = tools;
-    req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+    req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     let (body, _) = AnthropicEncoder
         .encode_request(&req)
@@ -1009,7 +1009,7 @@ fn openai_encoder_remaps_reused_tool_result_id_with_synthetic_adjacent_call() {
         include_usage: false,
     };
     req.tools = tools;
-    req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+    req.meta.source_protocol = Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 
     let (body, _) = OpenAIEncoder.encode_request(&req).expect("encode");
     let msgs = body
@@ -1197,7 +1197,7 @@ fn openai_encoder_preserves_reasoning_content_across_parallel_tool_calls() {
         include_usage: false,
     };
     req.tools = tools;
-    req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+    req.meta.source_protocol = Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 
     let (body, _) = OpenAIEncoder
         .encode_request(&req)
@@ -1416,7 +1416,7 @@ fn openai_encoder_drops_orphan_assistant_tool_calls_without_results() {
         include_usage: false,
     };
     req.tools = tools;
-    req.meta.source_protocol = Some(GOOGLE_GENERATE_CONTENT_V1BETA);
+    req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
 
     let (body, _) = OpenAIEncoder.encode_request(&req).expect("encode");
     let msgs = body
@@ -1586,7 +1586,7 @@ fn gemini_encoder_sanitizes_unsupported_json_schema_fields() {
         include_usage: false,
     };
     req.tools = tools;
-    req.meta.source_protocol = Some(OPENAI_CHAT_COMPLETIONS_V1);
+    req.meta.source_protocol = Some(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 
     let (body, _) = GoogleEncoder.encode_request(&req).expect("encode");
     let params = body

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -14,8 +14,8 @@ use nyro_core::protocol::codec::openai_responses::parser::{
 use nyro_core::protocol::codec::reasoning::normalize_response_reasoning;
 use nyro_core::protocol::codec::tool_correlation::normalize_request_tool_results;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_RESPONSES_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::ir::usage::Usage;
 use nyro_core::protocol::ir::{

--- a/crates/nyro-core/tests/protocol_gate.rs
+++ b/crates/nyro-core/tests/protocol_gate.rs
@@ -13,7 +13,7 @@
 
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ProviderProtocols;
-use nyro_core::protocol::ids::{OPENAI_CHAT_COMPLETIONS_V1, OPENAI_EMBEDDINGS_V1};
+use nyro_core::protocol::ids::{OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1};
 
 fn provider(protocol: &str) -> Provider {
     Provider {
@@ -45,11 +45,11 @@ fn openai_compat_protocol_suite_includes_embeddings() {
     let pp = ProviderProtocols::from_provider(&p);
 
     assert!(
-        pp.supports(OPENAI_CHAT_COMPLETIONS_V1),
+        pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1),
         "chat-completions must be included in openai-compatible suite"
     );
     assert!(
-        pp.supports(OPENAI_EMBEDDINGS_V1),
+        pp.supports(OPENAI_COMPATIBLE_EMBEDDINGS_V1),
         "embeddings must be included in openai-compatible suite"
     );
 }
@@ -63,15 +63,15 @@ fn endpoint_keyed_format_expands_to_full_protocol_suite() {
     let pp = ProviderProtocols::from_provider(&p);
 
     // parse_protocol("openai/chat/v1") → Protocol::OpenAICompatible → suite expansion
-    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
+    assert!(pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1));
     assert!(
-        pp.supports(OPENAI_EMBEDDINGS_V1),
+        pp.supports(OPENAI_COMPATIBLE_EMBEDDINGS_V1),
         "endpoint-keyed key triggers suite expansion; embeddings included"
     );
 
     // Embeddings resolves directly (Tier 1 — exact match after expansion).
-    let resolved = pp.resolve_egress(OPENAI_EMBEDDINGS_V1);
-    assert_eq!(resolved.protocol, OPENAI_EMBEDDINGS_V1);
+    let resolved = pp.resolve_egress(OPENAI_COMPATIBLE_EMBEDDINGS_V1);
+    assert_eq!(resolved.protocol, OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     assert!(!resolved.needs_conversion);
     assert_eq!(resolved.base_url, "https://a.example/v1");
 }
@@ -83,14 +83,14 @@ fn embeddings_endpoint_key_also_expands_to_full_openai_compat_suite() {
     let pp = ProviderProtocols::from_provider(&p);
 
     // Both chat and embeddings present after suite expansion.
-    assert!(pp.supports(OPENAI_EMBEDDINGS_V1));
+    assert!(pp.supports(OPENAI_COMPATIBLE_EMBEDDINGS_V1));
     assert!(
-        pp.supports(OPENAI_CHAT_COMPLETIONS_V1),
+        pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1),
         "chat-completions included via OpenAICompatible suite expansion"
     );
 
     // Chat resolves directly with no conversion needed.
-    let resolved = pp.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
-    assert_eq!(resolved.protocol, OPENAI_CHAT_COMPLETIONS_V1);
+    let resolved = pp.resolve_egress(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
+    assert_eq!(resolved.protocol, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert!(!resolved.needs_conversion);
 }

--- a/crates/nyro-core/tests/protocol_gate.rs
+++ b/crates/nyro-core/tests/protocol_gate.rs
@@ -13,7 +13,9 @@
 
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ProviderProtocols;
-use nyro_core::protocol::ids::{OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1};
+use nyro_core::protocol::ids::{
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1,
+};
 
 fn provider(protocol: &str) -> Provider {
     Provider {

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -8,8 +8,8 @@
 //!   request pipeline still bypasses its codec)
 
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
-    OPENAI_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+    OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolId,
 };
 use nyro_core::protocol::ir::Role;
 use nyro_core::protocol::registry::ProtocolRegistry;
@@ -21,11 +21,11 @@ fn registers_all_handlers_with_correct_ids() {
     assert_eq!(reg.list().len(), 5);
 
     for id in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
-        OPENAI_EMBEDDINGS_V1,
+        OPENAI_COMPATIBLE_EMBEDDINGS_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         let h = reg.get(&id).unwrap_or_else(|| panic!("missing {id}"));
         assert_eq!(h.id(), id);
@@ -38,7 +38,7 @@ fn list_by_protocol_segments() {
     assert_eq!(reg.list_by_protocol(Protocol::OpenAICompatible).len(), 2);
     assert_eq!(reg.list_by_protocol(Protocol::OpenAIResponses).len(), 1);
     assert_eq!(reg.list_by_protocol(Protocol::AnthropicMessages).len(), 1);
-    assert_eq!(reg.list_by_protocol(Protocol::GoogleGenerativeAI).len(), 1);
+    assert_eq!(reg.list_by_protocol(Protocol::GoogleGemini).len(), 1);
 }
 
 #[test]
@@ -46,13 +46,13 @@ fn ingress_routes_match_axum_router() {
     let reg = ProtocolRegistry::global();
 
     let cases: &[(&str, &str, ProtocolId)] = &[
-        ("POST", "/v1/chat/completions", OPENAI_CHAT_COMPLETIONS_V1),
+        ("POST", "/v1/chat/completions", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1),
         ("POST", "/v1/responses", OPENAI_RESPONSES_V1),
         ("POST", "/v1/messages", ANTHROPIC_MESSAGES_2023_06_01),
         (
             "POST",
             "/v1beta/models/:model_action",
-            GOOGLE_GENERATE_CONTENT_V1BETA,
+            GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
         ),
     ];
 
@@ -75,13 +75,13 @@ fn capabilities_match_dialect_special_cases() {
         "Responses must force upstream streaming"
     );
     assert!(
-        !reg.get(&OPENAI_CHAT_COMPLETIONS_V1)
+        !reg.get(&OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
             .unwrap()
             .capabilities()
             .force_upstream_stream
     );
     assert!(
-        reg.get(&GOOGLE_GENERATE_CONTENT_V1BETA)
+        reg.get(&GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
             .unwrap()
             .capabilities()
             .override_model_in_body,
@@ -92,7 +92,7 @@ fn capabilities_match_dialect_special_cases() {
 // ── Decoder / encoder smoke ──
 
 fn sample_body(id: ProtocolId) -> serde_json::Value {
-    if id == OPENAI_CHAT_COMPLETIONS_V1 {
+    if id == OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1 {
         json!({
             "model": "gpt-4o-mini",
             "messages": [
@@ -122,7 +122,7 @@ fn sample_body(id: ProtocolId) -> serde_json::Value {
             "max_tokens": 256,
             "stream": false
         })
-    } else if id == GOOGLE_GENERATE_CONTENT_V1BETA {
+    } else if id == GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA {
         json!({
             "system_instruction": {"parts": [{"text": "be helpful"}]},
             "contents": [
@@ -138,10 +138,10 @@ fn sample_body(id: ProtocolId) -> serde_json::Value {
 fn decoder_preserves_role_sequence_and_source_protocol() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         let body = sample_body(id);
         let req = reg
@@ -165,10 +165,10 @@ fn decoder_preserves_role_sequence_and_source_protocol() {
 fn encoder_round_trips_body_for_every_handler() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         let body = sample_body(id);
         let h = reg.get(&id).unwrap();
@@ -193,10 +193,10 @@ fn encoder_round_trips_body_for_every_handler() {
 fn parser_and_formatter_factories_construct() {
     let reg = ProtocolRegistry::global();
     for id in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         let h = reg.get(&id).unwrap();
         let _ = h.make_response_decoder();
@@ -211,7 +211,7 @@ fn parser_and_formatter_factories_construct() {
 #[test]
 fn embeddings_handler_advertises_passthrough_capabilities() {
     let reg = ProtocolRegistry::global();
-    let caps = reg.get(&OPENAI_EMBEDDINGS_V1).unwrap().capabilities();
+    let caps = reg.get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1).unwrap().capabilities();
     assert!(caps.embeddings);
     assert!(!caps.streaming);
     assert!(!caps.tools);
@@ -226,7 +226,7 @@ fn embeddings_routes_resolve_to_handler() {
         let h = reg
             .find_by_ingress_route("POST", path)
             .unwrap_or_else(|| panic!("no handler for POST {path}"));
-        assert_eq!(h.id(), OPENAI_EMBEDDINGS_V1);
+        assert_eq!(h.id(), OPENAI_COMPATIBLE_EMBEDDINGS_V1);
     }
 }
 
@@ -235,12 +235,12 @@ fn embeddings_aliases_resolve() {
     let reg = ProtocolRegistry::global();
     assert_eq!(
         reg.resolve_alias("openai-embeddings"),
-        Some(OPENAI_EMBEDDINGS_V1)
+        Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)
     );
-    assert_eq!(reg.resolve_alias("embeddings"), Some(OPENAI_EMBEDDINGS_V1));
+    assert_eq!(reg.resolve_alias("embeddings"), Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1));
     assert_eq!(
         reg.resolve_alias("openai/embeddings/v1"),
-        Some(OPENAI_EMBEDDINGS_V1)
+        Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)
     );
 }
 
@@ -253,7 +253,7 @@ fn embeddings_decoder_round_trips_body() {
         "encoding_format": "float"
     });
     let internal = reg
-        .get(&OPENAI_EMBEDDINGS_V1)
+        .get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1)
         .unwrap()
         .make_request_decoder()
         .decode_request(body.clone())
@@ -262,7 +262,7 @@ fn embeddings_decoder_round_trips_body() {
     assert!(!internal.stream.enabled);
 
     let (encoded, _headers) = reg
-        .get(&OPENAI_EMBEDDINGS_V1)
+        .get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1)
         .unwrap()
         .make_request_encoder()
         .encode_request(&internal)

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -8,8 +8,9 @@
 //!   request pipeline still bypasses its codec)
 
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1, Protocol, ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_COMPATIBLE_EMBEDDINGS_V1, OPENAI_RESPONSES_V1,
+    Protocol, ProtocolId,
 };
 use nyro_core::protocol::ir::Role;
 use nyro_core::protocol::registry::ProtocolRegistry;
@@ -46,7 +47,11 @@ fn ingress_routes_match_axum_router() {
     let reg = ProtocolRegistry::global();
 
     let cases: &[(&str, &str, ProtocolId)] = &[
-        ("POST", "/v1/chat/completions", OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1),
+        (
+            "POST",
+            "/v1/chat/completions",
+            OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        ),
         ("POST", "/v1/responses", OPENAI_RESPONSES_V1),
         ("POST", "/v1/messages", ANTHROPIC_MESSAGES_2023_06_01),
         (
@@ -211,7 +216,10 @@ fn parser_and_formatter_factories_construct() {
 #[test]
 fn embeddings_handler_advertises_passthrough_capabilities() {
     let reg = ProtocolRegistry::global();
-    let caps = reg.get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1).unwrap().capabilities();
+    let caps = reg
+        .get(&OPENAI_COMPATIBLE_EMBEDDINGS_V1)
+        .unwrap()
+        .capabilities();
     assert!(caps.embeddings);
     assert!(!caps.streaming);
     assert!(!caps.tools);
@@ -237,7 +245,10 @@ fn embeddings_aliases_resolve() {
         reg.resolve_alias("openai-embeddings"),
         Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)
     );
-    assert_eq!(reg.resolve_alias("embeddings"), Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1));
+    assert_eq!(
+        reg.resolve_alias("embeddings"),
+        Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)
+    );
     assert_eq!(
         reg.resolve_alias("openai/embeddings/v1"),
         Some(OPENAI_COMPATIBLE_EMBEDDINGS_V1)

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -12,7 +12,7 @@
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
@@ -44,11 +44,11 @@ fn parses_legacy_protocol_keys() {
     let provider = provider_with_protocol("openai", "https://a.example/v1");
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
+    assert!(pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1));
     assert!(!pp.supports(ANTHROPIC_MESSAGES_2023_06_01));
-    assert!(!pp.supports(GOOGLE_GENERATE_CONTENT_V1BETA));
+    assert!(!pp.supports(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA));
     assert!(!pp.supports(OPENAI_RESPONSES_V1));
-    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
+    assert_eq!(pp.default, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert_eq!(pp.base_url, "https://a.example/v1");
 }
 
@@ -57,8 +57,8 @@ fn parses_canonical_protocol_id() {
     let provider = provider_with_protocol("openai/chat/v1", "https://a.example/v1");
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
-    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
+    assert!(pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1));
+    assert_eq!(pp.default, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 }
 
 #[test]
@@ -66,17 +66,17 @@ fn parses_short_name_aliases() {
     let provider = provider_with_protocol("openai-chat", "https://a.example/v1");
     let pp = ProviderProtocols::from_provider(&provider);
 
-    assert!(pp.supports(OPENAI_CHAT_COMPLETIONS_V1));
-    assert_eq!(pp.default, OPENAI_CHAT_COMPLETIONS_V1);
+    assert!(pp.supports(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1));
+    assert_eq!(pp.default, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 }
 
 #[test]
 fn resolve_egress_exact_match_skips_conversion() {
     let provider = provider_with_protocol("openai", "https://a.example/v1");
     let pp = ProviderProtocols::from_provider(&provider);
-    let r = pp.resolve_egress(OPENAI_CHAT_COMPLETIONS_V1);
+    let r = pp.resolve_egress(OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
 
-    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
+    assert_eq!(r.protocol, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(!r.needs_conversion);
 }
@@ -91,8 +91,8 @@ fn resolve_egress_responses_falls_back_to_provider_default() {
     let r = pp.resolve_egress(OPENAI_RESPONSES_V1);
 
     // No exact match, no same-protocol match (OpenAIResponses ≠ OpenAICompatible).
-    // Tier 3: provider default = OPENAI_CHAT_COMPLETIONS_V1.
-    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
+    // Tier 3: provider default = OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1.
+    assert_eq!(r.protocol, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert_eq!(r.base_url, "https://a.example/v1");
     assert!(r.needs_conversion);
 }
@@ -104,7 +104,7 @@ fn resolve_egress_falls_back_to_global_default_when_family_missing() {
     // Anthropic ingress, no Anthropic endpoint → fall back to default.
     let r = pp.resolve_egress(ANTHROPIC_MESSAGES_2023_06_01);
 
-    assert_eq!(r.protocol, OPENAI_CHAT_COMPLETIONS_V1);
+    assert_eq!(r.protocol, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1);
     assert!(r.needs_conversion);
 }
 
@@ -113,10 +113,10 @@ fn protocol_handler_resolves_for_every_canonical_id() {
     let reg = ProtocolRegistry::global();
 
     for id in [
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         OPENAI_RESPONSES_V1,
         ANTHROPIC_MESSAGES_2023_06_01,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     ] {
         assert!(reg.get(&id).is_some(), "no handler registered for {id}");
         assert_eq!(id.handler().id(), id);

--- a/crates/nyro-core/tests/provider_protocols.rs
+++ b/crates/nyro-core/tests/provider_protocols.rs
@@ -12,8 +12,8 @@
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ProviderProtocols;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_RESPONSES_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_RESPONSES_V1,
 };
 use nyro_core::protocol::registry::ProtocolRegistry;
 

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -8,7 +8,7 @@
 use nyro_core::auth::types::StoredCredential;
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GENERATE_CONTENT_V1BETA, OPENAI_CHAT_COMPLETIONS_V1,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
     OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::provider::{VendorCtx, VendorRegistry, VendorScope};
@@ -75,7 +75,7 @@ fn resolve_falls_back_to_vendor_when_channel_unknown() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("openai"), Some("unknown-channel"));
     let ext = reg
-        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         .expect("openai vendor ext");
     assert!(matches!(
         ext.scope(),
@@ -113,11 +113,11 @@ fn vertex_build_url_rewrites_google_generate_content_to_vertex_resource() {
     p.base_url = "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global".into();
     p.api_key = r#"{"project_id":"demo-project"}"#.into();
     let ext = reg
-        .resolve(&p, GOOGLE_GENERATE_CONTENT_V1BETA)
+        .resolve(&p, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         .expect("vertex vendor ext");
     let ctx = ctx(
         &p,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
         &p.api_key,
         "gemini-2.5-flash",
         None,
@@ -143,11 +143,11 @@ fn vertex_build_url_rewrites_openai_compat_path_without_double_version() {
     p.base_url = "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi".into();
     p.api_key = r#"{"project_id":"demo-project"}"#.into();
     let ext = reg
-        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         .expect("vertex vendor ext");
     let ctx = ctx(
         &p,
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         &p.api_key,
         "google/gemini-2.5-flash",
         None,
@@ -166,13 +166,13 @@ fn resolve_falls_back_to_protocol_default_vendor_when_vendor_unknown() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("unmapped-vendor"), None);
     let openai = reg
-        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         .expect("openai protocol default");
     let anthropic = reg
         .resolve(&p, ANTHROPIC_MESSAGES_2023_06_01)
         .expect("anthropic protocol default");
     let google = reg
-        .resolve(&p, GOOGLE_GENERATE_CONTENT_V1BETA)
+        .resolve(&p, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
         .expect("google protocol default");
 
     // Resolves to the default vendor for each protocol suite
@@ -216,7 +216,7 @@ fn ollama_vendor_resolves_even_without_channel() {
     let reg = VendorRegistry::global();
     let p = make_provider(Some("ollama"), None);
     let ext = reg
-        .resolve(&p, OPENAI_CHAT_COMPLETIONS_V1)
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
         .expect("ollama vendor");
     assert!(matches!(
         ext.scope(),
@@ -232,10 +232,10 @@ fn ollama_vendor_resolves_even_without_channel() {
 fn openai_family_default_emits_bearer() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_CHAT_COMPLETIONS_V1).unwrap();
+    let ext = reg.resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).unwrap();
     let h = ext.auth_headers(&ctx(
         &p,
-        OPENAI_CHAT_COMPLETIONS_V1,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
         "sk-abc",
         "gpt-4",
         None,
@@ -263,10 +263,10 @@ fn anthropic_family_default_emits_x_api_key_and_version() {
 fn google_family_default_appends_key_query_param() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, GOOGLE_GENERATE_CONTENT_V1BETA).unwrap();
+    let ext = reg.resolve(&p, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA).unwrap();
     let c = ctx(
         &p,
-        GOOGLE_GENERATE_CONTENT_V1BETA,
+        GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
         "AIzaXYZ",
         "gemini-1.5",
         None,
@@ -297,8 +297,8 @@ fn google_family_default_appends_key_query_param() {
 fn openai_compat_strips_v1_when_base_already_has_path() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_CHAT_COMPLETIONS_V1).unwrap();
-    let c = ctx(&p, OPENAI_CHAT_COMPLETIONS_V1, "k", "m", None);
+    let ext = reg.resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).unwrap();
+    let c = ctx(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "k", "m", None);
 
     let stripped = ext.build_url(&c, "https://api.deepseek.com/v1", "/v1/chat/completions");
     assert_eq!(stripped, "https://api.deepseek.com/v1/chat/completions");

--- a/crates/nyro-core/tests/vendor_registry.rs
+++ b/crates/nyro-core/tests/vendor_registry.rs
@@ -8,8 +8,8 @@
 use nyro_core::auth::types::StoredCredential;
 use nyro_core::db::models::Provider;
 use nyro_core::protocol::ids::{
-    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
-    OPENAI_RESPONSES_V1, ProtocolId,
+    ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+    OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, OPENAI_RESPONSES_V1, ProtocolId,
 };
 use nyro_core::provider::{VendorCtx, VendorRegistry, VendorScope};
 use serde_json::Value;
@@ -232,7 +232,9 @@ fn ollama_vendor_resolves_even_without_channel() {
 fn openai_family_default_emits_bearer() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).unwrap();
+    let ext = reg
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
+        .unwrap();
     let h = ext.auth_headers(&ctx(
         &p,
         OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
@@ -263,7 +265,9 @@ fn anthropic_family_default_emits_x_api_key_and_version() {
 fn google_family_default_appends_key_query_param() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA).unwrap();
+    let ext = reg
+        .resolve(&p, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA)
+        .unwrap();
     let c = ctx(
         &p,
         GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
@@ -297,7 +301,9 @@ fn google_family_default_appends_key_query_param() {
 fn openai_compat_strips_v1_when_base_already_has_path() {
     let reg = VendorRegistry::global();
     let p = make_provider(None, None);
-    let ext = reg.resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1).unwrap();
+    let ext = reg
+        .resolve(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1)
+        .unwrap();
     let c = ctx(&p, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, "k", "m", None);
 
     let stripped = ext.build_url(&c, "https://api.deepseek.com/v1", "/v1/chat/completions");


### PR DESCRIPTION
Rename Protocol::GoogleGenerativeAI → Protocol::GoogleGemini to align with the canonical slug. Rename endpoint constants to follow the {PROTOCOL}_{ENDPOINT}_{VERSION} convention:
- OPENAI_CHAT_COMPLETIONS_V1 → OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1
- OPENAI_EMBEDDINGS_V1 → OPENAI_COMPATIBLE_EMBEDDINGS_V1
- GOOGLE_GENERATE_CONTENT_V1BETA → GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA

Remove deprecated aliases (OPENAI_CHAT_V1, GOOGLE_GENERATE_V1BETA) and the backward_compat_aliases test that verified them.