### PR TITLE
feat(ir): handle Gemini JSON returned from stream endpoints

### DIFF
--- a/crates/nyro-core/src/protocol/codec/google/gemini/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/google/gemini/stream.rs
@@ -166,13 +166,19 @@ impl StreamResponseDecoder for GoogleStreamParser {
             let block = self.buffer[..pos].to_string();
             self.buffer = self.buffer[pos + 2..].to_string();
 
+            let mut saw_sse_data = false;
             for line in block.lines() {
                 if let Some(data) = line.strip_prefix("data: ") {
+                    saw_sse_data = true;
                     let data = data.trim();
                     if let Ok(chunk) = serde_json::from_str::<Value>(data) {
                         parse_gemini_chunk(&chunk, &mut deltas, &mut self.first);
                     }
                 }
+            }
+
+            if !saw_sse_data && let Ok(chunk) = serde_json::from_str::<Value>(block.trim()) {
+                parse_gemini_chunk(&chunk, &mut deltas, &mut self.first);
             }
         }
 
@@ -694,7 +700,8 @@ fn extract_gemini_usage(v: &Value) -> Usage {
         ],
     )
     .unwrap_or(0);
-    let output = first_u64(
+    let total = first_u64(u, &["totalTokenCount", "total_tokens"]);
+    let candidate_output = first_u64(
         u,
         &[
             "candidatesTokenCount",
@@ -702,12 +709,21 @@ fn extract_gemini_usage(v: &Value) -> Usage {
             "outputTokenCount",
             "output_tokens",
         ],
+    );
+    let thoughts = first_u64(
+        u,
+        &["thoughtsTokenCount", "reasoning_tokens", "thought_tokens"],
     )
     .unwrap_or(0);
+    let output = total
+        .and_then(|total| total.checked_sub(input))
+        .or_else(|| candidate_output.map(|output| output.saturating_add(thoughts)))
+        .unwrap_or(0);
 
     Usage {
         prompt_tokens: input as u32,
         completion_tokens: output as u32,
+        total_tokens: total.unwrap_or(input.saturating_add(output)) as u32,
         ..Usage::default()
     }
 }
@@ -976,5 +992,60 @@ mod tests {
             "IMAGE"
         );
         assert_eq!(usage_event["responseId"], "stream-future");
+    }
+
+    #[test]
+    fn stream_parser_extracts_usage_from_non_sse_generate_content_response() {
+        let raw = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "text": "{\n \"\n}",
+                        "thoughtSignature": "EtpxCtdxAQtnKrzuYidcoegpuXXkuA=="
+                    }],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }],
+            "modelVersion": "gemini-3.5-flash",
+            "responseId": "Q90OarbFKsXM-sAPuOH-8AE",
+            "usageMetadata": {
+                "candidatesTokenCount": 1408,
+                "promptTokenCount": 10996,
+                "promptTokensDetails": [{
+                    "modality": "TEXT",
+                    "tokenCount": 10996
+                }],
+                "serviceTier": "standard",
+                "thoughtsTokenCount": 4649,
+                "totalTokenCount": 17053
+            }
+        })
+        .to_string();
+
+        let mut parser = GoogleStreamParser::new();
+        let initial = parser.parse_chunk(&raw).unwrap();
+        assert!(
+            initial.is_empty(),
+            "bare JSON should be completed by finish"
+        );
+
+        let deltas = parser.finish().unwrap();
+        let usage = deltas
+            .iter()
+            .find_map(|delta| match delta {
+                AiStreamDelta::Usage(usage) => Some(usage),
+                _ => None,
+            })
+            .expect("non-SSE streamGenerateContent response should emit usage");
+
+        assert_eq!(usage.prompt_tokens, 10996);
+        assert_eq!(usage.completion_tokens, 6057);
+        assert_eq!(usage.total_tokens, 17053);
+        assert!(deltas.iter().any(|delta| matches!(
+            delta,
+            AiStreamDelta::Done { stop_reason } if stop_reason == "stop"
+        )));
     }
 }

