### PR TITLE
feat(server): add graceful shutdown handling

### DIFF
--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod router;
 pub mod storage;
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -26,6 +27,10 @@ use config::{GatewayConfig, SqlStorageConfig, StorageBackendKind};
 use logging::LogEntry;
 use storage::sql::config::SqlBackendConfig;
 use storage::{DynStorage, PostgresStorage, SqliteStorage};
+
+async fn shutdown_pending() {
+    std::future::pending::<()>().await;
+}
 
 #[derive(Clone, Debug)]
 pub struct CapabilityCacheEntry {
@@ -182,11 +187,20 @@ impl Gateway {
     }
 
     pub async fn start_proxy(&self) -> anyhow::Result<()> {
+        self.start_proxy_with_shutdown(shutdown_pending()).await
+    }
+
+    pub async fn start_proxy_with_shutdown(
+        &self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> anyhow::Result<()> {
         let router = proxy::server::create_router(self.clone());
         let addr = format!("{}:{}", self.config.proxy_host, self.config.proxy_port);
         let listener = tokio::net::TcpListener::bind(&addr).await?;
         tracing::info!("proxy listening on {}", addr);
-        axum::serve(listener, router).await?;
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown)
+            .await?;
         Ok(())
     }
 
@@ -318,4 +332,39 @@ fn to_sql_backend_config(
         idle_timeout: config.idle_timeout,
         max_lifetime: config.max_lifetime,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn proxy_server_stops_when_shutdown_future_resolves() {
+        let config = GatewayConfig {
+            proxy_host: "127.0.0.1".to_string(),
+            proxy_port: 0,
+            storage: config::GatewayStorageConfig::default(),
+            ..Default::default()
+        };
+        let storage: DynStorage = Arc::new(storage::MemoryStorage::new(vec![], vec![], vec![]));
+        let (gateway, _log_rx) = Gateway::from_storage(config, storage).await.unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server = tokio::spawn(async move {
+            gateway
+                .start_proxy_with_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        });
+
+        shutdown_tx.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("proxy server should stop after shutdown")
+            .expect("proxy server task should complete")
+            .expect("proxy server should exit cleanly");
+    }
 }

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -16,6 +16,7 @@ use nyro_core::{
     storage::MemoryStorage,
 };
 use rust_embed::RustEmbed;
+use tokio::sync::broadcast;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 mod admin_routes;
@@ -234,7 +235,7 @@ async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
     tracing::info!("proxy  → http://{}:{}", proxy_host, proxy_port);
     tracing::info!("standalone mode: admin API and WebUI are disabled");
 
-    gateway.start_proxy().await?;
+    gateway.start_proxy_with_shutdown(shutdown_signal()).await?;
     Ok(())
 }
 
@@ -272,9 +273,15 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
 
     let gw_proxy = gateway.clone();
     let storage_for_logs = gateway.storage.clone();
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+    let proxy_shutdown = shutdown_tx.subscribe();
+    let admin_shutdown_tx = shutdown_tx.clone();
 
-    tokio::spawn(async move {
-        if let Err(e) = gw_proxy.start_proxy().await {
+    let proxy_task = tokio::spawn(async move {
+        if let Err(e) = gw_proxy
+            .start_proxy_with_shutdown(wait_for_shutdown(proxy_shutdown))
+            .await
+        {
             tracing::error!("proxy server error: {e}");
         }
     });
@@ -299,8 +306,52 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
     if admin_token.is_none() {
         tracing::warn!("admin API auth disabled: set --admin-token for production");
     }
-    axum::serve(listener, app).await?;
+    let admin_result = axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            let _ = admin_shutdown_tx.send(());
+        })
+        .await;
+
+    let _ = shutdown_tx.send(());
+    if let Err(error) = proxy_task.await {
+        tracing::error!("proxy server task failed: {error}");
+    }
+
+    admin_result?;
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            tracing::warn!("failed to listen for shutdown signal: {error}");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut signal) => {
+                signal.recv().await;
+            }
+            Err(error) => tracing::warn!("failed to listen for SIGTERM: {error}"),
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    tracing::info!("shutdown signal received");
+}
+
+async fn wait_for_shutdown(mut shutdown: broadcast::Receiver<()>) {
+    let _ = shutdown.recv().await;
 }
 
 // ── WebUI (embedded) ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add shutdown-aware proxy startup while preserving the existing start_proxy API
- listen for Ctrl+C and SIGTERM in server mode
- coordinate admin and proxy server shutdown in full server mode

## Tests
- cargo check -p nyro-server
- cargo test -p nyro-server
- cargo test -p nyro-core proxy_server_stops_when_shutdown_future_resolves

Note: cargo fmt/rustfmt is not installed in this environment, so formatting was checked with git diff --check.