### PR TITLE
fix(proxy): native Gemini proxy auth and streaming

### DIFF
--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -149,11 +149,15 @@ where
 /// Used when [`crate::proxy::planner::ProtocolMode::Native`] is in effect
 /// (ingress == egress) and the vendor declares no request mutations via
 /// [`Vendor::declared_request_mutations`]. Only auth headers and the egress
-/// URL are computed; the client body is forwarded verbatim.
+/// URL are computed; the client body is forwarded verbatim. `is_stream` must
+/// come from the decoded ingress request, not just a raw body field: native
+/// Gemini expresses streaming in the URL action (`:streamGenerateContent`)
+/// rather than a JSON `stream` property.
 pub async fn passthrough_run(
     vendor: &dyn Vendor,
     mut raw_body: serde_json::Value,
     ctx: &crate::provider::vendor::ProviderCtx<'_>,
+    is_stream: bool,
 ) -> Result<crate::provider::outbound::OutboundRequest, GatewayError> {
     // Replace the model field with the route-configured actual model so the
     // upstream receives the real model name, not the client's virtual alias.
@@ -183,10 +187,6 @@ pub async fn passthrough_run(
         }
     }
 
-    let is_stream = raw_body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
     let egress_path = ctx
         .protocol
         .handler()
@@ -216,7 +216,8 @@ mod tests {
     use crate::db::models::Provider;
     use crate::error::GatewayError;
     use crate::protocol::ids::{
-        ANTHROPIC_MESSAGES_2023_06_01, OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolId,
+        ANTHROPIC_MESSAGES_2023_06_01, GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+        OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1, ProtocolId,
     };
     use crate::protocol::ir::{AiRequest, AiResponse};
     use crate::provider::inbound::InboundResponse;
@@ -479,6 +480,37 @@ mod tests {
         assert!(
             out.headers.get(reqwest::header::AUTHORIZATION).is_none(),
             "Authorization must be removed once x-api-key is set",
+        );
+    }
+
+    #[tokio::test]
+    async fn passthrough_native_gemini_stream_uses_stream_generate_content_path() {
+        let gw = build_test_gateway().await;
+        let provider = provider_with_api_key("gemini-key");
+        let ctx = ProviderCtx {
+            provider: &provider,
+            protocol: GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+            egress_base_url: "https://gemini-proxy.local",
+            api_key: &provider.api_key,
+            actual_model: "gemini-2.5-flash",
+            credential: None,
+            gw: &gw,
+            disable_default_auth: false,
+        };
+
+        let out = passthrough_run(
+            &FakeApiKeyVendor,
+            serde_json::json!({ "contents": [{ "parts": [{ "text": "ping" }] }] }),
+            &ctx,
+            true,
+        )
+        .await
+        .expect("passthrough succeeds");
+
+        assert_eq!(
+            out.url,
+            "https://gemini-proxy.local/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+            "Gemini stream passthrough selects streaming from the URL action, not a body stream flag",
         );
     }
 }

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -503,8 +503,13 @@ pub async fn dispatch_pipeline(
             plan.mode == ProtocolMode::Native && !adapter.declared_response_mutations();
         let mut outbound = if passthrough_req {
             let raw = envelope.body.clone().unwrap_or_default();
-            match crate::provider::common::pipeline::passthrough_run(adapter.as_ref(), raw, &ctx)
-                .await
+            match crate::provider::common::pipeline::passthrough_run(
+                adapter.as_ref(),
+                raw,
+                &ctx,
+                is_stream,
+            )
+            .await
             {
                 Ok(o) => o,
                 Err(e) => {

--- a/crates/nyro-core/src/proxy/dispatcher/util.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/util.rs
@@ -130,6 +130,8 @@ fn should_forward_client_header(name: &str) -> bool {
             | "upgrade"
             | "host"
             | "content-length"
+            | "accept-encoding"
+            | "content-encoding"
             // Client network identity / local origin metadata.
             | "forwarded"
             | "x-forwarded-for"
@@ -297,5 +299,18 @@ mod tests {
         assert!(forwarded.get("remote-host").is_none());
         assert!(forwarded.get("connection").is_none());
         assert_eq!(forwarded.get("anthropic-beta").unwrap(), "prompt-caching");
+    }
+
+    #[test]
+    fn forwarded_client_headers_drop_client_encoding_negotiation() {
+        let mut headers = HeaderMap::new();
+        headers.insert("accept-encoding", HeaderValue::from_static("gzip"));
+
+        let forwarded = forwarded_client_headers(&headers);
+
+        assert!(
+            forwarded.get("accept-encoding").is_none(),
+            "reqwest must own upstream response decompression; client encoding hints are only for the Nyro response"
+        );
     }
 }

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -1,10 +1,11 @@
 //! Thin ingress shell: POST /v1beta/models/:model_action
 
 use axum::Json;
-use axum::extract::{Path, State};
-use axum::http::HeaderMap;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, HeaderValue};
 use axum::response::Response;
 use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::Gateway;
 use crate::protocol::codec::google::gemini::decoder::GoogleDecoder;
@@ -18,6 +19,7 @@ pub async fn handler(
     mut ctx: axum::extract::Extension<RequestContext>,
     headers: HeaderMap,
     Path(model_action): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
     Json(body): Json<Value>,
 ) -> Response {
     ctx.ingress_protocol = GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA;
@@ -36,6 +38,8 @@ pub async fn handler(
         })
         .collect();
     let envelope = RawEnvelope::new(Some(body.clone()), flat_headers, "POST", &path);
+    let mut auth_headers = headers.clone();
+    inject_query_key_for_auth(&mut auth_headers, &query);
     let request = match GoogleDecoder.decode_with_model(body, &model, is_stream) {
         Ok(r) => r,
         Err(e) => {
@@ -49,10 +53,40 @@ pub async fn handler(
     };
     dispatch_pipeline(
         gw,
-        headers,
+        auth_headers,
         envelope,
         request,
         GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
     )
     .await
+}
+
+fn inject_query_key_for_auth(headers: &mut HeaderMap, query: &HashMap<String, String>) {
+    if headers.contains_key("x-goog-api-key") {
+        return;
+    }
+
+    let Some(key) = query.get("key").map(|v| v.trim()).filter(|v| !v.is_empty()) else {
+        return;
+    };
+
+    if let Ok(value) = HeaderValue::from_str(key) {
+        headers.insert("x-goog-api-key", value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::security::extract_api_key;
+
+    #[test]
+    fn query_key_is_available_for_local_auth() {
+        let mut headers = HeaderMap::new();
+        let query = HashMap::from([("key".to_string(), " sk-client ".to_string())]);
+
+        inject_query_key_for_auth(&mut headers, &query);
+
+        assert_eq!(extract_api_key(&headers).as_deref(), Some("sk-client"));
+    }
 }

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -321,10 +321,14 @@ async fn passthrough_run_preserves_vendor_specific_fields() {
         disable_default_auth: false,
     };
 
-    let out =
-        nyro_core::provider::common::pipeline::passthrough_run(&vendor, raw_body.clone(), &ctx)
-            .await
-            .expect("passthrough_run must succeed");
+    let out = nyro_core::provider::common::pipeline::passthrough_run(
+        &vendor,
+        raw_body.clone(),
+        &ctx,
+        false,
+    )
+    .await
+    .expect("passthrough_run must succeed");
 
     // Vendor-specific extension fields must survive; model is replaced with
     // actual_model (same value here, so body equality still holds).
@@ -374,9 +378,10 @@ async fn passthrough_run_rewrites_model_to_actual_model() {
         disable_default_auth: false,
     };
 
-    let out = nyro_core::provider::common::pipeline::passthrough_run(&vendor, raw_body, &ctx)
-        .await
-        .expect("passthrough_run must succeed");
+    let out =
+        nyro_core::provider::common::pipeline::passthrough_run(&vendor, raw_body, &ctx, false)
+            .await
+            .expect("passthrough_run must succeed");
 
     assert_eq!(
         out.body["model"], "glm-4-flash",
@@ -402,10 +407,14 @@ async fn passthrough_run_sets_stream_path_for_streaming_body() {
         disable_default_auth: false,
     };
 
-    let out =
-        nyro_core::provider::common::pipeline::passthrough_run(&vendor, raw_body.clone(), &ctx)
-            .await
-            .expect("passthrough_run must succeed");
+    let out = nyro_core::provider::common::pipeline::passthrough_run(
+        &vendor,
+        raw_body.clone(),
+        &ctx,
+        true,
+    )
+    .await
+    .expect("passthrough_run must succeed");
 
     assert_eq!(out.body, raw_body);
     assert!(


### PR DESCRIPTION
## Summary
- use decoded ingress stream state for native Gemini passthrough so stream requests call streamGenerateContent
- accept Gemini-style ?key=... query auth locally without forwarding client keys upstream
- drop client accept/content encoding headers before upstream calls so reqwest owns decompression

## Tests
- cargo test -p nyro-core proxy::ingress::google_generative::generate_content::tests::query_key_is_available_for_local_auth -- --nocapture
- cargo test -p nyro-core passthrough_native_gemini_stream_uses_stream_generate_content_path -- --nocapture
- cargo test -p nyro-core proxy::dispatcher::util::tests -- --nocapture
- cargo check -p nyro-core