--- a/crates/nyro-core/src/proxy/dispatcher/stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/stream.rs
@@ -19,13 +19,14 @@ use tokio::sync::broadcast;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::cache::entry::CacheEntry;
+use crate::protocol::ids::ProtocolEndpoint;
 use crate::protocol::ir::AiStreamDelta;
 use crate::proxy::client::ProxyClient;
 use crate::proxy::observability::headers_to_json;
 
 use super::{
     CacheWriteCtx, CallCtx, LogBuilder, RequestExtras, StreamResponseAccumulator,
-    compute_embedding, error_response, set_cache_headers,
+    ai_response_to_deltas, compute_embedding, error_response, set_cache_headers,
 };
 
 // ── Streaming response handler ────────────────────────────────────────────────
@@ -113,10 +114,14 @@ pub(super) async fn handle_stream(
 
         tokio::spawn(async move {
             let mut log_buf: Vec<u8> = Vec::new();
+            let mut undecided_buf: Vec<u8> = Vec::new();
             let mut byte_stream = resp.bytes_stream();
             let mut stream_error: Option<String> = None;
             let mut chunks_count: i32 = 0;
             let mut first_chunk_ms: Option<i64> = None;
+            let mut passthrough_mode = PassthroughBodyMode::Undecided;
+            let mut converted_client_sse: Option<String> = None;
+            let mut converted_ai_resp = None;
 
             while let Some(result) = byte_stream.next().await {
                 match result {
@@ -126,8 +131,33 @@ pub(super) async fn handle_stream(
                         }
                         chunks_count += 1;
                         log_buf.extend_from_slice(&b);
-                        if pt_tx.send(Ok(b)).await.is_err() {
-                            break; // client disconnected
+                        match passthrough_mode {
+                            PassthroughBodyMode::Undecided => {
+                                undecided_buf.extend_from_slice(&b);
+                                match classify_passthrough_body(&undecided_buf) {
+                                    Some(PassthroughBodyMode::RawSse) => {
+                                        passthrough_mode = PassthroughBodyMode::RawSse;
+                                        let pending = std::mem::take(&mut undecided_buf);
+                                        if pt_tx.send(Ok(Bytes::from(pending))).await.is_err() {
+                                            break; // client disconnected
+                                        }
+                                    }
+                                    Some(PassthroughBodyMode::NonSseJson) => {
+                                        passthrough_mode = PassthroughBodyMode::NonSseJson;
+                                        undecided_buf.clear();
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            PassthroughBodyMode::RawSse => {
+                                if pt_tx.send(Ok(b)).await.is_err() {
+                                    break; // client disconnected
+                                }
+                            }
+                            PassthroughBodyMode::NonSseJson => {
+                                // Upstream returned a complete JSON response to a stream endpoint.
+                                // Buffer until EOF, then convert it to the downstream SSE shape.
+                            }
                         }
                     }
                     Err(e) => {
@@ -148,6 +178,17 @@ pub(super) async fn handle_stream(
             let upstream_latency_ms = upstream_start_pt.elapsed().as_millis() as i64;
             let raw_sse = String::from_utf8_lossy(&log_buf).into_owned();
 
+            if matches!(
+                passthrough_mode,
+                PassthroughBodyMode::NonSseJson | PassthroughBodyMode::Undecided
+            ) && let Some((client_sse, ai_resp)) =
+                format_non_sse_stream_response(&raw_sse, egress, ingress)
+            {
+                let _ = pt_tx.send(Ok(Bytes::from(client_sse.clone()))).await;
+                converted_client_sse = Some(client_sse);
+                converted_ai_resp = Some(ai_resp);
+            }
+
             // Parse accumulated buffer for usage stats (best-effort).
             let mut log_parser = egress.handler().make_stream_response_decoder();
             let mut accumulator = StreamResponseAccumulator::default();
@@ -158,7 +199,7 @@ pub(super) async fn handle_stream(
                 accumulator.apply_all(&ai_deltas);
             }
 
-            let mut ai_resp = accumulator.into_ai_response();
+            let mut ai_resp = converted_ai_resp.unwrap_or_else(|| accumulator.into_ai_response());
             if ai_resp.id.is_empty() {
                 ai_resp.id = format!("msg_{}", uuid::Uuid::new_v4().simple());
             }
@@ -178,7 +219,7 @@ pub(super) async fn handle_stream(
                     Some(raw_sse.clone()),
                     Some(upstream_latency_ms),
                 )
-                .with_client_response(None, Some(raw_sse))
+                .with_client_response(None, Some(converted_client_sse.unwrap_or(raw_sse)))
                 .stream_metrics(chunks_count, first_chunk_ms)
                 .emit();
 
@@ -406,4 +447,101 @@ pub(super) async fn handle_stream(
         .unwrap();
     set_cache_headers(&mut response, "MISS", cache_key, None, expose_headers);
     response
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PassthroughBodyMode {
+    Undecided,
+    RawSse,
+    NonSseJson,
+}
+
+fn classify_passthrough_body(bytes: &[u8]) -> Option<PassthroughBodyMode> {
+    let text = String::from_utf8_lossy(bytes);
+    let trimmed = text.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("data:")
+        || trimmed.starts_with("event:")
+        || trimmed.starts_with("id:")
+        || trimmed.starts_with("retry:")
+        || trimmed.starts_with(':')
+    {
+        return Some(PassthroughBodyMode::RawSse);
+    }
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        return Some(PassthroughBodyMode::NonSseJson);
+    }
+    Some(PassthroughBodyMode::RawSse)
+}
+
+fn format_non_sse_stream_response(
+    raw: &str,
+    egress: ProtocolEndpoint,
+    ingress: ProtocolEndpoint,
+) -> Option<(String, crate::protocol::ir::AiResponse)> {
+    let value = serde_json::from_str::<Value>(raw).ok()?;
+    let ai_resp = egress
+        .handler()
+        .make_response_decoder()
+        .parse_response(value)
+        .ok()?;
+    let deltas = ai_response_to_deltas(&ai_resp);
+    let mut stream_formatter = ingress.handler().make_stream_response_encoder();
+    let mut client_sse_parts = Vec::new();
+
+    for ev in stream_formatter.format_deltas(&deltas) {
+        client_sse_parts.push(ev.to_sse_string());
+    }
+    for ev in stream_formatter.format_done() {
+        client_sse_parts.push(ev.to_sse_string());
+    }
+
+    Some((client_sse_parts.join(""), ai_resp))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::ids::GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
+
+    #[test]
+    fn non_sse_gemini_stream_response_is_formatted_as_sse() {
+        let raw = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "hello"}],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }],
+            "modelVersion": "gemini-3.5-flash",
+            "responseId": "resp-json-stream",
+            "usageMetadata": {
+                "candidatesTokenCount": 3,
+                "promptTokenCount": 5,
+                "totalTokenCount": 8
+            }
+        })
+        .to_string();
+
+        let (sse, ai_resp) = format_non_sse_stream_response(
+            &raw,
+            GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+            GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+        )
+        .expect("complete JSON stream response should format as SSE");
+
+        assert!(sse.starts_with("data: "), "SSE must use data frames: {sse}");
+        assert!(
+            sse.contains("\"usageMetadata\""),
+            "terminal SSE must include Gemini usage metadata: {sse}"
+        );
+        assert_eq!(ai_resp.content, "hello");
+        assert_eq!(ai_resp.usage.prompt_tokens, 5);
+        assert_eq!(ai_resp.usage.completion_tokens, 3);
+        assert_eq!(ai_resp.usage.total_tokens, 8);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes Gemini `streamGenerateContent` requests where upstream returns a complete JSON GenerateContent response instead of SSE.
- Converts non-SSE JSON stream responses through the existing response decoder + `ai_response_to_deltas` + stream encoder path before sending downstream SSE.
- Preserves usage accounting from `usageMetadata`, including `totalTokenCount` / `thoughtsTokenCount` cases.
- Leaves normal upstream SSE passthrough behavior unchanged.

## Validation
- `cargo test -p nyro-core proxy::dispatcher::stream::tests::non_sse_gemini_stream_response_is_formatted_as_sse -- --exact`
- `cargo test -p nyro-core protocol::codec::google::gemini::stream::tests -- --nocapture`
- `cargo check -p nyro-core`
- `cargo fmt --check`

## Notes
- Not live-tested against Gemini upstream; covered with regression tests based on the observed response shape.
