### PR TITLE
feat(provider): append route target add to provider copy workflow

### DIFF
--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -33,7 +33,7 @@ const MODELS_DEV_RUNTIME_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct CopyProviderOptions {
     #[serde(default)]
-    pub copy_routes: bool,
+    pub append_targets: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -661,8 +661,8 @@ impl AdminService {
             copied
         };
 
-        if options.copy_routes {
-            self.copy_provider_routes(&original.id, &copied.id).await?;
+        if options.append_targets {
+            self.append_provider_targets(&original.id, &copied.id).await?;
         }
 
         Ok(copied)
@@ -1691,7 +1691,7 @@ impl AdminService {
         unreachable!("unbounded provider copy name search must return");
     }
 
-    async fn copy_provider_routes(
+    async fn append_provider_targets(
         &self,
         original_provider_id: &str,
         copied_provider_id: &str,
@@ -3460,7 +3460,7 @@ mod tests {
 
         let copied = gw
             .admin()
-            .copy_provider_with_options(&original.id, CopyProviderOptions { copy_routes: true })
+            .copy_provider_with_options(&original.id, CopyProviderOptions { append_targets: true })
             .await?;
 
         assert!(!copied.is_enabled);
@@ -3514,7 +3514,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn copy_provider_does_not_copy_routes_by_default() -> anyhow::Result<()> {
+    async fn copy_provider_does_not_append_targets_by_default() -> anyhow::Result<()> {
         let gw = build_gateway().await?;
         let original = gw
             .admin()

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -662,7 +662,8 @@ impl AdminService {
         };
 
         if options.append_targets {
-            self.append_provider_targets(&original.id, &copied.id).await?;
+            self.append_provider_targets(&original.id, &copied.id)
+                .await?;
         }
 
         Ok(copied)
@@ -3460,7 +3461,12 @@ mod tests {
 
         let copied = gw
             .admin()
-            .copy_provider_with_options(&original.id, CopyProviderOptions { append_targets: true })
+            .copy_provider_with_options(
+                &original.id,
+                CopyProviderOptions {
+                    append_targets: true,
+                },
+            )
             .await?;
 
         assert!(!copied.is_enabled);

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::Gateway;
@@ -29,6 +29,12 @@ const MODELS_DEV_SNAPSHOT: &str = include_str!("../../assets/models.dev.json");
 const MODELS_DEV_RUNTIME_FILE: &str = "models.dev.json";
 const MODELS_DEV_SOURCE_URL: &str = "https://models.dev/api.json";
 const MODELS_DEV_RUNTIME_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CopyProviderOptions {
+    #[serde(default)]
+    pub copy_routes: bool,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProviderOAuthStatusData {
@@ -577,6 +583,15 @@ impl AdminService {
     }
 
     pub async fn copy_provider(&self, id: &str) -> anyhow::Result<Provider> {
+        self.copy_provider_with_options(id, CopyProviderOptions::default())
+            .await
+    }
+
+    pub async fn copy_provider_with_options(
+        &self,
+        id: &str,
+        options: CopyProviderOptions,
+    ) -> anyhow::Result<Provider> {
         let original = self.get_provider(id).await?;
         let name = self.next_provider_copy_name(&original.name).await?;
         let copied = self
@@ -593,6 +608,15 @@ impl AdminService {
                 auth_mode: original.auth_mode.clone(),
                 use_proxy: original.use_proxy,
             })
+            .await?;
+        let copied = self
+            .update_provider(
+                &copied.id,
+                UpdateProvider {
+                    is_enabled: Some(false),
+                    ..Default::default()
+                },
+            )
             .await?;
 
         let copied = if original.effective_auth_mode() == "oauth" {
@@ -636,6 +660,10 @@ impl AdminService {
         } else {
             copied
         };
+
+        if options.copy_routes {
+            self.copy_provider_routes(&original.id, &copied.id).await?;
+        }
 
         Ok(copied)
     }
@@ -1663,6 +1691,64 @@ impl AdminService {
         unreachable!("unbounded provider copy name search must return");
     }
 
+    async fn copy_provider_routes(
+        &self,
+        original_provider_id: &str,
+        copied_provider_id: &str,
+    ) -> anyhow::Result<()> {
+        let routes = self.list_routes().await?;
+        for route in routes.into_iter().filter(|route| {
+            route
+                .targets
+                .iter()
+                .any(|target| target.provider_id == original_provider_id)
+        }) {
+            let mut targets = route
+                .targets
+                .iter()
+                .map(|target| CreateRouteTarget {
+                    provider_id: target.provider_id.clone(),
+                    model: target.model.clone(),
+                    weight: Some(target.weight),
+                    priority: Some(target.priority),
+                })
+                .collect::<Vec<_>>();
+
+            let copied_targets = route
+                .targets
+                .iter()
+                .filter(|target| target.provider_id == original_provider_id)
+                .map(|target| CreateRouteTarget {
+                    provider_id: copied_provider_id.to_string(),
+                    model: target.model.clone(),
+                    weight: Some(target.weight),
+                    priority: Some(target.priority),
+                });
+            targets.extend(copied_targets);
+
+            self.update_route(
+                &route.id,
+                UpdateRoute {
+                    targets: Some(
+                        targets
+                            .into_iter()
+                            .map(|target| UpsertRouteTarget {
+                                id: None,
+                                provider_id: target.provider_id,
+                                model: target.model,
+                                weight: target.weight,
+                                priority: target.priority,
+                            })
+                            .collect(),
+                    ),
+                    ..UpdateRoute::default()
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
     async fn ensure_route_name_unique(
         &self,
         exclude_id: Option<&str>,
@@ -2029,6 +2115,7 @@ impl AdminService {
                     models_source,
                     api_key: Some(String::new()),
                     auth_mode: Some("oauth".to_string()),
+                    is_enabled: Some(provider.is_enabled),
                     ..Default::default()
                 },
             )
@@ -3279,7 +3366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn copy_provider_creates_provider_with_copy_suffix() -> anyhow::Result<()> {
+    async fn copy_provider_creates_disabled_provider_with_copy_suffix() -> anyhow::Result<()> {
         let gw = build_gateway().await?;
         let original = gw
             .admin()
@@ -3300,7 +3387,8 @@ mod tests {
         assert_eq!(copied.api_key, original.api_key);
         assert_eq!(copied.auth_mode, original.auth_mode);
         assert_eq!(copied.use_proxy, original.use_proxy);
-        assert_eq!(copied.is_enabled, original.is_enabled);
+        assert!(original.is_enabled);
+        assert!(!copied.is_enabled);
 
         Ok(())
     }
@@ -3317,6 +3405,144 @@ mod tests {
         let second_copy = gw.admin().copy_provider(&original.id).await?;
 
         assert_eq!(second_copy.name, "source-provider_Copy2");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> anyhow::Result<()>
+    {
+        let gw = build_gateway().await?;
+        let original = gw
+            .admin()
+            .create_provider(api_key_provider_input("route-source-provider"))
+            .await?;
+        let fallback = gw
+            .admin()
+            .create_provider(api_key_provider_input("route-fallback-provider"))
+            .await?;
+
+        let source_route = gw
+            .admin()
+            .create_route(CreateRoute {
+                name: "source-route".to_string(),
+                virtual_model: "source-model".to_string(),
+                strategy: Some("priority".to_string()),
+                target_provider: String::new(),
+                target_model: String::new(),
+                targets: vec![
+                    CreateRouteTarget {
+                        provider_id: original.id.clone(),
+                        model: "source-upstream-model".to_string(),
+                        weight: Some(80),
+                        priority: Some(1),
+                    },
+                    CreateRouteTarget {
+                        provider_id: fallback.id.clone(),
+                        model: "fallback-upstream-model".to_string(),
+                        weight: Some(20),
+                        priority: Some(2),
+                    },
+                ],
+                access_control: Some(true),
+                cache: Some(RouteCacheConfig {
+                    exact: Some(RouteExactCacheConfig { ttl: Some(60) }),
+                    semantic: Some(RouteSemanticCacheConfig {
+                        ttl: Some(120),
+                        threshold: Some(0.8),
+                    }),
+                }),
+                cache_exact_ttl: None,
+                cache_semantic_ttl: None,
+                cache_semantic_threshold: None,
+            })
+            .await?;
+
+        let copied = gw
+            .admin()
+            .copy_provider_with_options(&original.id, CopyProviderOptions { copy_routes: true })
+            .await?;
+
+        assert!(!copied.is_enabled);
+        let routes = gw.admin().list_routes().await?;
+        assert_eq!(
+            routes.len(),
+            1,
+            "copying route targets must not create new routes"
+        );
+        assert!(routes.iter().all(|route| route.name != "source-route_Copy"));
+        assert!(
+            routes
+                .iter()
+                .all(|route| route.virtual_model != "source-model_Copy")
+        );
+
+        let updated_route = routes
+            .iter()
+            .find(|route| route.id == source_route.id)
+            .expect("source route should remain");
+        assert_eq!(updated_route.name, "source-route");
+        assert_eq!(updated_route.virtual_model, "source-model");
+        assert_eq!(updated_route.strategy, "priority");
+        assert!(updated_route.access_control);
+        assert_eq!(updated_route.cache_exact_ttl, Some(60));
+        assert_eq!(updated_route.cache_semantic_ttl, Some(120));
+        assert_eq!(updated_route.cache_semantic_threshold, Some(0.8));
+        assert_eq!(updated_route.target_provider, original.id);
+        assert_eq!(updated_route.target_model, "source-upstream-model");
+        assert_eq!(updated_route.targets.len(), 3);
+        assert!(updated_route.targets.iter().any(|target| {
+            target.provider_id == original.id
+                && target.model == "source-upstream-model"
+                && target.weight == 80
+                && target.priority == 1
+        }));
+        assert!(updated_route.targets.iter().any(|target| {
+            target.provider_id == copied.id
+                && target.model == "source-upstream-model"
+                && target.weight == 80
+                && target.priority == 1
+        }));
+        assert!(updated_route.targets.iter().any(|target| {
+            target.provider_id == fallback.id
+                && target.model == "fallback-upstream-model"
+                && target.weight == 20
+                && target.priority == 2
+        }));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn copy_provider_does_not_copy_routes_by_default() -> anyhow::Result<()> {
+        let gw = build_gateway().await?;
+        let original = gw
+            .admin()
+            .create_provider(api_key_provider_input("no-route-copy-provider"))
+            .await?;
+
+        gw.admin()
+            .create_route(CreateRoute {
+                name: "no-route-copy-source".to_string(),
+                virtual_model: "no-route-copy-model".to_string(),
+                strategy: None,
+                target_provider: original.id.clone(),
+                target_model: "source-upstream-model".to_string(),
+                targets: vec![],
+                access_control: None,
+                cache: None,
+                cache_exact_ttl: None,
+                cache_semantic_ttl: None,
+                cache_semantic_threshold: None,
+            })
+            .await?;
+
+        gw.admin().copy_provider(&original.id).await?;
+
+        let routes = gw.admin().list_routes().await?;
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].targets.len(), 1);
+        assert_eq!(routes[0].targets[0].provider_id, original.id);
 
         Ok(())
     }

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -305,7 +305,7 @@ pub struct UpdateProvider {
     pub is_enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateRoute {
     pub name: Option<String>,
     #[serde(alias = "vmodel")]

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -5,6 +5,7 @@ use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::{Extension, Json, Router};
 use nyro_core::Gateway;
+use nyro_core::admin::CopyProviderOptions;
 use nyro_core::auth::AuthExchangeInput;
 use nyro_core::db::models::*;
 use serde::Deserialize;
@@ -181,8 +182,10 @@ async fn create_provider_handler(
 async fn copy_provider_handler(
     State(gw): State<Gateway>,
     Path(id): Path<String>,
+    options: Option<Json<CopyProviderOptions>>,
 ) -> impl IntoResponse {
-    match gw.admin().copy_provider(&id).await {
+    let options = options.map(|Json(options)| options).unwrap_or_default();
+    match gw.admin().copy_provider_with_options(&id, options).await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
         Err(e) => err(e),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use nyro_core::Gateway;
-use nyro_core::admin::ProviderOAuthStatusData;
+use nyro_core::admin::{CopyProviderOptions, ProviderOAuthStatusData};
 use nyro_core::auth::{AuthExchangeInput, AuthSessionInitData, AuthSessionStatusData};
 use nyro_core::db::models::*;
 use serde::{Deserialize, Serialize};
@@ -46,9 +46,13 @@ pub async fn create_provider(
 }
 
 #[tauri::command]
-pub async fn copy_provider(gw: State<'_, Gateway>, id: String) -> Result<Provider, String> {
+pub async fn copy_provider(
+    gw: State<'_, Gateway>,
+    id: String,
+    options: Option<CopyProviderOptions>,
+) -> Result<Provider, String> {
     gw.admin()
-        .copy_provider(&id)
+        .copy_provider_with_options(&id, options.unwrap_or_default())
         .await
         .map_err(|e| e.to_string())
 }

--- a/webui/src/components/ui/confirm-dialog.tsx
+++ b/webui/src/components/ui/confirm-dialog.tsx
@@ -14,6 +14,7 @@ type ConfirmDialogProps = {
   onOpenChange: (open: boolean) => void;
   title: string;
   description?: string;
+  content?: React.ReactNode;
   hideCancel?: boolean;
   cancelText?: string;
   confirmText?: string;
@@ -26,6 +27,7 @@ function ConfirmDialog({
   onOpenChange,
   title,
   description,
+  content,
   hideCancel = false,
   cancelText = "Cancel",
   confirmText = "Confirm",
@@ -39,6 +41,7 @@ function ConfirmDialog({
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
+        {content && <div className="py-2">{content}</div>}
         <DialogFooter>
           {!hideCancel && (
             <Button variant="secondary" onClick={() => onOpenChange(false)}>

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -67,7 +67,11 @@ function resolveHTTP(cmd: string, args?: Record<string, unknown>): HTTPMapping {
     case "create_provider":
       return { method: "POST", url: `${base}/providers`, body: args?.input as Record<string, unknown> };
     case "copy_provider":
-      return { method: "POST", url: `${base}/providers/${args?.id}/copy` };
+      return {
+        method: "POST",
+        url: `${base}/providers/${args?.id}/copy`,
+        body: (args?.options ?? {}) as Record<string, unknown>,
+      };
     case "update_provider":
       return { method: "PUT", url: `${base}/providers/${args?.id}`, body: args?.input as Record<string, unknown> };
     case "delete_provider":

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -39,6 +39,7 @@ import { NyroIcon } from "@/components/ui/nyro-icon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
@@ -389,6 +390,7 @@ export default function ProvidersPage() {
   const [testTarget, setTestTarget] = useState<Provider | null>(null);
   const [providerToDelete, setProviderToDelete] = useState<Provider | null>(null);
   const [providerToCopy, setProviderToCopy] = useState<Provider | null>(null);
+  const [copyRoutes, setCopyRoutes] = useState(false);
   const [selectedPresetId, setSelectedPresetId] = useState(DEFAULT_PRESET_ID);
   const [showCreateApiKey, setShowCreateApiKey] = useState(true);
   const [showEditApiKey, setShowEditApiKey] = useState(false);
@@ -555,9 +557,11 @@ export default function ProvidersPage() {
   });
 
   const copyMut = useMutation({
-    mutationFn: (id: string) => backend<Provider>("copy_provider", { id }),
+    mutationFn: ({ id, copyRoutes }: { id: string; copyRoutes: boolean }) =>
+      backend<Provider>("copy_provider", { id, options: { copy_routes: copyRoutes } }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["providers"] });
+      qc.invalidateQueries({ queryKey: ["routes"] });
     },
     onError: (error: unknown) => {
       showErrorDialog("复制提供商失败", "Failed to copy provider", error);
@@ -2401,7 +2405,10 @@ export default function ProvidersPage() {
                       <Pencil className="h-4 w-4" />
                     </button>
                     <button
-                      onClick={() => setProviderToCopy(p)}
+                      onClick={() => {
+                        setCopyRoutes(false);
+                        setProviderToCopy(p);
+                      }}
                       disabled={copyMut.isPending}
                       title={isZh ? "复制" : "Copy"}
                       className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-emerald-50 hover:text-emerald-500 cursor-pointer disabled:opacity-50"
@@ -2523,23 +2530,50 @@ export default function ProvidersPage() {
       <ConfirmDialog
         open={Boolean(providerToCopy)}
         onOpenChange={(open) => {
-          if (!open && !copyMut.isPending) setProviderToCopy(null);
+          if (!open && !copyMut.isPending) {
+            setProviderToCopy(null);
+            setCopyRoutes(false);
+          }
         }}
         title={isZh ? "确认复制提供商" : "Confirm provider copy"}
         description={
           providerToCopy
             ? (isZh
-              ? `确认复制「${providerToCopy.name}」吗？新提供商名称将为「${nextProviderCopyName(providers, providerToCopy.name)}」。`
-              : `Copy "${providerToCopy.name}"? The new provider name will be "${nextProviderCopyName(providers, providerToCopy.name)}".`)
+              ? `确认复制「${providerToCopy.name}」吗？新提供商名称将为「${nextProviderCopyName(providers, providerToCopy.name)}」。复制出的 Provider 默认为关闭状态。`
+              : `Copy "${providerToCopy.name}"? The new provider name will be "${nextProviderCopyName(providers, providerToCopy.name)}". The copied provider will be disabled by default.`)
             : undefined
+        }
+        content={
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+            <Checkbox
+              checked={copyRoutes}
+              onCheckedChange={(checked) => setCopyRoutes(checked === true)}
+              disabled={copyMut.isPending}
+              aria-label={isZh ? "是否同步路由 Target" : "Copy route targets"}
+              className="mt-0.5"
+            />
+            <span className="space-y-1">
+              <span className="block font-medium text-slate-800">
+                {isZh ? "是否同步路由 Target" : "Copy route targets"}
+              </span>
+              <span className="block text-xs text-slate-500">
+                {isZh
+                  ? "勾选后不会新建路由，只会在引用该 Provider 的现有路由中复制对应 Target 并指向新 Provider。"
+                  : "When selected, no routes are created; matching targets in existing routes are duplicated and pointed at the new provider."}
+              </span>
+            </span>
+          </label>
         }
         cancelText={isZh ? "取消" : "Cancel"}
         confirmText={copyMut.isPending ? (isZh ? "复制中..." : "Copying...") : (isZh ? "确认复制" : "Copy")}
         confirmClassName="bg-slate-900 text-white hover:bg-slate-800"
         onConfirm={() => {
           if (!providerToCopy || copyMut.isPending) return;
-          copyMut.mutate(providerToCopy.id, {
-            onSuccess: () => setProviderToCopy(null),
+          copyMut.mutate({ id: providerToCopy.id, copyRoutes }, {
+            onSuccess: () => {
+              setProviderToCopy(null);
+              setCopyRoutes(false);
+            },
           });
         }}
       />

--- a/webui/src/pages/providers.tsx
+++ b/webui/src/pages/providers.tsx
@@ -390,7 +390,7 @@ export default function ProvidersPage() {
   const [testTarget, setTestTarget] = useState<Provider | null>(null);
   const [providerToDelete, setProviderToDelete] = useState<Provider | null>(null);
   const [providerToCopy, setProviderToCopy] = useState<Provider | null>(null);
-  const [copyRoutes, setCopyRoutes] = useState(false);
+  const [appendTargets, setAppendTargets] = useState(false);
   const [selectedPresetId, setSelectedPresetId] = useState(DEFAULT_PRESET_ID);
   const [showCreateApiKey, setShowCreateApiKey] = useState(true);
   const [showEditApiKey, setShowEditApiKey] = useState(false);
@@ -557,8 +557,8 @@ export default function ProvidersPage() {
   });
 
   const copyMut = useMutation({
-    mutationFn: ({ id, copyRoutes }: { id: string; copyRoutes: boolean }) =>
-      backend<Provider>("copy_provider", { id, options: { copy_routes: copyRoutes } }),
+    mutationFn: ({ id, appendTargets }: { id: string; appendTargets: boolean }) =>
+      backend<Provider>("copy_provider", { id, options: { append_targets: appendTargets } }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["providers"] });
       qc.invalidateQueries({ queryKey: ["routes"] });
@@ -2406,7 +2406,7 @@ export default function ProvidersPage() {
                     </button>
                     <button
                       onClick={() => {
-                        setCopyRoutes(false);
+                        setAppendTargets(false);
                         setProviderToCopy(p);
                       }}
                       disabled={copyMut.isPending}
@@ -2532,34 +2532,34 @@ export default function ProvidersPage() {
         onOpenChange={(open) => {
           if (!open && !copyMut.isPending) {
             setProviderToCopy(null);
-            setCopyRoutes(false);
+            setAppendTargets(false);
           }
         }}
         title={isZh ? "确认复制提供商" : "Confirm provider copy"}
         description={
           providerToCopy
             ? (isZh
-              ? `确认复制「${providerToCopy.name}」吗？新提供商名称将为「${nextProviderCopyName(providers, providerToCopy.name)}」。复制出的 Provider 默认为关闭状态。`
-              : `Copy "${providerToCopy.name}"? The new provider name will be "${nextProviderCopyName(providers, providerToCopy.name)}". The copied provider will be disabled by default.`)
+              ? `复制「${providerToCopy.name}」为「${nextProviderCopyName(providers, providerToCopy.name)}」，新提供商默认禁用。`
+              : `Copy "${providerToCopy.name}" as "${nextProviderCopyName(providers, providerToCopy.name)}" (disabled by default).`)
             : undefined
         }
         content={
           <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
             <Checkbox
-              checked={copyRoutes}
-              onCheckedChange={(checked) => setCopyRoutes(checked === true)}
+              checked={appendTargets}
+              onCheckedChange={(checked) => setAppendTargets(checked === true)}
               disabled={copyMut.isPending}
-              aria-label={isZh ? "是否同步路由 Target" : "Copy route targets"}
+              aria-label={isZh ? "追加路由目标" : "Append route targets"}
               className="mt-0.5"
             />
             <span className="space-y-1">
               <span className="block font-medium text-slate-800">
-                {isZh ? "是否同步路由 Target" : "Copy route targets"}
+                {isZh ? "追加路由目标" : "Append route targets"}
               </span>
               <span className="block text-xs text-slate-500">
                 {isZh
-                  ? "勾选后不会新建路由，只会在引用该 Provider 的现有路由中复制对应 Target 并指向新 Provider。"
-                  : "When selected, no routes are created; matching targets in existing routes are duplicated and pointed at the new provider."}
+                  ? "在引用该提供商的现有路由中追加指向新提供商的目标。"
+                  : "Append targets pointing to the new provider in existing routes that reference this provider."}
               </span>
             </span>
           </label>
@@ -2569,10 +2569,10 @@ export default function ProvidersPage() {
         confirmClassName="bg-slate-900 text-white hover:bg-slate-800"
         onConfirm={() => {
           if (!providerToCopy || copyMut.isPending) return;
-          copyMut.mutate({ id: providerToCopy.id, copyRoutes }, {
+          copyMut.mutate({ id: providerToCopy.id, appendTargets }, {
             onSuccess: () => {
               setProviderToCopy(null);
-              setCopyRoutes(false);
+              setAppendTargets(false);
             },
           });
         }}


### PR DESCRIPTION
## Summary
- Add provider copy options through core admin, HTTP, Tauri, and WebUI flows.
- Copied providers are disabled by default for manual review before enabling.
- Optional route sync duplicates matching route targets onto existing routes without creating new route records.

## Test Plan
- [x] cargo test -p nyro-core admin::tests::copy_provider -- --nocapture
- [x] cargo check -p nyro-server && cargo check -p nyro-desktop
- [x] npm --prefix webui run build
- [x] git diff --check
