### PR TITLE
refactor(database): merge virtual_model into name

### DIFF
--- a/crates/nyro-core/src/admin/import_export.rs
+++ b/crates/nyro-core/src/admin/import_export.rs
@@ -72,7 +72,6 @@ impl AdminService {
                 .into_iter()
                 .map(|m| ExportModel {
                     name: m.name,
-                    virtual_model: m.virtual_model,
                     target_model: m.target_model,
                     access_control: m.access_control,
                     is_enabled: m.is_enabled,
@@ -139,7 +138,6 @@ impl AdminService {
                 && self
                     .create_model(CreateModel {
                         name: m.name.clone(),
-                        virtual_model: m.virtual_model.clone(),
                         balance: Some("weighted".to_string()),
                         target_provider: pid,
                         target_model: m.target_model.clone(),

--- a/crates/nyro-core/src/admin/model_data.rs
+++ b/crates/nyro-core/src/admin/model_data.rs
@@ -1,12 +1,5 @@
 use super::*;
 
-pub(super) fn ensure_virtual_model(model: &str) -> anyhow::Result<()> {
-    if model.trim().is_empty() {
-        anyhow::bail!("virtual_model cannot be empty");
-    }
-    Ok(())
-}
-
 pub(super) fn normalize_model_balance(balance: Option<&str>) -> anyhow::Result<String> {
     let normalized = balance.unwrap_or("weighted").trim().to_ascii_lowercase();
     match normalized.as_str() {

--- a/crates/nyro-core/src/admin/models.rs
+++ b/crates/nyro-core/src/admin/models.rs
@@ -16,8 +16,6 @@ impl AdminService {
     pub async fn create_model(&self, input: CreateModel) -> anyhow::Result<Model> {
         let name = normalize_name(&input.name, "model name")?;
         self.ensure_model_name_unique(None, &name).await?;
-        ensure_virtual_model(&input.virtual_model)?;
-        self.ensure_model_unique(None, &input.virtual_model).await?;
         let balance = normalize_model_balance(input.balance.as_deref())?;
         let backends = normalize_create_model_backends(&input)?;
         ensure_model_backends_valid(&backends)?;
@@ -31,7 +29,6 @@ impl AdminService {
             .models()
             .create(CreateModel {
                 name,
-                virtual_model: input.virtual_model,
                 balance: Some(balance),
                 target_provider: primary_backend.provider_id.clone(),
                 target_model: primary_backend.model.clone(),
@@ -54,10 +51,6 @@ impl AdminService {
             "model name",
         )?;
         self.ensure_model_name_unique(Some(id), &name).await?;
-        let virtual_model = input
-            .virtual_model
-            .clone()
-            .unwrap_or_else(|| current.virtual_model.clone());
         let balance = normalize_model_balance(input.balance.as_deref().or(Some(&current.balance)))?;
         let backends = normalize_update_model_backends(&current, &input)?;
         ensure_model_backends_valid(&backends)?;
@@ -66,8 +59,6 @@ impl AdminService {
             .ok_or_else(|| anyhow::anyhow!("at least one model backend is required"))?;
         let access_control = input.access_control.unwrap_or(current.access_control);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
-        ensure_virtual_model(&virtual_model)?;
-        self.ensure_model_unique(Some(id), &virtual_model).await?;
 
         self.gw
             .storage
@@ -76,7 +67,6 @@ impl AdminService {
                 id,
                 UpdateModel {
                     name: Some(name),
-                    virtual_model: Some(virtual_model),
                     balance: Some(balance),
                     target_provider: Some(primary_backend.provider_id.clone()),
                     target_model: Some(primary_backend.model.clone()),
@@ -101,24 +91,6 @@ impl AdminService {
         self.reload_model_cache().await?;
         Ok(())
     }
-    async fn ensure_model_unique(
-        &self,
-        exclude_id: Option<&str>,
-        virtual_model: &str,
-    ) -> anyhow::Result<()> {
-        if self
-            .gw
-            .storage
-            .models()
-            .exists_by_virtual_model(virtual_model, exclude_id)
-            .await?
-        {
-            let normalized_model = virtual_model.trim();
-            anyhow::bail!("model already exists for virtual_model={normalized_model}");
-        }
-        Ok(())
-    }
-
     async fn ensure_model_name_unique(
         &self,
         exclude_id: Option<&str>,

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -97,6 +97,9 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     // Rename column: models strategy → balance
     rename_column_if_needed(pool, "models", "strategy", "balance").await?;
 
+    // Merge virtual_model into name and drop the column
+    migrate_merge_virtual_model_into_name(pool).await?;
+
     Ok(())
 }
 
@@ -705,6 +708,29 @@ async fn rename_column_if_needed(
     Ok(())
 }
 
+async fn migrate_merge_virtual_model_into_name(pool: &SqlitePool) -> anyhow::Result<()> {
+    if !column_exists(pool, "models", "virtual_model").await? {
+        return Ok(());
+    }
+    tracing::info!("merging virtual_model into name on models table");
+    sqlx::query(
+        "UPDATE models SET name = TRIM(virtual_model)
+         WHERE virtual_model IS NOT NULL AND TRIM(virtual_model) != ''",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("ALTER TABLE models DROP COLUMN virtual_model")
+        .execute(pool)
+        .await?;
+    // Also clean up legacy match_pattern column if present
+    if column_exists(pool, "models", "match_pattern").await? {
+        sqlx::query("ALTER TABLE models DROP COLUMN match_pattern")
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
 const INIT_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS providers (
     id          TEXT PRIMARY KEY,
@@ -733,7 +759,6 @@ CREATE TABLE IF NOT EXISTS providers (
 CREATE TABLE IF NOT EXISTS routes (
     id                TEXT PRIMARY KEY,
     name              TEXT NOT NULL,
-    virtual_model     TEXT,
     balance           TEXT DEFAULT 'weighted',
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -109,8 +109,6 @@ pub struct UpsertOAuthCredential {
 pub struct Model {
     pub id: String,
     pub name: String,
-    #[serde(alias = "vmodel")]
-    pub virtual_model: String,
     pub balance: String,
     pub target_provider: String,
     pub target_model: String,
@@ -298,9 +296,8 @@ pub struct UpdateProvider {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateModel {
+    #[serde(alias = "virtual_model", alias = "vmodel")]
     pub name: Option<String>,
-    #[serde(alias = "vmodel")]
-    pub virtual_model: Option<String>,
     #[serde(rename = "balance", alias = "strategy")]
     pub balance: Option<String>,
     pub target_provider: Option<String>,
@@ -313,9 +310,8 @@ pub struct UpdateModel {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateModel {
+    #[serde(alias = "virtual_model", alias = "vmodel")]
     pub name: String,
-    #[serde(alias = "vmodel")]
-    pub virtual_model: String,
     #[serde(rename = "balance", alias = "strategy")]
     pub balance: Option<String>,
     pub target_provider: String,
@@ -476,8 +472,8 @@ pub struct ExportProvider {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportModel {
+    #[serde(alias = "virtual_model")]
     pub name: String,
-    pub virtual_model: String,
     pub target_model: String,
     #[serde(default)]
     pub access_control: bool,

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -44,7 +44,7 @@ pub async fn models_list(State(gw): State<Gateway>, headers: HeaderMap) -> Respo
         .models
         .iter()
         .filter(|model| !model.access_control || accessible_route_ids.contains(&model.id))
-        .map(|model| model.virtual_model.trim())
+        .map(|model| model.name.trim())
         .filter(|model| !model.is_empty())
         .map(ToString::to_string)
         .collect::<BTreeSet<_>>();

--- a/crates/nyro-core/src/router/matcher.rs
+++ b/crates/nyro-core/src/router/matcher.rs
@@ -18,5 +18,5 @@ impl ModelCache {
 }
 
 pub fn match_model<'a>(models: &'a [Model], model: &str) -> Option<&'a Model> {
-    models.iter().find(|m| m.virtual_model == model)
+    models.iter().find(|m| m.name == model)
 }

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -157,18 +157,7 @@ impl ModelStore for MemoryStorage {
         let models = self.models.read().await;
         Ok(models
             .iter()
-            .any(|m| m.name == name && exclude_id.is_none_or(|eid| m.id != eid)))
-    }
-
-    async fn exists_by_virtual_model(
-        &self,
-        virtual_model: &str,
-        exclude_id: Option<&str>,
-    ) -> anyhow::Result<bool> {
-        let models = self.models.read().await;
-        Ok(models
-            .iter()
-            .any(|m| m.virtual_model == virtual_model && exclude_id.is_none_or(|eid| m.id != eid)))
+            .any(|m| m.name.eq_ignore_ascii_case(name) && exclude_id.is_none_or(|eid| m.id != eid)))
     }
 }
 

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -469,13 +469,11 @@ impl ModelStore for PostgresModelStore {
 
     async fn create(&self, input: CreateModel) -> anyhow::Result<Model> {
         let id = uuid::Uuid::new_v4().to_string();
-        let virtual_model = input.virtual_model.trim().to_string();
         sqlx::query(
-            "INSERT INTO models (id, name, virtual_model, balance, target_provider, target_model, access_control) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO models (id, name, balance, target_provider, target_model, access_control) VALUES ($1, $2, $3, $4, $5, $6)",
         )
         .bind(&id)
         .bind(input.name.trim())
-        .bind(&virtual_model)
         .bind(input.balance.unwrap_or_else(|| "weighted".to_string()))
         .bind(input.target_provider.trim())
         .bind(input.target_model.trim())
@@ -488,11 +486,6 @@ impl ModelStore for PostgresModelStore {
     async fn update(&self, id: &str, input: UpdateModel) -> anyhow::Result<Model> {
         let current = self.get(id).await?.context("model not found for update")?;
         let name = input.name.unwrap_or(current.name);
-        let virtual_model = input
-            .virtual_model
-            .unwrap_or(current.virtual_model)
-            .trim()
-            .to_string();
         let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
@@ -500,10 +493,9 @@ impl ModelStore for PostgresModelStore {
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE models SET name=$1, virtual_model=$2, balance=$3, target_provider=$4, target_model=$5, access_control=$6, is_enabled=$7 WHERE id=$8",
+            "UPDATE models SET name=$1, balance=$2, target_provider=$3, target_model=$4, access_control=$5, is_enabled=$6 WHERE id=$7",
         )
         .bind(name.trim())
-        .bind(&virtual_model)
         .bind(balance.trim().to_lowercase())
         .bind(target_provider.trim())
         .bind(target_model.trim())
@@ -537,31 +529,6 @@ impl ModelStore for PostgresModelStore {
                 "SELECT id FROM models WHERE lower(trim(name)) = lower(trim($1)) LIMIT 1",
             )
             .bind(name)
-            .fetch_optional(&self.pool)
-            .await?
-        };
-        Ok(row.is_some())
-    }
-
-    async fn exists_by_virtual_model(
-        &self,
-        virtual_model: &str,
-        exclude_id: Option<&str>,
-    ) -> anyhow::Result<bool> {
-        let normalized_model = virtual_model.trim();
-        let row = if let Some(exclude_id) = exclude_id {
-            sqlx::query_scalar::<_, String>(
-                "SELECT id FROM models WHERE virtual_model = $1 AND id != $2 LIMIT 1",
-            )
-            .bind(normalized_model)
-            .bind(exclude_id)
-            .fetch_optional(&self.pool)
-            .await?
-        } else {
-            sqlx::query_scalar::<_, String>(
-                "SELECT id FROM models WHERE virtual_model = $1 LIMIT 1",
-            )
-            .bind(normalized_model)
             .fetch_optional(&self.pool)
             .await?
         };
@@ -1265,6 +1232,20 @@ END $$;"#,
         // Rename column: models strategy → balance
         pg_rename_column_if_needed(self.adapter.pool(), "models", "strategy", "balance").await?;
 
+        // Merge virtual_model into name and drop the column
+        if pg_column_exists(self.adapter.pool(), "models", "virtual_model").await? {
+            tracing::info!("merging virtual_model into name on models table (postgres)");
+            sqlx::query(
+                "UPDATE models SET name = BTRIM(virtual_model)
+                 WHERE virtual_model IS NOT NULL AND BTRIM(virtual_model) != ''",
+            )
+            .execute(self.adapter.pool())
+            .await?;
+            sqlx::query("ALTER TABLE models DROP COLUMN virtual_model")
+                .execute(self.adapter.pool())
+                .await?;
+        }
+
         Ok(())
     }
 
@@ -1500,7 +1481,7 @@ fn provider_select(suffix: Option<&str>) -> String {
 
 fn model_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
+        "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1618,7 +1599,6 @@ CREATE TABLE IF NOT EXISTS providers (
 CREATE TABLE IF NOT EXISTS routes (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
-    virtual_model TEXT,
     balance TEXT DEFAULT 'weighted',
     target_provider TEXT NOT NULL REFERENCES providers(id),
     target_model TEXT NOT NULL,

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use sqlx::Row;
 use sqlx::SqlitePool;
 use std::time::Duration;
 
@@ -469,24 +468,11 @@ struct SqliteModelStore {
     pool: SqlitePool,
 }
 
-impl SqliteModelStore {
-    async fn has_match_pattern_column(&self) -> anyhow::Result<bool> {
-        let rows = sqlx::query("PRAGMA table_info(models)")
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(rows.iter().any(|row| {
-            row.try_get::<String, _>("name")
-                .map(|name| name == "match_pattern")
-                .unwrap_or(false)
-        }))
-    }
-}
-
 #[async_trait]
 impl ModelStore for SqliteModelStore {
     async fn list(&self) -> anyhow::Result<Vec<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
+            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -494,7 +480,7 @@ impl ModelStore for SqliteModelStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, virtual_model, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
+            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -503,83 +489,42 @@ impl ModelStore for SqliteModelStore {
 
     async fn create(&self, input: CreateModel) -> anyhow::Result<Model> {
         let id = uuid::Uuid::new_v4().to_string();
-        let virtual_model = input.virtual_model.trim().to_string();
         let balance = input.balance.unwrap_or_else(|| "weighted".to_string());
-        if self.has_match_pattern_column().await? {
-            sqlx::query(
-                "INSERT INTO models (id, name, virtual_model, match_pattern, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            )
-            .bind(&id)
-            .bind(input.name.trim())
-            .bind(&virtual_model)
-            .bind(&virtual_model)
-            .bind(balance)
-            .bind(input.target_provider.trim())
-            .bind(input.target_model.trim())
-            .bind(input.access_control.unwrap_or(false))
-            .execute(&self.pool)
-            .await?;
-        } else {
-            sqlx::query(
-                "INSERT INTO models (id, name, virtual_model, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            )
-            .bind(&id)
-            .bind(input.name.trim())
-            .bind(&virtual_model)
-            .bind(balance)
-            .bind(input.target_provider.trim())
-            .bind(input.target_model.trim())
-            .bind(input.access_control.unwrap_or(false))
-            .execute(&self.pool)
-            .await?;
-        }
+        sqlx::query(
+            "INSERT INTO models (id, name, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(input.name.trim())
+        .bind(balance)
+        .bind(input.target_provider.trim())
+        .bind(input.target_model.trim())
+        .bind(input.access_control.unwrap_or(false))
+        .execute(&self.pool)
+        .await?;
         self.get(&id).await?.context("model missing after create")
     }
 
     async fn update(&self, id: &str, input: UpdateModel) -> anyhow::Result<Model> {
         let current = self.get(id).await?.context("model not found for update")?;
         let name = input.name.unwrap_or(current.name);
-        let virtual_model = input
-            .virtual_model
-            .unwrap_or(current.virtual_model)
-            .trim()
-            .to_string();
         let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
         let access_control = input.access_control.unwrap_or(current.access_control);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
-        if self.has_match_pattern_column().await? {
-            sqlx::query(
-                "UPDATE models SET name=?, virtual_model=?, match_pattern=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
-            )
-            .bind(name.trim())
-            .bind(&virtual_model)
-            .bind(&virtual_model)
-            .bind(balance.trim().to_lowercase())
-            .bind(target_provider.trim())
-            .bind(target_model.trim())
-            .bind(access_control)
-            .bind(is_enabled)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        } else {
-            sqlx::query(
-                "UPDATE models SET name=?, virtual_model=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
-            )
-            .bind(name.trim())
-            .bind(&virtual_model)
-            .bind(balance.trim().to_lowercase())
-            .bind(target_provider.trim())
-            .bind(target_model.trim())
-            .bind(access_control)
-            .bind(is_enabled)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        }
+        sqlx::query(
+            "UPDATE models SET name=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
+        )
+        .bind(name.trim())
+        .bind(balance.trim().to_lowercase())
+        .bind(target_provider.trim())
+        .bind(target_model.trim())
+        .bind(access_control)
+        .bind(is_enabled)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         self.get(id).await?.context("model missing after update")
     }
 
@@ -611,37 +556,6 @@ impl ModelStore for SqliteModelStore {
         };
         Ok(row.is_some())
     }
-
-    async fn exists_by_virtual_model(
-        &self,
-        virtual_model: &str,
-        exclude_id: Option<&str>,
-    ) -> anyhow::Result<bool> {
-        let has_match_pattern = self.has_match_pattern_column().await?;
-        let sql = if has_match_pattern && exclude_id.is_some() {
-            "SELECT id FROM models WHERE COALESCE(NULLIF(virtual_model, ''), match_pattern) = ? AND id != ? LIMIT 1"
-        } else if has_match_pattern {
-            "SELECT id FROM models WHERE COALESCE(NULLIF(virtual_model, ''), match_pattern) = ? LIMIT 1"
-        } else if exclude_id.is_some() {
-            "SELECT id FROM models WHERE virtual_model = ? AND id != ? LIMIT 1"
-        } else {
-            "SELECT id FROM models WHERE virtual_model = ? LIMIT 1"
-        };
-        let normalized_model = virtual_model.trim();
-        let row = if let Some(exclude_id) = exclude_id {
-            sqlx::query_scalar::<_, String>(sql)
-                .bind(normalized_model)
-                .bind(exclude_id)
-                .fetch_optional(&self.pool)
-                .await?
-        } else {
-            sqlx::query_scalar::<_, String>(sql)
-                .bind(normalized_model)
-                .fetch_optional(&self.pool)
-                .await?
-        };
-        Ok(row.is_some())
-    }
 }
 
 #[async_trait]
@@ -650,7 +564,6 @@ impl ModelSnapshotStore for SqliteModelStore {
         Ok(sqlx::query_as::<_, Model>(
             r#"SELECT
                 id, name,
-                virtual_model,
                 COALESCE(balance, 'weighted') AS balance,
                 target_provider, target_model,
                 COALESCE(access_control, 0) AS access_control,

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -72,11 +72,6 @@ pub trait ModelStore: Send + Sync {
     async fn update(&self, id: &str, input: UpdateModel) -> anyhow::Result<Model>;
     async fn delete(&self, id: &str) -> anyhow::Result<()>;
     async fn exists_by_name(&self, name: &str, exclude_id: Option<&str>) -> anyhow::Result<bool>;
-    async fn exists_by_virtual_model(
-        &self,
-        virtual_model: &str,
-        exclude_id: Option<&str>,
-    ) -> anyhow::Result<bool>;
 }
 
 #[async_trait]

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -69,8 +69,7 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
     let source_route = gw
         .admin()
         .create_model(CreateModel {
-            name: "source-route".to_string(),
-            virtual_model: "source-model".to_string(),
+            name: "source-model".to_string(),
             balance: Some("priority".to_string()),
             target_provider: String::new(),
             target_model: String::new(),
@@ -109,19 +108,13 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
         1,
         "copying route targets must not create new routes"
     );
-    assert!(models.iter().all(|model| model.name != "source-route_Copy"));
-    assert!(
-        models
-            .iter()
-            .all(|model| model.virtual_model != "source-model_Copy")
-    );
+    assert!(models.iter().all(|model| model.name != "source-model_Copy"));
 
     let updated_model = models
         .iter()
         .find(|model| model.id == source_route.id)
         .expect("source route should remain");
-    assert_eq!(updated_model.name, "source-route");
-    assert_eq!(updated_model.virtual_model, "source-model");
+    assert_eq!(updated_model.name, "source-model");
     assert_eq!(updated_model.balance, "priority");
     assert!(updated_model.access_control);
     assert_eq!(updated_model.target_provider, original.id);
@@ -159,8 +152,7 @@ async fn copy_provider_does_not_append_targets_by_default() -> anyhow::Result<()
 
     gw.admin()
         .create_model(CreateModel {
-            name: "no-route-copy-source".to_string(),
-            virtual_model: "no-route-copy-model".to_string(),
+            name: "no-route-copy-model".to_string(),
             balance: None,
             target_provider: original.id.clone(),
             target_model: "source-upstream-model".to_string(),
@@ -194,8 +186,7 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
     let removed_route = gw
         .admin()
         .create_model(CreateModel {
-            name: "route-owned-by-deleted-provider".to_string(),
-            virtual_model: "route-owned-model".to_string(),
+            name: "route-owned-model".to_string(),
             balance: None,
             target_provider: removed_provider.id.clone(),
             target_model: "gpt-delete".to_string(),
@@ -206,8 +197,7 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
     let kept_route = gw
         .admin()
         .create_model(CreateModel {
-            name: "route-with-secondary-deleted-provider".to_string(),
-            virtual_model: "route-kept-model".to_string(),
+            name: "route-kept-model".to_string(),
             balance: None,
             target_provider: kept_provider.id.clone(),
             target_model: "gpt-keep".to_string(),

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -53,8 +53,7 @@ AI 模型供应商配置（API endpoint、密钥、认证方式等）。
 | Column | Type | Default | Description |
 |---|---|---|---|
 | `id` | TEXT PK | — | 主键，UUID |
-| `name` | TEXT NOT NULL | — | 显示名称 |
-| `virtual_model` | TEXT | NULL | 客户端请求中使用的模型名（匹配键） |
+| `name` | TEXT NOT NULL | — | 显示名称，同时作为客户端请求的模型匹配键（路由唯一键的一部分） |
 | `balance` | TEXT | `'weighted'` | 多后端负载均衡策略：`weighted`、`priority`、`cooldown`、`latency` |
 | `target_provider` | TEXT NOT NULL | — | 默认后端 provider ID（FK → providers.id） |
 | `target_model` | TEXT NOT NULL | — | 默认后端使用的上游模型名 |
@@ -217,6 +216,7 @@ routes             → models
 route_targets      → model_backends
 api_key_routes     → api_key_models
 routes.strategy    → models.balance
+routes.virtual_model → models.name（合并至 name 列）
 request_logs.route_id   → request_logs.model_id
 request_logs.route_name → request_logs.model_name
 ```

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -458,24 +458,19 @@ trait VendorExtension: Send + Sync {
 
 ### 7.1 Route 模型
 
-路由唯一键为 `(ingress_protocol, virtual_model)`：
+路由唯一键为 `(ingress_protocol, name)`：
 
 | 字段 | 类型 | 说明 |
 |---|---|---|
 | `id` | TEXT PK | UUID |
-| `name` | TEXT | 人类可读名称 |
+| `name` | TEXT | 人类可读名称，同时作为客户端请求的模型匹配键（路由唯一键的一部分） |
 | `ingress_protocol` | TEXT | 接入协议（canonical ProtocolId） |
-| `virtual_model` | TEXT | 客户端传入的 model 值，精确匹配 |
 | `target_provider` | TEXT FK | 目标模型提供商 |
 | `target_model` | TEXT | 实际调用的模型 |
 | `access_control` | BOOLEAN | 是否启用访问控制，默认 false |
 | `is_active` | BOOLEAN | 路由启用状态，默认 true |
 
-虚拟模型名继承规则：`virtual_model = 用户填写 ?? target_model`
-
-两种使用模式：
-- **透明代理**：虚拟模型名 = 真实模型名，客户端代码与直连 Provider 完全一致
-- **抽象层**：虚拟模型名 ≠ 真实模型名，后端随时切换模型，客户端无感知
+`name` 同时承担显示名称和路由匹配键两个角色。当客户端请求中的 `model` 值与某条路由的 `name` 精确匹配时，该路由被命中，请求被转发到 `target_provider` 的 `target_model`。
 
 ### 7.2 API Key 模型
 
@@ -485,7 +480,7 @@ Route 与 API Key 是**独立管理、多对多绑定**的关系：
 API Key ──── (授权绑定) ──── Route
   │                            │
   ├── 配额: RPM / TPM / TPD     ├── 接入协议 (canonical ProtocolId)
-  ├── 过期时间                  ├── 虚拟模型名 (精确匹配)
+  ├── 过期时间                  ├── 模型名 (精确匹配)
   ├── 状态: active / revoked   ├── 目标提供商 + 目标模型
   └── 名称                      └── 访问控制开关
 ```
@@ -557,14 +552,13 @@ CREATE TABLE providers (
 -- 路由规则
 CREATE TABLE routes (
     id                TEXT PRIMARY KEY,
-    name              TEXT NOT NULL,
+    name              TEXT NOT NULL,    -- 显示名称 + 路由匹配键
     ingress_protocol  TEXT NOT NULL,   -- canonical ProtocolId
-    virtual_model     TEXT NOT NULL,
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,
     access_control    INTEGER NOT NULL DEFAULT 0,
     is_active         INTEGER NOT NULL DEFAULT 1,
-    UNIQUE(ingress_protocol, virtual_model)
+    UNIQUE(ingress_protocol, name)
 );
 
 -- 访问控制 Key

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -139,9 +139,8 @@ pub struct YamlEndpoint {
 
 #[derive(Debug, Deserialize)]
 pub struct YamlModel {
+    #[serde(alias = "vmodel", alias = "virtual_model")]
     pub name: String,
-    #[serde(alias = "vmodel")]
-    pub virtual_model: String,
     #[serde(default = "default_balance", alias = "strategy")]
     pub balance: String,
     #[serde(default, rename = "backends", alias = "targets")]
@@ -240,9 +239,6 @@ impl YamlConfig {
                     "YAML field 'type' (route_type) is no longer supported and will be ignored; \
                      remove it from your config file"
                 );
-            }
-            if m.virtual_model.trim().is_empty() {
-                anyhow::bail!("models[{i}] ({}): virtual_model is required", m.name);
             }
             if m.backends.is_empty() {
                 anyhow::bail!("models[{i}] ({}): at least one backend is required", m.name);
@@ -350,7 +346,6 @@ pub fn build_models(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Model> {
             Model {
                 id: model_id,
                 name: ym.name.clone(),
-                virtual_model: ym.virtual_model.clone(),
                 balance: ym.balance.clone(),
                 target_provider: primary.map(|b| b.provider_id.clone()).unwrap_or_default(),
                 target_model: primary.map(|b| b.model.clone()).unwrap_or_default(),
@@ -492,7 +487,6 @@ providers:
     apikey: sk-x
 models:
   - name: gpt-4o
-    vmodel: gpt-4o
     backends:
       - provider: openai
         model: gpt-4o
@@ -512,13 +506,52 @@ providers:
     apikey: sk-x
 routes:
   - name: gpt-4o
-    vmodel: gpt-4o
     targets:
       - provider: openai
         model: gpt-4o
 "#;
         let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
         cfg.validate().expect("validate");
+    }
+
+    #[test]
+    fn vmodel_alias_maps_to_name() {
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+models:
+  - vmodel: gpt-4o
+    backends:
+      - provider: openai
+        model: gpt-4o
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        assert_eq!(cfg.models[0].name, "gpt-4o");
+    }
+
+    #[test]
+    fn virtual_model_alias_maps_to_name() {
+        let yaml = r#"
+providers:
+  - name: openai
+    endpoints:
+      openai:
+        base_url: https://api.openai.com/v1
+    apikey: sk-x
+models:
+  - virtual_model: gpt-4o
+    backends:
+      - provider: openai
+        model: gpt-4o
+"#;
+        let cfg: YamlConfig = serde_yaml::from_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        assert_eq!(cfg.models[0].name, "gpt-4o");
     }
 
     #[test]
@@ -573,13 +606,11 @@ providers:
     apikey: sk-x
 models:
   - name: embeddings
-    vmodel: text-embedding-3-small
     type: embedding
     backends:
       - provider: openai
         model: text-embedding-3-small
   - name: chat
-    vmodel: gpt-4o
     route_type: chat
     backends:
       - provider: openai
@@ -609,7 +640,6 @@ providers:
     capabilities_source: models.dev
 models:
   - name: chat
-    vmodel: gpt-4o
     backends:
       - provider: openai
         model: gpt-4o
@@ -635,7 +665,6 @@ providers:
     capabilities_source: http
 models:
   - name: embeddings
-    vmodel: text-embedding-3-small
     type: embedding
     backends:
       - provider: openai

--- a/tests/e2e/admin/test_admin.py
+++ b/tests/e2e/admin/test_admin.py
@@ -24,13 +24,12 @@ def _create_provider(env: dict[str, str], name: str) -> str:
     return resp["data"]["id"]
 
 
-def _create_model(env: dict[str, str], provider_id: str, name: str, vmodel: str) -> str:
+def _create_model(env: dict[str, str], provider_id: str, name: str) -> str:
     status, resp = http_request(
         "POST",
         f"{env['admin']}/api/v1/models",
         payload={
             "name": name,
-            "virtual_model": vmodel,
             "target_provider": provider_id,
             "target_model": "gpt-4o-mini",
             "access_control": True,
@@ -82,7 +81,7 @@ def test_provider_crud(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_model_crud(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-model")
-    model_id = _create_model(admin_env, provider_id, "test-model", "test-vmodel")
+    model_id = _create_model(admin_env, provider_id, "test-model")
 
     status, resp = http_request("GET", f"{admin_env['admin']}/api/v1/models", headers=admin_env["auth"])
     assert status == 200
@@ -94,7 +93,7 @@ def test_model_crud(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_api_key_crud(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-key")
-    model_id = _create_model(admin_env, provider_id, "test-model-key", "test-vmodel-key")
+    model_id = _create_model(admin_env, provider_id, "test-model-key")
     api_key = _create_api_key(admin_env, model_id, "test-key")
     assert api_key.get("key"), f"missing api key material: {api_key}"
 
@@ -103,7 +102,7 @@ def test_api_key_crud(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_access_control_rejects_anonymous(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-access")
-    _create_model(admin_env, provider_id, "test-model-access", "test-model-access")
+    _create_model(admin_env, provider_id, "test-model-access")
 
     status, _ = http_request(
         "POST",
@@ -117,7 +116,7 @@ def test_access_control_rejects_anonymous(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_export_config_counts(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-export")
-    _create_model(admin_env, provider_id, "test-model-export", "test-vmodel-export")
+    _create_model(admin_env, provider_id, "test-model-export")
 
     status, resp = http_request(
         "GET",
@@ -134,7 +133,7 @@ def test_export_config_counts(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_proxy_request_creates_log(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-log")
-    model_id = _create_model(admin_env, provider_id, "test-model-log", "test-model-log")
+    model_id = _create_model(admin_env, provider_id, "test-model-log")
     api_key = _create_api_key(admin_env, model_id, "test-key-log")
 
     status, resp = http_request(
@@ -168,7 +167,7 @@ def test_proxy_request_creates_log(admin_env: dict[str, str]) -> None:
 @pytest.mark.admin
 def test_stats_overview_incremented(admin_env: dict[str, str]) -> None:
     provider_id = _create_provider(admin_env, "test-provider-stats")
-    model_id = _create_model(admin_env, provider_id, "test-model-stats", "test-model-stats")
+    model_id = _create_model(admin_env, provider_id, "test-model-stats")
     api_key = _create_api_key(admin_env, model_id, "test-key-stats")
 
     status, _ = http_request(

--- a/tests/e2e/proxy/conftest.py
+++ b/tests/e2e/proxy/conftest.py
@@ -8,7 +8,7 @@ Pipeline orchestrated by these fixtures:
      25208-25211 (or ephemeral if those are busy).
   3. Synthesise a ``standalone.yaml`` whose 4 providers point at the replay
      instances and whose models use the ``replay_model`` string as
-     ``name`` / ``vmodel`` / ``targets[].model`` (so nyro overrides the
+     ``name`` / ``targets[].model`` (so nyro overrides the
      request body model and replay's HashMap lookup hits).
   4. Boot ``nyro-server`` against that config and yield its base URL.
 
@@ -137,7 +137,6 @@ def _render_standalone(
         for replay_model in replay_models.get(protocol, []):
             models.append({
                 "name": replay_model,
-                "vmodel": replay_model,
                 "backends": [
                     {"provider": f"replay-{protocol}", "model": replay_model},
                 ],

--- a/tests/e2e/storage/conftest.py
+++ b/tests/e2e/storage/conftest.py
@@ -193,8 +193,7 @@ def build_harness(work_dir: Path) -> None:
             }).await?;
 
             let route = admin.create_model(CreateModel {
-                name: format!("{backend}-e2e-model"),
-                virtual_model: format!("{backend}-model"),
+                name: format!("{backend}-model"),
                 balance: None,
                 target_provider: provider.id.clone(),
                 target_model: "gpt-4o-mini".to_string(),

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -23,7 +23,6 @@ export interface Provider {
 export interface Model {
   id: string;
   name: string;
-  virtual_model: string;
   balance: ModelBalance;
   target_provider: string;
   target_model: string;
@@ -229,7 +228,6 @@ export interface UpdateProvider {
 
 export interface CreateModel {
   name: string;
-  virtual_model: string;
   balance?: ModelBalance;
   target_provider: string;
   target_model: string;
@@ -239,7 +237,6 @@ export interface CreateModel {
 
 export interface UpdateModel {
   name?: string;
-  virtual_model?: string;
   balance?: ModelBalance;
   target_provider?: string;
   target_model?: string;
@@ -315,7 +312,6 @@ export interface ExportProvider {
 
 export interface ExportModel {
   name: string;
-  virtual_model: string;
   target_model: string;
   access_control: boolean;
   is_enabled: boolean;

--- a/webui/src/pages/api-keys.tsx
+++ b/webui/src/pages/api-keys.tsx
@@ -217,7 +217,7 @@ export default function ApiKeysPage() {
     () =>
       routes.map((route) => ({
         value: route.id,
-        label: `${route.name} (${route.virtual_model})`,
+        label: route.name,
       })),
     [routes],
   );

--- a/webui/src/pages/connect.tsx
+++ b/webui/src/pages/connect.tsx
@@ -527,7 +527,7 @@ export default function ConnectPage() {
   const proxyPort = status?.proxy_port;
   const hasProxyPort = typeof proxyPort === "number" && Number.isFinite(proxyPort) && proxyPort > 0;
   const host = hasProxyPort ? `http://localhost:${proxyPort}` : "http://localhost:<proxy-port>";
-  const codeModel = selectedRoute?.virtual_model ?? "gpt-4o";
+  const codeModel = selectedRoute?.name ?? "gpt-4o";
   const codeRouteType: RouteKind = "chat";
   const codeProtocol = selectedCodeProtocol;
   const selectedCliTool =
@@ -602,7 +602,7 @@ export default function ConnectPage() {
     selectedCliRoute?.access_control
       ? selectedCliApiKey?.key ?? UNSELECTED_KEY_PLACEHOLDER
       : OPTIONAL_KEY_PLACEHOLDER;
-  const cliModel = selectedCliRoute?.virtual_model ?? "gpt-4o";
+  const cliModel = selectedCliRoute?.name ?? "gpt-4o";
   const canSyncCli =
     IS_TAURI &&
     hasProxyPort &&
@@ -833,7 +833,7 @@ export default function ConnectPage() {
                       }}
                     options={cliRoutes.map((route) => ({
                       value: route.id,
-                      label: `${route.name} · ${route.virtual_model}`,
+                      label: route.name,
                     }))}
                     placeholder={
                       cliRoutes.length > 0
@@ -1065,7 +1065,7 @@ export default function ConnectPage() {
                     onValueChange={setSelectedCodeRouteId}
                     options={codeRoutes.map((route) => ({
                       value: route.id,
-                      label: `${route.name} · ${route.virtual_model}`,
+                      label: route.name,
                     }))}
                     placeholder={
                       codeRoutes.length > 0

--- a/webui/src/pages/models.tsx
+++ b/webui/src/pages/models.tsx
@@ -34,7 +34,6 @@ const PAGE_SIZE = 7;
 
 type ModelForm = {
   name: string;
-  virtual_model: string;
   balance: ModelBalance;
   targets: ModelBackendForm[];
   access_control: boolean;
@@ -50,7 +49,6 @@ type ModelBackendForm = {
 
 const emptyCreate: ModelForm = {
   name: "",
-  virtual_model: "",
   balance: "weighted",
   targets: [{ provider_id: "", model: "", weight: 100, priority: 1 }],
   access_control: false,
@@ -416,7 +414,6 @@ export default function ModelsPage() {
     setEditForm({
       id: route.id,
       name: route.name,
-      virtual_model: route.virtual_model,
       balance: route.balance ?? "weighted",
       targets,
       access_control: route.access_control,
@@ -474,7 +471,7 @@ export default function ModelsPage() {
         <div>
           <h1 className="text-2xl font-bold text-slate-900">{isZh ? "模型" : "Models"}</h1>
           <p className="mt-1 text-sm text-slate-500">
-            {isZh ? "按虚拟模型精确匹配，自动开放所有接入协议" : "Exact match by virtual model, all ingress protocols enabled"}
+            {isZh ? "按模型名称精确匹配，自动开放所有接入协议" : "Exact match by model name, all ingress protocols enabled"}
           </p>
         </div>
         <Button
@@ -495,19 +492,11 @@ export default function ModelsPage() {
           <h2 className="text-lg font-semibold text-slate-900">{isZh ? "新建模型" : "New Model"}</h2>
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
+              <FieldLabel>{isZh ? "模型名称（虚拟模型 ID）" : "Model Name (Virtual Model ID)"}</FieldLabel>
               <Input
                 value={createForm.name}
                 onChange={(e) => setCreateForm((prev) => ({ ...prev, name: e.target.value }))}
                 placeholder={isZh ? "输入模型名称" : "Enter model name"}
-              />
-            </div>
-            <div className="space-y-2">
-              <FieldLabel>{isZh ? "虚拟模型 ID" : "Virtual Model ID"}</FieldLabel>
-              <Input
-                value={createForm.virtual_model}
-                onChange={(e) => setCreateForm((prev) => ({ ...prev, virtual_model: e.target.value }))}
-                placeholder={isZh ? "客户端请求中的模型 ID（精确匹配）" : "Client model ID (exact match)"}
               />
             </div>
             <div className="space-y-2">
@@ -579,7 +568,6 @@ export default function ModelsPage() {
               disabled={
                 createMut.isPending ||
                 !createForm.name.trim() ||
-                !createForm.virtual_model.trim() ||
                 createForm.targets.some((target) => !target.provider_id || !target.model.trim())
               }
             >
@@ -628,19 +616,10 @@ export default function ModelsPage() {
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
+                      <FieldLabel>{isZh ? "模型名称（虚拟模型 ID）" : "Model Name (Virtual Model ID)"}</FieldLabel>
                       <Input
                         value={editForm.name}
                         onChange={(e) => setEditForm((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <FieldLabel>{isZh ? "虚拟模型 ID" : "Virtual Model ID"}</FieldLabel>
-                      <Input
-                        value={editForm.virtual_model}
-                        onChange={(e) =>
-                          setEditForm((prev) => (prev ? { ...prev, virtual_model: e.target.value } : prev))
-                        }
                       />
                     </div>
                     <div className="space-y-2">
@@ -744,9 +723,6 @@ export default function ModelsPage() {
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="inline-flex h-5 items-center font-semibold text-slate-900">{route.name}</span>
-                    <code className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[11px] leading-none text-slate-600">
-                      {route.virtual_model}
-                    </code>
                     {route.targets && route.targets.length > 1 && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? `共 ${route.targets.length} 个目标` : `${route.targets.length} Targets`}
@@ -840,7 +816,7 @@ export default function ModelsPage() {
           if (!open) setModelToDisable(null);
         }}
         title={isZh ? "确认禁用模型" : "Confirm model disable"}
-        description={isZh ? "禁用后，该虚拟模型将不可用，确认禁用？" : "After disabling, the virtual model will be unavailable. Confirm disable?"}
+        description={isZh ? "禁用后，该模型将不可用，确认禁用？" : "After disabling, the model will be unavailable. Confirm disable?"}
         cancelText={isZh ? "取消" : "Cancel"}
         confirmText={isZh ? "禁用" : "Disable"}
         onConfirm={() => {
@@ -895,7 +871,6 @@ function buildCreatePayload(form: ModelForm): CreateModel {
   const primary = targets[0] ?? { provider_id: "", model: "" };
   return {
     name: form.name.trim(),
-    virtual_model: form.virtual_model.trim(),
     balance: form.balance,
     targets,
     target_provider: primary.provider_id,
@@ -915,7 +890,6 @@ function buildUpdatePayload(form: ModelForm & { id: string }): UpdateModel {
   const primary = targets[0] ?? { provider_id: "", model: "" };
   return {
     name: form.name.trim(),
-    virtual_model: form.virtual_model.trim(),
     balance: form.balance,
     targets,
     target_provider: primary.provider_id,


### PR DESCRIPTION
## Summary
- Merge `virtual_model` into `name` — single field now serves as both display name and routing key, matching the standard pattern in OpenAI/LiteLLM/OneAPI/OpenRouter
- Add data migration: `virtual_model` values are copied to `name` (routing priority), then column is dropped
- Maintain backward compatibility via serde aliases (`virtual_model`, `vmodel`) on CreateModel/UpdateModel/ExportModel/YamlModel

## Test plan
- [x] `cargo build` — zero warnings, zero errors
- [x] `cargo test` — all 254 tests pass (including new `vmodel_alias_maps_to_name` and `virtual_model_alias_maps_to_name` tests)
- [ ] Verify data migration on existing database: models with `virtual_model` should have routing value preserved in `name`
- [ ] Verify `POST /api/v1/models` with `{"virtual_model": "gpt-4o", ...}` still works (backward compat)
- [ ] Verify `GET /v1/models` returns `name` values
- [ ] Verify YAML config with `vmodel:` or `virtual_model:` key still parses correctly