### PR TITLE
feat(proxy): forward client cache hints without leaking identity

### DIFF
--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -522,10 +522,17 @@ pub async fn dispatch_pipeline(
             }
         };
 
-        // Merge runtime-binding extra headers (runtime binding < adapter, adapter wins).
+        // Merge runtime-binding extra headers and safe client headers.
+        //
+        // Precedence: runtime binding < forwarded client hints < adapter.
+        // Sensitive client headers (auth keys, cookies, IP/host forwarding
+        // metadata, hop-by-hop transport headers) are filtered in
+        // `forwarded_client_headers`, while adapter/provider auth remains
+        // authoritative.
         match runtime_binding_headers(&provider_runtime.binding) {
             Ok(binding_hdrs) => {
                 let mut merged = binding_hdrs;
+                merged.extend(forwarded_client_headers(&headers));
                 merged.extend(outbound.headers);
                 outbound.headers = merged;
             }

--- a/crates/nyro-core/src/proxy/dispatcher/util.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/util.rs
@@ -5,7 +5,10 @@
 
 use tokio::time::Duration;
 
-use reqwest::header::{HeaderMap as ReqwestHeaderMap, HeaderValue as ReqwestHeaderValue};
+use reqwest::header::{
+    HeaderMap as ReqwestHeaderMap, HeaderName as ReqwestHeaderName,
+    HeaderValue as ReqwestHeaderValue,
+};
 
 use crate::Gateway;
 use crate::cache::entry::CacheEntry;
@@ -70,6 +73,90 @@ pub(super) fn runtime_binding_headers(
         );
     }
     Ok(headers)
+}
+
+/// Convert client-supplied request headers into the safe subset that may be
+/// forwarded upstream.
+///
+/// Authentication, API-key, cookie, hop-by-hop, proxy, and client network
+/// identity headers are intentionally dropped so Nyro's local credentials and
+/// caller IP/host metadata never leak to providers. Provider/runtime headers
+/// are merged elsewhere after this function, so internal credentials still win.
+pub(super) fn forwarded_client_headers(headers: &axum::http::HeaderMap) -> ReqwestHeaderMap {
+    let mut forwarded = ReqwestHeaderMap::new();
+    for (name, value) in headers {
+        if !should_forward_client_header(name.as_str()) {
+            continue;
+        }
+        if let (Ok(name), Ok(value)) = (
+            ReqwestHeaderName::from_bytes(name.as_str().as_bytes()),
+            ReqwestHeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            forwarded.append(name, value);
+        }
+    }
+    forwarded
+}
+
+fn should_forward_client_header(name: &str) -> bool {
+    let name = name.trim().to_ascii_lowercase();
+    if name.is_empty() {
+        return false;
+    }
+
+    let denied = matches!(
+        name.as_str(),
+        // Local/proxy credentials and cookies.
+        "authorization"
+            | "proxy-authorization"
+            | "www-authenticate"
+            | "proxy-authenticate"
+            | "x-api-key"
+            | "x-goog-api-key"
+            | "api-key"
+            | "x-auth-token"
+            | "x-access-token"
+            | "x-refresh-token"
+            | "access-token"
+            | "refresh-token"
+            | "cookie"
+            | "set-cookie"
+            // Hop-by-hop / transport-managed headers.
+            | "connection"
+            | "keep-alive"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+            | "host"
+            | "content-length"
+            // Client network identity / local origin metadata.
+            | "forwarded"
+            | "x-forwarded-for"
+            | "x-forwarded-host"
+            | "x-forwarded-proto"
+            | "x-forwarded-port"
+            | "x-forwarded-server"
+            | "x-original-forwarded-for"
+            | "x-real-ip"
+            | "x-client-ip"
+            | "x-cluster-client-ip"
+            | "x-remote-ip"
+            | "x-remote-addr"
+            | "remote-host"
+            | "remote-addr"
+            | "cf-connecting-ip"
+            | "true-client-ip"
+            | "fastly-client-ip"
+            | "via"
+            | "origin"
+            | "referer"
+    ) || name.ends_with("-api-key")
+        || name.starts_with("sec-")
+        || name.starts_with("proxy-")
+        || name.starts_with("cf-");
+
+    !denied
 }
 
 // ── Route-level cache configuration helpers ────────────────────────────────────
