### PR TITLE
refactor(database): rename request_logs route_id/route_name → model_id/model_name and strategy → balance

### DIFF
--- a/crates/nyro-core/src/admin/import_export.rs
+++ b/crates/nyro-core/src/admin/import_export.rs
@@ -140,7 +140,7 @@ impl AdminService {
                     .create_model(CreateModel {
                         name: m.name.clone(),
                         virtual_model: m.virtual_model.clone(),
-                        strategy: Some("weighted".to_string()),
+                        balance: Some("weighted".to_string()),
                         target_provider: pid,
                         target_model: m.target_model.clone(),
                         targets: vec![],

--- a/crates/nyro-core/src/admin/model_data.rs
+++ b/crates/nyro-core/src/admin/model_data.rs
@@ -7,11 +7,11 @@ pub(super) fn ensure_virtual_model(model: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(super) fn normalize_model_strategy(strategy: Option<&str>) -> anyhow::Result<String> {
-    let normalized = strategy.unwrap_or("weighted").trim().to_ascii_lowercase();
+pub(super) fn normalize_model_balance(balance: Option<&str>) -> anyhow::Result<String> {
+    let normalized = balance.unwrap_or("weighted").trim().to_ascii_lowercase();
     match normalized.as_str() {
         "weighted" | "priority" => Ok(normalized),
-        _ => anyhow::bail!("unsupported model strategy: {normalized}"),
+        _ => anyhow::bail!("unsupported model balance: {normalized}"),
     }
 }
 

--- a/crates/nyro-core/src/admin/models.rs
+++ b/crates/nyro-core/src/admin/models.rs
@@ -18,7 +18,7 @@ impl AdminService {
         self.ensure_model_name_unique(None, &name).await?;
         ensure_virtual_model(&input.virtual_model)?;
         self.ensure_model_unique(None, &input.virtual_model).await?;
-        let strategy = normalize_model_strategy(input.strategy.as_deref())?;
+        let balance = normalize_model_balance(input.balance.as_deref())?;
         let backends = normalize_create_model_backends(&input)?;
         ensure_model_backends_valid(&backends)?;
         let primary_backend = backends
@@ -32,7 +32,7 @@ impl AdminService {
             .create(CreateModel {
                 name,
                 virtual_model: input.virtual_model,
-                strategy: Some(strategy),
+                balance: Some(balance),
                 target_provider: primary_backend.provider_id.clone(),
                 target_model: primary_backend.model.clone(),
                 targets: vec![],
@@ -58,8 +58,7 @@ impl AdminService {
             .virtual_model
             .clone()
             .unwrap_or_else(|| current.virtual_model.clone());
-        let strategy =
-            normalize_model_strategy(input.strategy.as_deref().or(Some(&current.strategy)))?;
+        let balance = normalize_model_balance(input.balance.as_deref().or(Some(&current.balance)))?;
         let backends = normalize_update_model_backends(&current, &input)?;
         ensure_model_backends_valid(&backends)?;
         let primary_backend = backends
@@ -78,7 +77,7 @@ impl AdminService {
                 UpdateModel {
                     name: Some(name),
                     virtual_model: Some(virtual_model),
-                    strategy: Some(strategy),
+                    balance: Some(balance),
                     target_provider: Some(primary_backend.provider_id.clone()),
                     target_model: Some(primary_backend.model.clone()),
                     targets: None,

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -39,7 +39,7 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     ensure_provider_column(pool, "use_proxy", "INTEGER DEFAULT 0").await?;
     migrate_collapse_provider_protocol_columns(pool).await?;
     ensure_route_column(pool, "virtual_model", "TEXT").await?;
-    ensure_route_column(pool, "strategy", "TEXT DEFAULT 'weighted'").await?;
+    ensure_route_column(pool, "balance", "TEXT DEFAULT 'weighted'").await?;
     ensure_route_column(pool, "access_control", "INTEGER DEFAULT 0").await?;
     ensure_request_log_column(pool, "api_key_id", "TEXT").await?;
     ensure_request_log_column(pool, "method", "TEXT").await?;
@@ -77,8 +77,8 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     ensure_request_log_column(pool, "is_stream", "INTEGER DEFAULT 0").await?;
     ensure_request_log_column(pool, "api_key_name", "TEXT").await?;
     ensure_request_log_column(pool, "provider_name", "TEXT").await?;
-    ensure_request_log_column(pool, "route_id", "TEXT").await?;
-    ensure_request_log_column(pool, "route_name", "TEXT").await?;
+    ensure_request_log_column(pool, "model_id", "TEXT").await?;
+    ensure_request_log_column(pool, "model_name", "TEXT").await?;
     ensure_request_log_column(pool, "cache_read_tokens", "INTEGER DEFAULT 0").await?;
 
     // Rename tables: routes → models, route_targets → model_backends, api_key_routes → api_key_models
@@ -89,6 +89,13 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     // Rename columns within renamed tables
     rename_column_if_needed(pool, "model_backends", "route_id", "model_id").await?;
     rename_column_if_needed(pool, "api_key_models", "route_id", "model_id").await?;
+
+    // Rename columns: request_logs route_id/route_name → model_id/model_name
+    rename_column_if_needed(pool, "request_logs", "route_id", "model_id").await?;
+    rename_column_if_needed(pool, "request_logs", "route_name", "model_name").await?;
+
+    // Rename column: models strategy → balance
+    rename_column_if_needed(pool, "models", "strategy", "balance").await?;
 
     Ok(())
 }
@@ -565,7 +572,13 @@ async fn migrate_api_key_status_to_is_enabled(pool: &SqlitePool) -> anyhow::Resu
 }
 
 async fn backfill_route_fields(pool: &SqlitePool) -> anyhow::Result<()> {
-    if column_exists(pool, "routes", "strategy").await? {
+    if column_exists(pool, "models", "balance").await? {
+        sqlx::query(
+            "UPDATE models SET balance = 'weighted' WHERE balance IS NULL OR trim(balance) = ''",
+        )
+        .execute(pool)
+        .await?;
+    } else if column_exists(pool, "routes", "strategy").await? {
         sqlx::query(
             "UPDATE routes SET strategy = 'weighted' WHERE strategy IS NULL OR trim(strategy) = ''",
         )
@@ -721,7 +734,7 @@ CREATE TABLE IF NOT EXISTS routes (
     id                TEXT PRIMARY KEY,
     name              TEXT NOT NULL,
     virtual_model     TEXT,
-    strategy          TEXT DEFAULT 'weighted',
+    balance           TEXT DEFAULT 'weighted',
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,
     access_control    INTEGER DEFAULT 0,
@@ -751,8 +764,8 @@ CREATE TABLE IF NOT EXISTS request_logs (
     upstream_protocol         TEXT,
     provider_id               TEXT,
     provider_name             TEXT,
-    route_id                  TEXT,
-    route_name                TEXT,
+    model_id                  TEXT,
+    model_name                TEXT,
     upstream_url              TEXT,
     client_model              TEXT,
     upstream_model            TEXT,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -111,7 +111,7 @@ pub struct Model {
     pub name: String,
     #[serde(alias = "vmodel")]
     pub virtual_model: String,
-    pub strategy: String,
+    pub balance: String,
     pub target_provider: String,
     pub target_model: String,
     pub access_control: bool,
@@ -136,7 +136,7 @@ pub struct ModelBackend {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
-pub enum ModelStrategy {
+pub enum ModelBalance {
     /// Weighted reservoir sampling — targets with higher weight are preferred.
     #[default]
     Weighted,
@@ -148,7 +148,7 @@ pub enum ModelStrategy {
     Latency,
 }
 
-impl ModelStrategy {
+impl ModelBalance {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Weighted => "weighted",
@@ -159,7 +159,7 @@ impl ModelStrategy {
     }
 }
 
-impl std::str::FromStr for ModelStrategy {
+impl std::str::FromStr for ModelBalance {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -168,7 +168,7 @@ impl std::str::FromStr for ModelStrategy {
             "priority" => Ok(Self::Priority),
             "cooldown" => Ok(Self::Cooldown),
             "latency" => Ok(Self::Latency),
-            other => anyhow::bail!("unsupported model strategy: {other}"),
+            other => anyhow::bail!("unsupported model balance: {other}"),
         }
     }
 }
@@ -217,8 +217,10 @@ pub struct RequestLog {
     pub upstream_protocol: Option<String>,
     pub provider_id: Option<String>,
     pub provider_name: Option<String>,
-    pub route_id: Option<String>,
-    pub route_name: Option<String>,
+    #[serde(alias = "route_id")]
+    pub model_id: Option<String>,
+    #[serde(alias = "route_name")]
+    pub model_name: Option<String>,
     pub upstream_url: Option<String>,
     pub client_model: Option<String>,
     pub upstream_model: Option<String>,
@@ -299,7 +301,8 @@ pub struct UpdateModel {
     pub name: Option<String>,
     #[serde(alias = "vmodel")]
     pub virtual_model: Option<String>,
-    pub strategy: Option<String>,
+    #[serde(rename = "balance", alias = "strategy")]
+    pub balance: Option<String>,
     pub target_provider: Option<String>,
     pub target_model: Option<String>,
     #[serde(default)]
@@ -313,7 +316,8 @@ pub struct CreateModel {
     pub name: String,
     #[serde(alias = "vmodel")]
     pub virtual_model: String,
-    pub strategy: Option<String>,
+    #[serde(rename = "balance", alias = "strategy")]
+    pub balance: Option<String>,
     pub target_provider: String,
     pub target_model: String,
     #[serde(default)]

--- a/crates/nyro-core/src/integrations/hooks.rs
+++ b/crates/nyro-core/src/integrations/hooks.rs
@@ -13,8 +13,8 @@ use crate::protocol::ir::{AiRequest, AiResponse};
 /// hooks can be `'static` without lifetime constraints.
 #[derive(Debug, Clone)]
 pub struct HookContext {
-    /// Matched route ID (from the route database row).
-    pub route_id: String,
+    /// Matched model ID (from the model database row).
+    pub model_id: String,
     /// Upstream provider name (empty for `RequestHook` — provider not yet selected).
     pub provider_name: String,
     /// The model name as seen by the client (may differ from upstream model).

--- a/crates/nyro-core/src/logging/mod.rs
+++ b/crates/nyro-core/src/logging/mod.rs
@@ -16,13 +16,13 @@ pub struct LogEntry {
     /// Unix 毫秒时间戳
     pub created_at: i64,
 
-    // === 路由 ===
+    // === 模型 ===
     pub client_protocol: String,
     pub upstream_protocol: String,
     pub provider_id: String,
     pub provider_name: String,
-    pub route_id: Option<String>,
-    pub route_name: Option<String>,
+    pub model_id: Option<String>,
+    pub model_name: Option<String>,
     pub upstream_url: Option<String>,
     pub client_model: String,
     pub upstream_model: String,

--- a/crates/nyro-core/src/proxy/context.rs
+++ b/crates/nyro-core/src/proxy/context.rs
@@ -207,8 +207,8 @@ pub struct RequestContext {
     pub cancellation: CancellationToken,
     /// The protocol the client spoke on the ingress side.
     pub ingress_protocol: ProtocolId,
-    /// Matched route ID (after `security` layer).
-    pub route_id: Option<String>,
+    /// Matched model ID (after `security` layer).
+    pub model_id: Option<String>,
     /// Resolved provider ID (after `planner` layer).
     pub provider_id: Option<String>,
     /// Selected target ID (after `planner` layer).
@@ -232,7 +232,7 @@ impl RequestContext {
             deadline: Deadline::from_now(timeout),
             cancellation: CancellationToken::new(),
             ingress_protocol,
-            route_id: None,
+            model_id: None,
             provider_id: None,
             target_id: None,
             egress_protocol: None,

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -137,7 +137,7 @@ pub async fn dispatch_pipeline(
     let hook_registry = crate::integrations::HookRegistry::global();
     if hook_registry.has_request_hooks() {
         let hook_ctx = crate::integrations::HookContext {
-            route_id: route.id.clone(),
+            model_id: route.id.clone(),
             provider_name: String::new(),
             model: request.model.clone(),
             api_key_id: auth_key.id.clone(),
@@ -178,7 +178,7 @@ pub async fn dispatch_pipeline(
         .emit();
         return error_response(503, "no route targets configured");
     }
-    let ordered_targets = TargetSelector::select_ordered(&route.strategy, &targets);
+    let ordered_targets = TargetSelector::select_ordered(&route.balance, &targets);
     if ordered_targets.is_empty() {
         LogBuilder::from_dispatch(
             &gw,
@@ -348,8 +348,8 @@ pub async fn dispatch_pipeline(
         let call_ctx = CallCtx {
             gw: gw.clone(),
             provider: &provider,
-            route_id: &route.id,
-            route_name: &route.name,
+            model_id: &route.id,
+            model_name: &route.name,
             egress,
             ingress,
             ingress_str: &ingress_str,
@@ -400,8 +400,8 @@ pub async fn dispatch_pipeline(
         if status < 400 {
             gw.health_registry.record_success(&target_key);
             let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-            TargetSelector::record_selected(&route.strategy, &target_key);
-            TargetSelector::record_latency(&route.strategy, &target_key, elapsed_ms);
+            TargetSelector::record_selected(&route.balance, &target_key);
+            TargetSelector::record_latency(&route.balance, &target_key, elapsed_ms);
             return response;
         }
         gw.health_registry.record_failure(&target_key);
@@ -466,8 +466,8 @@ pub async fn dispatch(
 struct CallCtx<'a> {
     gw: Gateway,
     provider: &'a Provider,
-    route_id: &'a str,
-    route_name: &'a str,
+    model_id: &'a str,
+    model_name: &'a str,
     egress: ProtocolId,
     ingress: ProtocolId,
     ingress_str: &'a str,
@@ -510,8 +510,8 @@ struct LogBuilder {
     api_key_name: Option<String>,
     provider_id: String,
     provider_name: String,
-    route_id: Option<String>,
-    route_name: Option<String>,
+    model_id: Option<String>,
+    model_name: Option<String>,
     is_stream: bool,
     start: Instant,
     client_status_code: i32,
@@ -532,8 +532,8 @@ impl LogBuilder {
             api_key_name: call_ctx.api_key_name.map(ToString::to_string),
             provider_id: call_ctx.provider.id.clone(),
             provider_name: call_ctx.provider.name.clone(),
-            route_id: Some(call_ctx.route_id.to_string()),
-            route_name: Some(call_ctx.route_name.to_string()),
+            model_id: Some(call_ctx.model_id.to_string()),
+            model_name: Some(call_ctx.model_name.to_string()),
             is_stream: call_ctx.is_stream,
             start: call_ctx.start,
             client_status_code: 200,
@@ -562,8 +562,8 @@ impl LogBuilder {
             api_key_name: None,
             provider_id: String::new(),
             provider_name: String::new(),
-            route_id: None,
-            route_name: None,
+            model_id: None,
+            model_name: None,
             is_stream: false,
             start,
             client_status_code: 200,
@@ -685,8 +685,8 @@ impl LogBuilder {
             upstream_protocol: self.upstream_protocol,
             provider_id: self.provider_id,
             provider_name: self.provider_name,
-            route_id: self.route_id,
-            route_name: self.route_name,
+            model_id: self.model_id,
+            model_name: self.model_name,
             upstream_url: self.extras.upstream_url,
             client_model: self.client_model,
             upstream_model: self.upstream_model,

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -190,7 +190,7 @@ pub(super) async fn handle_non_stream(
     if hook_registry.has_response_hooks() {
         let latency_ms = call_ctx.start.elapsed().as_millis() as u64;
         let hook_ctx = HookContext {
-            route_id: call_ctx.route_id.to_string(),
+            model_id: call_ctx.model_id.to_string(),
             provider_name: call_ctx.provider.name.clone(),
             model: ai_resp.model.clone(),
             api_key_id: call_ctx.api_key_id.map(str::to_string),
@@ -341,8 +341,8 @@ mod tests {
         let call_ctx = CallCtx {
             gw: gw.clone(),
             provider: &provider,
-            route_id: "route-google",
-            route_name: "Google route",
+            model_id: "route-google",
+            model_name: "Google route",
             egress: GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
             ingress: OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
             ingress_str: "openai/chat/v1",

--- a/crates/nyro-core/src/router/selector.rs
+++ b/crates/nyro-core/src/router/selector.rs
@@ -17,10 +17,10 @@
 //!
 //! ```rust,ignore
 //! // Dispatcher
-//! let ordered = TargetSelector::select_ordered(&route.strategy, &targets);
+//! let ordered = TargetSelector::select_ordered(&route.balance, &targets);
 //! // After a successful call (for stateful strategies):
-//! TargetSelector::record_selected(&route.strategy, &target_key);
-//! TargetSelector::record_latency(&route.strategy, &target_key, elapsed_ms);
+//! TargetSelector::record_selected(&route.balance, &target_key);
+//! TargetSelector::record_latency(&route.balance, &target_key, elapsed_ms);
 //! ```
 
 use std::collections::{BTreeMap, HashMap};
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 
 use rand::Rng;
 
-use crate::db::models::{ModelBackend, ModelStrategy};
+use crate::db::models::{ModelBackend, ModelBalance};
 
 // ── SelectedTarget ────────────────────────────────────────────────────────────
 
@@ -176,29 +176,29 @@ impl RoutingStrategy for LatencyStrategy {
 pub struct TargetSelector;
 
 impl TargetSelector {
-    /// Return targets ordered by the named strategy. Unrecognised strategy
+    /// Return targets ordered by the named balance. Unrecognised balance
     /// strings fall back to `weighted`.
-    pub fn select_ordered(strategy: &str, targets: &[ModelBackend]) -> Vec<SelectedTarget> {
-        match ModelStrategy::from_str(strategy).unwrap_or_default() {
-            ModelStrategy::Weighted => WeightedStrategy.select_ordered(targets),
-            ModelStrategy::Priority => PriorityStrategy.select_ordered(targets),
-            ModelStrategy::Cooldown => CooldownStrategy::global().select_ordered(targets),
-            ModelStrategy::Latency => LatencyStrategy::global().select_ordered(targets),
+    pub fn select_ordered(balance: &str, targets: &[ModelBackend]) -> Vec<SelectedTarget> {
+        match ModelBalance::from_str(balance).unwrap_or_default() {
+            ModelBalance::Weighted => WeightedStrategy.select_ordered(targets),
+            ModelBalance::Priority => PriorityStrategy.select_ordered(targets),
+            ModelBalance::Cooldown => CooldownStrategy::global().select_ordered(targets),
+            ModelBalance::Latency => LatencyStrategy::global().select_ordered(targets),
         }
     }
 
     /// Record that `target_key` was successfully selected.
-    /// Only meaningful for the `cooldown` strategy; a no-op for others.
-    pub fn record_selected(strategy: &str, target_key: &str) {
-        if ModelStrategy::from_str(strategy).unwrap_or_default() == ModelStrategy::Cooldown {
+    /// Only meaningful for the `cooldown` balance; a no-op for others.
+    pub fn record_selected(balance: &str, target_key: &str) {
+        if ModelBalance::from_str(balance).unwrap_or_default() == ModelBalance::Cooldown {
             CooldownStrategy::global().record_selected(target_key);
         }
     }
 
     /// Record observed response latency for `target_key`.
-    /// Only meaningful for the `latency` strategy; a no-op for others.
-    pub fn record_latency(strategy: &str, target_key: &str, latency_ms: f64) {
-        if ModelStrategy::from_str(strategy).unwrap_or_default() == ModelStrategy::Latency {
+    /// Only meaningful for the `latency` balance; a no-op for others.
+    pub fn record_latency(balance: &str, target_key: &str, latency_ms: f64) {
+        if ModelBalance::from_str(balance).unwrap_or_default() == ModelBalance::Latency {
             LatencyStrategy::global().record_latency(target_key, latency_ms);
         }
     }

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -471,12 +471,12 @@ impl ModelStore for PostgresModelStore {
         let id = uuid::Uuid::new_v4().to_string();
         let virtual_model = input.virtual_model.trim().to_string();
         sqlx::query(
-            "INSERT INTO models (id, name, virtual_model, strategy, target_provider, target_model, access_control) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO models (id, name, virtual_model, balance, target_provider, target_model, access_control) VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(&id)
         .bind(input.name.trim())
         .bind(&virtual_model)
-        .bind(input.strategy.unwrap_or_else(|| "weighted".to_string()))
+        .bind(input.balance.unwrap_or_else(|| "weighted".to_string()))
         .bind(input.target_provider.trim())
         .bind(input.target_model.trim())
         .bind(input.access_control.unwrap_or(false))
@@ -493,18 +493,18 @@ impl ModelStore for PostgresModelStore {
             .unwrap_or(current.virtual_model)
             .trim()
             .to_string();
-        let strategy = input.strategy.unwrap_or(current.strategy);
+        let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
         let access_control = input.access_control.unwrap_or(current.access_control);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE models SET name=$1, virtual_model=$2, strategy=$3, target_provider=$4, target_model=$5, access_control=$6, is_enabled=$7 WHERE id=$8",
+            "UPDATE models SET name=$1, virtual_model=$2, balance=$3, target_provider=$4, target_model=$5, access_control=$6, is_enabled=$7 WHERE id=$8",
         )
         .bind(name.trim())
         .bind(&virtual_model)
-        .bind(strategy.trim().to_lowercase())
+        .bind(balance.trim().to_lowercase())
         .bind(target_provider.trim())
         .bind(target_model.trim())
         .bind(access_control)
@@ -886,7 +886,7 @@ impl LogStore for PostgresLogStore {
             sqlx::query(
                 r#"INSERT INTO request_logs
                     (id, created_at, api_key_id, api_key_name,
-                     client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url,
+                     client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url,
                      client_model, upstream_model,
                      method, path,
                      client_request_headers, client_request_body,
@@ -907,8 +907,8 @@ impl LogStore for PostgresLogStore {
             .bind(&entry.upstream_protocol)
             .bind(&entry.provider_id)
             .bind(&entry.provider_name)
-            .bind(&entry.route_id)
-            .bind(&entry.route_name)
+            .bind(&entry.model_id)
+            .bind(&entry.model_name)
             .bind(&entry.upstream_url)
             .bind(&entry.client_model)
             .bind(&entry.upstream_model)
@@ -943,7 +943,7 @@ impl LogStore for PostgresLogStore {
         // List query skips heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
             "SELECT id, COALESCE(created_at::BIGINT, 0) AS created_at, api_key_id, api_key_name, \
-             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url, \
              client_model, upstream_model, method, path, \
              NULL::text AS client_request_headers, NULL::text AS client_request_body, \
              NULL::text AS client_response_headers, NULL::text AS client_response_body, \
@@ -1007,7 +1007,7 @@ impl LogStore for PostgresLogStore {
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
         let row = sqlx::query_as::<_, RequestLog>(
             "SELECT id, COALESCE(created_at::BIGINT, 0) AS created_at, api_key_id, api_key_name, \
-             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url, \
              client_model, upstream_model, method, path, \
              client_request_headers, client_request_body, \
              client_response_headers, client_response_body, \
@@ -1098,12 +1098,14 @@ impl StorageBootstrap for PostgresBootstrap {
         sqlx::raw_sql(POSTGRES_INIT_SQL)
             .execute(self.adapter.pool())
             .await?;
-        sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS strategy TEXT DEFAULT 'weighted'")
+        sqlx::query("ALTER TABLE routes ADD COLUMN IF NOT EXISTS balance TEXT DEFAULT 'weighted'")
             .execute(self.adapter.pool())
             .await?;
-        sqlx::query("UPDATE routes SET strategy = 'weighted' WHERE strategy IS NULL OR btrim(strategy) = ''")
-            .execute(self.adapter.pool())
-            .await?;
+        sqlx::query(
+            "UPDATE routes SET balance = 'weighted' WHERE balance IS NULL OR btrim(balance) = ''",
+        )
+        .execute(self.adapter.pool())
+        .await?;
         sqlx::query("ALTER TABLE providers ADD COLUMN IF NOT EXISTS use_proxy BOOLEAN NOT NULL DEFAULT FALSE")
             .execute(self.adapter.pool())
             .await?;
@@ -1248,6 +1250,20 @@ END $$;"#,
             "model_id",
         )
         .await?;
+
+        // Rename columns in request_logs: route_id → model_id, route_name → model_name
+        pg_rename_column_if_needed(self.adapter.pool(), "request_logs", "route_id", "model_id")
+            .await?;
+        pg_rename_column_if_needed(
+            self.adapter.pool(),
+            "request_logs",
+            "route_name",
+            "model_name",
+        )
+        .await?;
+
+        // Rename column: models strategy → balance
+        pg_rename_column_if_needed(self.adapter.pool(), "models", "strategy", "balance").await?;
 
         Ok(())
     }
@@ -1484,7 +1500,7 @@ fn provider_select(suffix: Option<&str>) -> String {
 
 fn model_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
+        "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1603,7 +1619,7 @@ CREATE TABLE IF NOT EXISTS routes (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     virtual_model TEXT,
-    strategy TEXT DEFAULT 'weighted',
+    balance TEXT DEFAULT 'weighted',
     target_provider TEXT NOT NULL REFERENCES providers(id),
     target_model TEXT NOT NULL,
     access_control BOOLEAN DEFAULT FALSE,
@@ -1633,8 +1649,8 @@ CREATE TABLE IF NOT EXISTS request_logs (
     upstream_protocol         TEXT,
     provider_id               TEXT,
     provider_name             TEXT,
-    route_id                  TEXT,
-    route_name                TEXT,
+    model_id                  TEXT,
+    model_name                TEXT,
     upstream_url              TEXT,
     client_model              TEXT,
     upstream_model            TEXT,

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -486,7 +486,7 @@ impl SqliteModelStore {
 impl ModelStore for SqliteModelStore {
     async fn list(&self) -> anyhow::Result<Vec<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
+            "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -494,7 +494,7 @@ impl ModelStore for SqliteModelStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, virtual_model, COALESCE(strategy, 'weighted') AS strategy, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
+            "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -504,16 +504,16 @@ impl ModelStore for SqliteModelStore {
     async fn create(&self, input: CreateModel) -> anyhow::Result<Model> {
         let id = uuid::Uuid::new_v4().to_string();
         let virtual_model = input.virtual_model.trim().to_string();
-        let strategy = input.strategy.unwrap_or_else(|| "weighted".to_string());
+        let balance = input.balance.unwrap_or_else(|| "weighted".to_string());
         if self.has_match_pattern_column().await? {
             sqlx::query(
-                "INSERT INTO models (id, name, virtual_model, match_pattern, strategy, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO models (id, name, virtual_model, match_pattern, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(input.name.trim())
             .bind(&virtual_model)
             .bind(&virtual_model)
-            .bind(strategy)
+            .bind(balance)
             .bind(input.target_provider.trim())
             .bind(input.target_model.trim())
             .bind(input.access_control.unwrap_or(false))
@@ -521,12 +521,12 @@ impl ModelStore for SqliteModelStore {
             .await?;
         } else {
             sqlx::query(
-                "INSERT INTO models (id, name, virtual_model, strategy, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO models (id, name, virtual_model, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&id)
             .bind(input.name.trim())
             .bind(&virtual_model)
-            .bind(strategy)
+            .bind(balance)
             .bind(input.target_provider.trim())
             .bind(input.target_model.trim())
             .bind(input.access_control.unwrap_or(false))
@@ -544,7 +544,7 @@ impl ModelStore for SqliteModelStore {
             .unwrap_or(current.virtual_model)
             .trim()
             .to_string();
-        let strategy = input.strategy.unwrap_or(current.strategy);
+        let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
         let access_control = input.access_control.unwrap_or(current.access_control);
@@ -552,12 +552,12 @@ impl ModelStore for SqliteModelStore {
 
         if self.has_match_pattern_column().await? {
             sqlx::query(
-                "UPDATE models SET name=?, virtual_model=?, match_pattern=?, strategy=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
+                "UPDATE models SET name=?, virtual_model=?, match_pattern=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
             .bind(&virtual_model)
-            .bind(strategy.trim().to_lowercase())
+            .bind(balance.trim().to_lowercase())
             .bind(target_provider.trim())
             .bind(target_model.trim())
             .bind(access_control)
@@ -567,11 +567,11 @@ impl ModelStore for SqliteModelStore {
             .await?;
         } else {
             sqlx::query(
-                "UPDATE models SET name=?, virtual_model=?, strategy=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
+                "UPDATE models SET name=?, virtual_model=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
             )
             .bind(name.trim())
             .bind(&virtual_model)
-            .bind(strategy.trim().to_lowercase())
+            .bind(balance.trim().to_lowercase())
             .bind(target_provider.trim())
             .bind(target_model.trim())
             .bind(access_control)
@@ -651,7 +651,7 @@ impl ModelSnapshotStore for SqliteModelStore {
             r#"SELECT
                 id, name,
                 virtual_model,
-                COALESCE(strategy, 'weighted') AS strategy,
+                COALESCE(balance, 'weighted') AS balance,
                 target_provider, target_model,
                 COALESCE(access_control, 0) AS access_control,
                 COALESCE(is_enabled, 1) AS is_enabled,
@@ -1046,7 +1046,7 @@ impl LogStore for SqliteLogStore {
             sqlx::query(
                 r#"INSERT INTO request_logs
                     (id, created_at, api_key_id, api_key_name,
-                     client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url,
+                     client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url,
                      client_model, upstream_model,
                      method, path,
                      client_request_headers, client_request_body,
@@ -1067,8 +1067,8 @@ impl LogStore for SqliteLogStore {
             .bind(&entry.upstream_protocol)
             .bind(&entry.provider_id)
             .bind(&entry.provider_name)
-            .bind(&entry.route_id)
-            .bind(&entry.route_name)
+            .bind(&entry.model_id)
+            .bind(&entry.model_name)
             .bind(&entry.upstream_url)
             .bind(&entry.client_model)
             .bind(&entry.upstream_model)
@@ -1103,7 +1103,7 @@ impl LogStore for SqliteLogStore {
         // List query skips the heavy body/header columns (NULL placeholders preserve struct layout).
         let mut data_sql = String::from(
             "SELECT id, COALESCE(CAST(created_at AS INTEGER), 0) AS created_at, api_key_id, api_key_name, \
-             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url, \
              client_model, upstream_model, method, path, \
              NULL AS client_request_headers, NULL AS client_request_body, \
              NULL AS client_response_headers, NULL AS client_response_body, \
@@ -1156,7 +1156,7 @@ impl LogStore for SqliteLogStore {
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
         let row = sqlx::query_as::<_, RequestLog>(
             "SELECT id, COALESCE(CAST(created_at AS INTEGER), 0) AS created_at, api_key_id, api_key_name, \
-             client_protocol, upstream_protocol, provider_id, provider_name, route_id, route_name, upstream_url, \
+             client_protocol, upstream_protocol, provider_id, provider_name, model_id, model_name, upstream_url, \
              client_model, upstream_model, method, path, \
              client_request_headers, client_request_body, \
              client_response_headers, client_response_body, \

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -71,7 +71,7 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
         .create_model(CreateModel {
             name: "source-route".to_string(),
             virtual_model: "source-model".to_string(),
-            strategy: Some("priority".to_string()),
+            balance: Some("priority".to_string()),
             target_provider: String::new(),
             target_model: String::new(),
             targets: vec![
@@ -122,7 +122,7 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
         .expect("source route should remain");
     assert_eq!(updated_model.name, "source-route");
     assert_eq!(updated_model.virtual_model, "source-model");
-    assert_eq!(updated_model.strategy, "priority");
+    assert_eq!(updated_model.balance, "priority");
     assert!(updated_model.access_control);
     assert_eq!(updated_model.target_provider, original.id);
     assert_eq!(updated_model.target_model, "source-upstream-model");
@@ -161,7 +161,7 @@ async fn copy_provider_does_not_append_targets_by_default() -> anyhow::Result<()
         .create_model(CreateModel {
             name: "no-route-copy-source".to_string(),
             virtual_model: "no-route-copy-model".to_string(),
-            strategy: None,
+            balance: None,
             target_provider: original.id.clone(),
             target_model: "source-upstream-model".to_string(),
             targets: vec![],
@@ -196,7 +196,7 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
         .create_model(CreateModel {
             name: "route-owned-by-deleted-provider".to_string(),
             virtual_model: "route-owned-model".to_string(),
-            strategy: None,
+            balance: None,
             target_provider: removed_provider.id.clone(),
             target_model: "gpt-delete".to_string(),
             targets: vec![],
@@ -208,7 +208,7 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
         .create_model(CreateModel {
             name: "route-with-secondary-deleted-provider".to_string(),
             virtual_model: "route-kept-model".to_string(),
-            strategy: None,
+            balance: None,
             target_provider: kept_provider.id.clone(),
             target_model: "gpt-keep".to_string(),
             targets: vec![

--- a/crates/nyro-core/tests/logging_spec.rs
+++ b/crates/nyro-core/tests/logging_spec.rs
@@ -118,8 +118,8 @@ fn log_entry_timestamp_is_unix_millis() {
         upstream_protocol: "openai/chat/v1".into(),
         provider_id: "test-provider".into(),
         provider_name: "Test Provider".into(),
-        route_id: None,
-        route_name: None,
+        model_id: None,
+        model_name: None,
         upstream_url: None,
         client_model: "gpt-4".into(),
         upstream_model: "gpt-4".into(),
@@ -159,8 +159,8 @@ fn stream_indicator_via_chunks_count() {
         upstream_protocol: String::new(),
         provider_id: String::new(),
         provider_name: String::new(),
-        route_id: None,
-        route_name: None,
+        model_id: None,
+        model_name: None,
         upstream_url: None,
         client_model: String::new(),
         upstream_model: String::new(),
@@ -216,8 +216,8 @@ fn db_schema_sql_contains_new_columns() {
         "api_key_name",
         "provider_id",
         "provider_name",
-        "route_id",
-        "route_name",
+        "model_id",
+        "model_name",
         "client_protocol",
         "upstream_protocol",
         "upstream_url",
@@ -259,8 +259,8 @@ fn db_schema_sql_contains_new_columns() {
         let _: &Option<String> = &r.api_key_name;
         let _: &Option<String> = &r.provider_id;
         let _: &Option<String> = &r.provider_name;
-        let _: &Option<String> = &r.route_id;
-        let _: &Option<String> = &r.route_name;
+        let _: &Option<String> = &r.model_id;
+        let _: &Option<String> = &r.model_name;
         let _: &Option<String> = &r.client_protocol;
         let _: &Option<String> = &r.upstream_protocol;
         let _: &Option<String> = &r.upstream_url;

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -1,0 +1,224 @@
+# Database Schema
+
+Nyro supports two storage backends — **SQLite** (default) and **PostgreSQL** — with identical table structures.
+
+## Entity Relationship
+
+```
+providers ──1:N── model_backends ──N:1── models
+    │                                    │
+    └──1:1── provider_oauth_credentials  └──M:N── api_keys (via api_key_models)
+
+api_keys ──M:N── models (via api_key_models)
+request_logs (append-only)
+settings (key-value)
+```
+
+---
+
+## providers
+
+AI 模型供应商配置（API endpoint、密钥、认证方式等）。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | TEXT PK | — | 主键，UUID |
+| `name` | TEXT NOT NULL | — | 显示名称 |
+| `vendor` | TEXT | NULL | 供应商标识（如 `openai`、`anthropic`） |
+| `protocol` | TEXT NOT NULL | — | 默认通信协议（如 `openai-compatible`） |
+| `base_url` | TEXT NOT NULL | — | API 端点基础 URL |
+| `preset_key` | TEXT | NULL | 预设模板 key（内置供应商模板标识） |
+| `channel` | TEXT | NULL | 预设通道 ID（如 `default`、`azure`） |
+| `models_source` | TEXT | NULL | 模型列表获取方式 |
+| `static_models` | TEXT | NULL | 静态模型列表（`\n` 分隔） |
+| `api_key` | TEXT NOT NULL | — | API 密钥 |
+| `auth_mode` | TEXT | `'apikey'` | 认证方式：`apikey` 或 `oauth` |
+| `access_token` | TEXT | NULL | OAuth access token（迁移至 oauth 表后弃用） |
+| `refresh_token` | TEXT | NULL | OAuth refresh token（迁移至 oauth 表后弃用） |
+| `expires_at` | TEXT | NULL | OAuth token 过期时间（迁移至 oauth 表后弃用） |
+| `use_proxy` | INTEGER | `0` | 是否通过代理发送请求 |
+| `last_test_success` | INTEGER | NULL | 最近一次连通性测试是否成功 |
+| `last_test_at` | TEXT | NULL | 最近一次连通性测试时间 |
+| `is_enabled` | INTEGER | `1` | 是否启用 |
+| `priority` | INTEGER | `0` | 优先级（预留） |
+| `created_at` | TEXT | `datetime('now')` | 创建时间 |
+| `updated_at` | TEXT | `datetime('now')` | 更新时间 |
+
+---
+
+## models
+
+虚拟模型配置，定义客户端请求的模型名如何映射到后端。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | TEXT PK | — | 主键，UUID |
+| `name` | TEXT NOT NULL | — | 显示名称 |
+| `virtual_model` | TEXT | NULL | 客户端请求中使用的模型名（匹配键） |
+| `balance` | TEXT | `'weighted'` | 多后端负载均衡策略：`weighted`、`priority`、`cooldown`、`latency` |
+| `target_provider` | TEXT NOT NULL | — | 默认后端 provider ID（FK → providers.id） |
+| `target_model` | TEXT NOT NULL | — | 默认后端使用的上游模型名 |
+| `access_control` | INTEGER | `0` | 是否启用 API Key 访问控制 |
+| `is_enabled` | INTEGER | `1` | 是否启用 |
+| `priority` | INTEGER | `0` | 优先级（预留） |
+| `created_at` | TEXT | `datetime('now')` | 创建时间 |
+
+---
+
+## model_backends
+
+模型后端列表，一个 model 可对应多个 provider + 上游模型的组合。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | TEXT PK | — | 主键，UUID |
+| `model_id` | TEXT NOT NULL | — | 所属模型 ID（FK → models.id, ON DELETE CASCADE） |
+| `provider_id` | TEXT NOT NULL | — | 供应商 ID（FK → providers.id） |
+| `model` | TEXT NOT NULL | — | 上游模型名（发送给 provider 的模型标识） |
+| `weight` | INTEGER | `100` | 权重（`weighted` 策略下生效） |
+| `priority` | INTEGER | `1` | 优先级，数值越小越优先（`priority` 策略下生效） |
+| `created_at` | TEXT | `datetime('now')` | 创建时间 |
+
+**索引**：`idx_model_backends_model_id` on `model_id`
+
+---
+
+## api_keys
+
+API 密钥管理，用于代理端口的访问认证和限流。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | TEXT PK | — | 主键，UUID |
+| `key` | TEXT NOT NULL UNIQUE | — | 密钥值（如 `nyro-xxxx`） |
+| `name` | TEXT NOT NULL | — | 显示名称 |
+| `rpm` | INTEGER | NULL | 每分钟请求数限制 |
+| `rpd` | INTEGER | NULL | 每日请求数限制 |
+| `tpm` | INTEGER | NULL | 每分钟 token 数限制 |
+| `tpd` | INTEGER | NULL | 每日 token 数限制 |
+| `is_enabled` | INTEGER | `1` | 是否启用 |
+| `expires_at` | TEXT | NULL | 过期时间 |
+| `created_at` | TEXT | `datetime('now')` | 创建时间 |
+| `updated_at` | TEXT | `datetime('now')` | 更新时间 |
+
+**索引**：`idx_api_keys_key` on `key`
+
+---
+
+## api_key_models
+
+API Key 与模型的访问绑定关系（M:N 关联表）。仅当 model 启用 `access_control` 时生效。
+
+| Column | Type | Description |
+|---|---|---|
+| `api_key_id` | TEXT NOT NULL | API Key ID（FK → api_keys.id, ON DELETE CASCADE） |
+| `model_id` | TEXT NOT NULL | 模型 ID（FK → models.id, ON DELETE CASCADE） |
+
+**主键**：`(api_key_id, model_id)`
+
+**索引**：`idx_api_key_models_model_id` on `model_id`
+
+---
+
+## provider_oauth_credentials
+
+OAuth 凭据存储，用于需要 OAuth 认证的供应商（如 Google Vertex AI）。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `provider_id` | TEXT PK | — | 供应商 ID（FK → providers.id, ON DELETE CASCADE） |
+| `driver_key` | TEXT | `''` | OAuth 驱动标识 |
+| `scheme` | TEXT | `''` | 认证方案 |
+| `access_token` | TEXT | `''` | OAuth access token |
+| `refresh_token` | TEXT | NULL | OAuth refresh token |
+| `expires_at` | TEXT | NULL | Token 过期时间 |
+| `resource_url` | TEXT | NULL | 资源 URL（部分 OAuth 流程需要） |
+| `subject_id` | TEXT | NULL | 认证主体 ID |
+| `scopes` | TEXT | `'[]'` | OAuth 权限范围（JSON 数组） |
+| `meta` | TEXT | `'{}'` | 扩展元数据（JSON） |
+| `status` | TEXT | `'connected'` | 连接状态 |
+| `status_version` | INTEGER | `0` | 状态版本号（乐观锁） |
+| `last_error` | TEXT | NULL | 最近一次错误信息 |
+| `last_refresh_at` | TEXT | NULL | 最近一次 token 刷新时间 |
+| `created_at` | TEXT | `datetime('now')` | 创建时间 |
+| `updated_at` | TEXT | `datetime('now')` | 更新时间 |
+
+---
+
+## request_logs
+
+请求日志（追加写入，记录每次代理请求的完整信息）。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | TEXT PK | — | 日志 ID |
+| `created_at` | INTEGER | `0` | Unix 毫秒时间戳 |
+| `api_key_id` | TEXT | NULL | 认证使用的 API Key ID |
+| `api_key_name` | TEXT | NULL | API Key 名称（快照） |
+| `client_protocol` | TEXT | NULL | 客户端协议（如 `openai/chat/v1`） |
+| `upstream_protocol` | TEXT | NULL | 上游协议 |
+| `provider_id` | TEXT | NULL | 供应商 ID |
+| `provider_name` | TEXT | NULL | 供应商名称（快照） |
+| `model_id` | TEXT | NULL | 匹配到的模型 ID |
+| `model_name` | TEXT | NULL | 模型名称（快照） |
+| `upstream_url` | TEXT | NULL | 上游请求 URL |
+| `client_model` | TEXT | NULL | 客户端请求中的模型名 |
+| `upstream_model` | TEXT | NULL | 实际发送给上游的模型名 |
+| `method` | TEXT | NULL | HTTP 方法 |
+| `path` | TEXT | NULL | 请求路径 |
+| `client_request_headers` | TEXT | NULL | 客户端请求头（JSON，可选记录） |
+| `client_request_body` | TEXT | NULL | 客户端请求体（可选记录） |
+| `client_response_headers` | TEXT | NULL | 客户端响应头（JSON，可选记录） |
+| `client_response_body` | TEXT | NULL | 客户端响应体（可选记录） |
+| `upstream_request_headers` | TEXT | NULL | 上游请求头（JSON，可选记录） |
+| `upstream_request_body` | TEXT | NULL | 上游请求体（可选记录） |
+| `upstream_response_headers` | TEXT | NULL | 上游响应头（JSON，可选记录） |
+| `upstream_response_body` | TEXT | NULL | 上游响应体（可选记录） |
+| `upstream_status_code` | INTEGER | NULL | 上游 HTTP 状态码 |
+| `client_status_code` | INTEGER | NULL | 返回给客户端的 HTTP 状态码 |
+| `latency_total_ms` | INTEGER | NULL | 总延迟（毫秒） |
+| `latency_upstream_ms` | INTEGER | NULL | 上游延迟（毫秒） |
+| `input_tokens` | INTEGER | `0` | 输入 token 数 |
+| `output_tokens` | INTEGER | `0` | 输出 token 数 |
+| `cache_read_tokens` | INTEGER | `0` | 缓存命中 token 数 |
+| `is_stream` | INTEGER | `0` | 是否为流式请求 |
+| `stream_chunks_count` | INTEGER | `0` | 流式分块数量 |
+| `stream_first_chunk_ms` | INTEGER | NULL | 首个分块延迟（毫秒） |
+
+**索引**：
+- `idx_logs_created_at` on `created_at`
+- `idx_logs_provider_id` on `provider_id`
+- `idx_logs_client_status` on `client_status_code`
+- `idx_logs_upstream_model` on `upstream_model`
+- `idx_logs_api_key` on `api_key_id`
+- `idx_logs_client_protocol` on `client_protocol`
+- `idx_logs_upstream_protocol` on `upstream_protocol`
+
+---
+
+## settings
+
+系统配置键值对。
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `key` | TEXT PK | — | 配置键 |
+| `value` | TEXT NOT NULL | — | 配置值 |
+| `updated_at` | TEXT | `datetime('now')` | 更新时间 |
+
+---
+
+## 迁移说明
+
+Nyro 采用 idempotent 迁移策略：`INIT_SQL` 创建旧名称表（如 `routes`、`route_targets`、`api_key_routes`），`migrate()` 末尾执行 rename：
+
+```
+routes             → models
+route_targets      → model_backends
+api_key_routes     → api_key_models
+routes.strategy    → models.balance
+request_logs.route_id   → request_logs.model_id
+request_logs.route_name → request_logs.model_name
+```
+
+所有 rename 操作均为幂等：先检查旧列存在且新列不存在，才执行 `ALTER TABLE RENAME`。

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -142,8 +142,8 @@ pub struct YamlModel {
     pub name: String,
     #[serde(alias = "vmodel")]
     pub virtual_model: String,
-    #[serde(default = "default_strategy")]
-    pub strategy: String,
+    #[serde(default = "default_balance", alias = "strategy")]
+    pub balance: String,
     #[serde(default, rename = "backends", alias = "targets")]
     pub backends: Vec<YamlModelBackend>,
     #[serde(default)]
@@ -153,7 +153,7 @@ pub struct YamlModel {
     pub route_type: Option<String>,
 }
 
-fn default_strategy() -> String {
+fn default_balance() -> String {
     "weighted".to_string()
 }
 
@@ -351,7 +351,7 @@ pub fn build_models(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Model> {
                 id: model_id,
                 name: ym.name.clone(),
                 virtual_model: ym.virtual_model.clone(),
-                strategy: ym.strategy.clone(),
+                balance: ym.balance.clone(),
                 target_provider: primary.map(|b| b.provider_id.clone()).unwrap_or_default(),
                 target_model: primary.map(|b| b.model.clone()).unwrap_or_default(),
                 access_control: ym.access_control,

--- a/tests/e2e/storage/conftest.py
+++ b/tests/e2e/storage/conftest.py
@@ -195,15 +195,11 @@ def build_harness(work_dir: Path) -> None:
             let route = admin.create_model(CreateModel {
                 name: format!("{backend}-e2e-model"),
                 virtual_model: format!("{backend}-model"),
-                strategy: None,
+                balance: None,
                 target_provider: provider.id.clone(),
                 target_model: "gpt-4o-mini".to_string(),
                 targets: vec![],
                 access_control: Some(true),
-                cache: None,
-                cache_exact_ttl: None,
-                cache_semantic_ttl: None,
-                cache_semantic_threshold: None,
             }).await?;
 
             let api_key = admin.create_api_key(CreateApiKey {

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -24,7 +24,7 @@ export interface Model {
   id: string;
   name: string;
   virtual_model: string;
-  strategy: ModelStrategy;
+  balance: ModelBalance;
   target_provider: string;
   target_model: string;
   access_control: boolean;
@@ -33,7 +33,7 @@ export interface Model {
   targets: ModelBackend[];
 }
 
-export type ModelStrategy = "weighted" | "priority";
+export type ModelBalance = "weighted" | "priority";
 
 export interface ModelBackend {
   id: string;
@@ -230,7 +230,7 @@ export interface UpdateProvider {
 export interface CreateModel {
   name: string;
   virtual_model: string;
-  strategy?: ModelStrategy;
+  balance?: ModelBalance;
   target_provider: string;
   target_model: string;
   targets?: CreateModelBackend[];
@@ -240,7 +240,7 @@ export interface CreateModel {
 export interface UpdateModel {
   name?: string;
   virtual_model?: string;
-  strategy?: ModelStrategy;
+  balance?: ModelBalance;
   target_provider?: string;
   target_model?: string;
   targets?: UpsertModelBackend[];

--- a/webui/src/pages/models.tsx
+++ b/webui/src/pages/models.tsx
@@ -10,7 +10,7 @@ import type {
   ModelCapabilities,
   Provider,
   Model as ModelType,
-  ModelStrategy,
+  ModelBalance,
   UpdateModel,
   UpsertModelBackend,
 } from "@/lib/types";
@@ -35,7 +35,7 @@ const PAGE_SIZE = 7;
 type ModelForm = {
   name: string;
   virtual_model: string;
-  strategy: ModelStrategy;
+  balance: ModelBalance;
   targets: ModelBackendForm[];
   access_control: boolean;
 };
@@ -51,7 +51,7 @@ type ModelBackendForm = {
 const emptyCreate: ModelForm = {
   name: "",
   virtual_model: "",
-  strategy: "weighted",
+  balance: "weighted",
   targets: [{ provider_id: "", model: "", weight: 100, priority: 1 }],
   access_control: false,
 };
@@ -60,7 +60,7 @@ function FieldLabel({ children }: { children: string }) {
   return <label className="ml-1 text-xs leading-none font-normal text-slate-900">{children}</label>;
 }
 
-function strategyLabel(value: ModelStrategy, isZh: boolean) {
+function balanceLabel(value: ModelBalance, isZh: boolean) {
   if (value === "priority") return isZh ? "主备分级" : "Priority";
   return isZh ? "加权轮询" : "Weighted";
 }
@@ -151,7 +151,7 @@ type TargetRowProps = {
   mode: "create" | "edit";
   index: number;
   target: ModelBackendForm;
-  strategy: ModelStrategy;
+  balance: ModelBalance;
   isZh: boolean;
   providerOptions: Array<{ value: string; label: string; provider: Provider }>;
   providerMap: Map<string, Provider>;
@@ -164,7 +164,7 @@ function TargetRow({
   mode,
   index,
   target,
-  strategy,
+  balance,
   isZh,
   providerOptions,
   providerMap,
@@ -212,7 +212,7 @@ function TargetRow({
     staleTime: 60_000,
   });
 
-  const rowClassName = strategy === "weighted"
+  const rowClassName = balance === "weighted"
     ? "grid w-full grid-cols-[minmax(0,2.8fr)_minmax(0,5.2fr)_minmax(0,1.25fr)_32px] items-center gap-2.5"
     : "grid w-full grid-cols-[minmax(0,2.8fr)_minmax(0,5.2fr)_minmax(0,1.25fr)_32px] items-center gap-2.5";
 
@@ -271,7 +271,7 @@ function TargetRow({
           />
         )}
 
-        {strategy === "weighted" ? (
+        {balance === "weighted" ? (
           <Input
             className="bg-white"
             type="number"
@@ -417,7 +417,7 @@ export default function ModelsPage() {
       id: route.id,
       name: route.name,
       virtual_model: route.virtual_model,
-      strategy: route.strategy ?? "weighted",
+      balance: route.balance ?? "weighted",
       targets,
       access_control: route.access_control,
     });
@@ -513,9 +513,9 @@ export default function ModelsPage() {
             <div className="space-y-2">
               <FieldLabel>{isZh ? "负载策略" : "Load Strategy"}</FieldLabel>
               <Select
-                value={createForm.strategy}
-                onValueChange={(value: ModelStrategy) =>
-                  setCreateForm((prev) => ({ ...prev, strategy: value }))
+                value={createForm.balance}
+                onValueChange={(value: ModelBalance) =>
+                  setCreateForm((prev) => ({ ...prev, balance: value }))
                 }
               >
                 <SelectTrigger>
@@ -541,7 +541,7 @@ export default function ModelsPage() {
                     mode="create"
                     index={index}
                     target={target}
-                    strategy={createForm.strategy}
+                    balance={createForm.balance}
                     isZh={isZh}
                     providerOptions={providerOptions}
                     providerMap={providerMap}
@@ -646,9 +646,9 @@ export default function ModelsPage() {
                     <div className="space-y-2">
                       <FieldLabel>{isZh ? "负载策略" : "Load Strategy"}</FieldLabel>
                       <Select
-                        value={editForm.strategy}
-                        onValueChange={(value: ModelStrategy) =>
-                          setEditForm((prev) => (prev ? { ...prev, strategy: value } : prev))
+                        value={editForm.balance}
+                        onValueChange={(value: ModelBalance) =>
+                          setEditForm((prev) => (prev ? { ...prev, balance: value } : prev))
                         }
                       >
                         <SelectTrigger>
@@ -674,7 +674,7 @@ export default function ModelsPage() {
                             mode="edit"
                             index={index}
                             target={target}
-                            strategy={editForm.strategy}
+                            balance={editForm.balance}
                             isZh={isZh}
                             providerOptions={providerOptions}
                             providerMap={providerMap}
@@ -756,7 +756,7 @@ export default function ModelsPage() {
                       variant="secondary"
                       className="connect-label-badge bg-sky-50 text-sky-700"
                     >
-                      {strategyLabel(route.strategy ?? "weighted", isZh)}
+                      {balanceLabel(route.balance ?? "weighted", isZh)}
                     </Badge>
                     {route.access_control && (
                       <Badge variant="success" className="connect-label-badge">
@@ -896,7 +896,7 @@ function buildCreatePayload(form: ModelForm): CreateModel {
   return {
     name: form.name.trim(),
     virtual_model: form.virtual_model.trim(),
-    strategy: form.strategy,
+    balance: form.balance,
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,
@@ -916,7 +916,7 @@ function buildUpdatePayload(form: ModelForm & { id: string }): UpdateModel {
   return {
     name: form.name.trim(),
     virtual_model: form.virtual_model.trim(),
-    strategy: form.strategy,
+    balance: form.balance,
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,


### PR DESCRIPTION
- request_logs: rename route_id → model_id, route_name → model_name to align with frontend (already using model_id/model_name), fixing empty model name display in log detail dialog
- models: rename strategy column → balance to reflect AI gateway load-balancing semantics; serde aliases preserve backward compat
- Fix storage E2E test: remove deleted cache fields from harness
- Add docs/database/schema.md with full table documentation