@@ -159,4 +246,56 @@ pub(super) fn extract_semantic_embedding_input(request: &AiRequest) -> Option<(S
         format!("{system_prompt}\n{last_user}")
     };
     Some((system_prompt, combined))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderValue};
+
+    use super::*;
+
+    #[test]
+    fn forwarded_client_headers_keep_cache_hints() {
+        let mut headers = HeaderMap::new();
+        headers.insert("anthropic-beta", HeaderValue::from_static("prompt-caching"));
+        headers.insert("openai-beta", HeaderValue::from_static("responses=v1"));
+        headers.insert("idempotency-key", HeaderValue::from_static("request-123"));
+
+        let forwarded = forwarded_client_headers(&headers);
+
+        assert_eq!(forwarded.get("anthropic-beta").unwrap(), "prompt-caching");
+        assert_eq!(forwarded.get("openai-beta").unwrap(), "responses=v1");
+        assert_eq!(forwarded.get("idempotency-key").unwrap(), "request-123");
+    }
+
+    #[test]
+    fn forwarded_client_headers_drop_keys_and_sensitive_network_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer nyro-key"));
+        headers.insert("x-api-key", HeaderValue::from_static("nyro-key"));
+        headers.insert("x-goog-api-key", HeaderValue::from_static("nyro-key"));
+        headers.insert(
+            "proxy-authorization",
+            HeaderValue::from_static("Basic secret"),
+        );
+        headers.insert("cookie", HeaderValue::from_static("session=secret"));
+        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.1"));
+        headers.insert("x-real-ip", HeaderValue::from_static("10.0.0.2"));
+        headers.insert("remote-host", HeaderValue::from_static("client.local"));
+        headers.insert("connection", HeaderValue::from_static("keep-alive"));
+        headers.insert("anthropic-beta", HeaderValue::from_static("prompt-caching"));
+
+        let forwarded = forwarded_client_headers(&headers);
+
+        assert!(forwarded.get("authorization").is_none());
+        assert!(forwarded.get("x-api-key").is_none());
+        assert!(forwarded.get("x-goog-api-key").is_none());
+        assert!(forwarded.get("proxy-authorization").is_none());
+        assert!(forwarded.get("cookie").is_none());
+        assert!(forwarded.get("x-forwarded-for").is_none());
+        assert!(forwarded.get("x-real-ip").is_none());
+        assert!(forwarded.get("remote-host").is_none());
+        assert!(forwarded.get("connection").is_none());
+        assert_eq!(forwarded.get("anthropic-beta").unwrap(), "prompt-caching");
+    }
 }

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -68,6 +68,12 @@ fn build_proxy_cors_layer(origins: &[String], proxy_port: u16) -> CorsLayer {
             header::ACCEPT,
             header::HeaderName::from_static("x-api-key"),
             header::HeaderName::from_static("anthropic-version"),
+            header::HeaderName::from_static("anthropic-beta"),
+            header::HeaderName::from_static("openai-beta"),
+            header::HeaderName::from_static("openai-organization"),
+            header::HeaderName::from_static("openai-project"),
+            header::HeaderName::from_static("idempotency-key"),
+            header::HeaderName::from_static("x-request-id"),
         ])
 }
 


### PR DESCRIPTION
## Summary
- Forward safe client request headers to upstream providers so cache/beta/idempotency hints survive proxying.
- Filter Nyro/client credentials, cookies, hop-by-hop headers, proxy headers, and caller network identity headers including x-forwarded-for, x-real-ip, and remote-host.
- Allow common cache/beta headers through proxy CORS preflight.

## Test Plan
- cargo test -p nyro-core proxy::dispatcher::util::tests::forwarded_client_headers -- --nocapture
- cargo check -p nyro-core
- cargo fmt --check
- git diff --check