### PR TITLE
feat(model): add per-model payload logging control and unify enable_* naming

### DIFF
--- a/crates/nyro-core/src/admin/import_export.rs
+++ b/crates/nyro-core/src/admin/import_export.rs
@@ -73,7 +73,8 @@ impl AdminService {
                 .map(|m| ExportModel {
                     name: m.name,
                     target_model: m.target_model,
-                    access_control: m.access_control,
+                    enable_auth: m.enable_auth,
+                    enable_payload: m.enable_payload,
                     is_enabled: m.is_enabled,
                 })
                 .collect(),
@@ -142,7 +143,8 @@ impl AdminService {
                         target_provider: pid,
                         target_model: m.target_model.clone(),
                         targets: vec![],
-                        access_control: Some(m.access_control),
+                        enable_auth: Some(m.enable_auth),
+                        enable_payload: m.enable_payload,
                     })
                     .await
                     .is_ok()

--- a/crates/nyro-core/src/admin/models.rs
+++ b/crates/nyro-core/src/admin/models.rs
@@ -33,7 +33,8 @@ impl AdminService {
                 target_provider: primary_backend.provider_id.clone(),
                 target_model: primary_backend.model.clone(),
                 targets: vec![],
-                access_control: input.access_control,
+                enable_auth: input.enable_auth,
+                enable_payload: input.enable_payload,
             })
             .await?;
         if let Some(store) = self.gw.storage.model_backends() {
@@ -57,7 +58,8 @@ impl AdminService {
         let primary_backend = backends
             .first()
             .ok_or_else(|| anyhow::anyhow!("at least one model backend is required"))?;
-        let access_control = input.access_control.unwrap_or(current.access_control);
+        let enable_auth = input.enable_auth.unwrap_or(current.enable_auth);
+        let enable_payload = input.enable_payload.unwrap_or(current.enable_payload);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         self.gw
@@ -71,7 +73,8 @@ impl AdminService {
                     target_provider: Some(primary_backend.provider_id.clone()),
                     target_model: Some(primary_backend.model.clone()),
                     targets: None,
-                    access_control: Some(access_control),
+                    enable_auth: Some(enable_auth),
+                    enable_payload: Some(enable_payload),
                     is_enabled: Some(is_enabled),
                 },
             )

--- a/crates/nyro-core/src/db/mod.rs
+++ b/crates/nyro-core/src/db/mod.rs
@@ -100,6 +100,18 @@ pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
     // Merge virtual_model into name and drop the column
     migrate_merge_virtual_model_into_name(pool).await?;
 
+    // Rename access_control → enable_auth on models table
+    rename_column_if_needed(pool, "models", "access_control", "enable_auth").await?;
+
+    // Add enable_payload column to models table
+    ensure_model_column(pool, "enable_payload", "INTEGER").await?;
+
+    // Rename settings key log_record_payloads → enable_payload
+    sqlx::query("UPDATE settings SET key = 'enable_payload' WHERE key = 'log_record_payloads'")
+        .execute(pool)
+        .await
+        .ok();
+
     Ok(())
 }
 
@@ -331,6 +343,19 @@ async fn ensure_route_column(
 ) -> anyhow::Result<()> {
     if !column_exists(pool, "routes", column_name).await? {
         let sql = format!("ALTER TABLE routes ADD COLUMN {column_name} {definition}");
+        sqlx::query(&sql).execute(pool).await?;
+    }
+
+    Ok(())
+}
+
+async fn ensure_model_column(
+    pool: &SqlitePool,
+    column_name: &str,
+    definition: &str,
+) -> anyhow::Result<()> {
+    if !column_exists(pool, "models", column_name).await? {
+        let sql = format!("ALTER TABLE models ADD COLUMN {column_name} {definition}");
         sqlx::query(&sql).execute(pool).await?;
     }
 
@@ -762,7 +787,8 @@ CREATE TABLE IF NOT EXISTS routes (
     balance           TEXT DEFAULT 'weighted',
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,
-    access_control    INTEGER DEFAULT 0,
+    enable_auth       INTEGER DEFAULT 0,
+    enable_payload    INTEGER,
     is_enabled        INTEGER DEFAULT 1,
     priority          INTEGER DEFAULT 0,
     created_at        TEXT DEFAULT (datetime('now'))

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -112,7 +112,9 @@ pub struct Model {
     pub balance: String,
     pub target_provider: String,
     pub target_model: String,
-    pub access_control: bool,
+    #[serde(alias = "access_control")]
+    pub enable_auth: bool,
+    pub enable_payload: Option<bool>,
     pub is_enabled: bool,
     pub created_at: String,
     #[serde(default)]
@@ -304,7 +306,9 @@ pub struct UpdateModel {
     pub target_model: Option<String>,
     #[serde(default)]
     pub targets: Option<Vec<UpsertModelBackend>>,
-    pub access_control: Option<bool>,
+    #[serde(alias = "access_control")]
+    pub enable_auth: Option<bool>,
+    pub enable_payload: Option<Option<bool>>,
     pub is_enabled: Option<bool>,
 }
 
@@ -318,7 +322,9 @@ pub struct CreateModel {
     pub target_model: String,
     #[serde(default)]
     pub targets: Vec<CreateModelBackend>,
-    pub access_control: Option<bool>,
+    #[serde(alias = "access_control")]
+    pub enable_auth: Option<bool>,
+    pub enable_payload: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -475,8 +481,10 @@ pub struct ExportModel {
     #[serde(alias = "virtual_model")]
     pub name: String,
     pub target_model: String,
+    #[serde(alias = "access_control")]
+    pub enable_auth: bool,
     #[serde(default)]
-    pub access_control: bool,
+    pub enable_payload: Option<bool>,
     pub is_enabled: bool,
 }
 

--- a/crates/nyro-core/src/logging/mod.rs
+++ b/crates/nyro-core/src/logging/mod.rs
@@ -5,7 +5,7 @@ use crate::storage::DynStorage;
 
 const DEFAULT_RETENTION_DAYS: i64 = 7;
 const DEFAULT_RECORD_PAYLOADS: bool = true;
-pub const LOG_RECORD_PAYLOADS_KEY: &str = "log_record_payloads";
+pub const ENABLE_PAYLOAD_KEY: &str = "enable_payload";
 pub const LOG_RETENTION_DAYS_KEY: &str = "log_retention_days";
 
 #[derive(Debug, Clone)]
@@ -59,6 +59,11 @@ pub struct LogEntry {
     pub stream_chunks_count: i32,
     /// TTFB（ms）；非流式为 None
     pub stream_first_chunk_ms: Option<i64>,
+
+    // === 瞬态（不写入 DB） ===
+    /// Per-model enable_payload override.
+    /// None = use default (true), Some(true) = force on, Some(false) = force off.
+    pub enable_payload: Option<bool>,
 }
 
 impl LogEntry {
@@ -118,10 +123,10 @@ async fn cleanup_old_logs(storage: DynStorage) {
     }
 }
 
-async fn read_record_payloads(storage: &DynStorage) -> bool {
+async fn read_enable_payload(storage: &DynStorage) -> bool {
     storage
         .settings()
-        .get(LOG_RECORD_PAYLOADS_KEY)
+        .get(ENABLE_PAYLOAD_KEY)
         .await
         .ok()
         .flatten()
@@ -136,9 +141,11 @@ async fn read_record_payloads(storage: &DynStorage) -> bool {
 
 async fn flush(storage: DynStorage, buffer: &mut Vec<LogEntry>) {
     let mut entries = std::mem::take(buffer);
-    let record_payloads = read_record_payloads(&storage).await;
-    if !record_payloads {
-        for entry in entries.iter_mut() {
+    let global_enabled = read_enable_payload(&storage).await;
+    for entry in entries.iter_mut() {
+        // AND 语义：全局 OFF 则一切不记录，全局 ON 时按模型开关
+        let should_record = global_enabled && entry.enable_payload.unwrap_or(true);
+        if !should_record {
             entry.client_request_headers = None;
             entry.client_request_body = None;
             entry.client_response_headers = None;
@@ -148,6 +155,8 @@ async fn flush(storage: DynStorage, buffer: &mut Vec<LogEntry>) {
             entry.upstream_response_headers = None;
             entry.upstream_response_body = None;
         }
+        // Clear transient field before DB write
+        entry.enable_payload = None;
     }
     let _ = storage.logs().append_batch(entries).await;
 }

--- a/crates/nyro-core/src/proxy/dispatcher/auth.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/auth.rs
@@ -89,7 +89,7 @@ pub(super) async fn authorize_model_access<S: ProxyAccessStore + ?Sized>(
     model: &Model,
     headers: &HeaderMap,
 ) -> Result<AuthenticatedKey, Response> {
-    if !model.access_control {
+    if !model.enable_auth {
         return Ok(AuthenticatedKey {
             id: None,
             name: None,

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -359,6 +359,7 @@ pub async fn dispatch_pipeline(
             api_key_id: auth_key.id.as_deref(),
             api_key_name: auth_key.name.as_deref(),
             is_stream,
+            enable_payload: route.enable_payload,
             start,
         };
         let response = if is_stream {
@@ -477,6 +478,7 @@ struct CallCtx<'a> {
     api_key_id: Option<&'a str>,
     api_key_name: Option<&'a str>,
     is_stream: bool,
+    enable_payload: Option<bool>,
     start: Instant,
 }
 
@@ -513,6 +515,7 @@ struct LogBuilder {
     model_id: Option<String>,
     model_name: Option<String>,
     is_stream: bool,
+    enable_payload: Option<bool>,
     start: Instant,
     client_status_code: i32,
     usage: Usage,
@@ -535,6 +538,7 @@ impl LogBuilder {
             model_id: Some(call_ctx.model_id.to_string()),
             model_name: Some(call_ctx.model_name.to_string()),
             is_stream: call_ctx.is_stream,
+            enable_payload: call_ctx.enable_payload,
             start: call_ctx.start,
             client_status_code: 200,
             usage: Usage::default(),
@@ -565,6 +569,7 @@ impl LogBuilder {
             model_id: None,
             model_name: None,
             is_stream: false,
+            enable_payload: None,
             start,
             client_status_code: 200,
             usage: Usage::default(),
@@ -708,6 +713,7 @@ impl LogBuilder {
             is_stream: self.is_stream,
             stream_chunks_count: self.extras.stream_chunks_count,
             stream_first_chunk_ms: self.extras.stream_first_chunk_ms,
+            enable_payload: self.enable_payload,
         };
         send_log(&self.gw, entry);
     }

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -352,6 +352,7 @@ mod tests {
             api_key_id: None,
             api_key_name: None,
             is_stream: false,
+            enable_payload: None,
             start: std::time::Instant::now(),
         };
         let req_extras = RequestExtras {

--- a/crates/nyro-core/src/proxy/handler.rs
+++ b/crates/nyro-core/src/proxy/handler.rs
@@ -43,7 +43,7 @@ pub async fn models_list(State(gw): State<Gateway>, headers: HeaderMap) -> Respo
     let models = cache
         .models
         .iter()
-        .filter(|model| !model.access_control || accessible_route_ids.contains(&model.id))
+        .filter(|model| !model.enable_auth || accessible_route_ids.contains(&model.id))
         .map(|model| model.name.trim())
         .filter(|model| !model.is_empty())
         .map(ToString::to_string)

--- a/crates/nyro-core/src/proxy/security.rs
+++ b/crates/nyro-core/src/proxy/security.rs
@@ -120,7 +120,7 @@ pub async fn check_model_access(
     headers: &HeaderMap,
     ctx: &mut RequestContext,
 ) -> Result<AuthenticatedKey, GatewayError> {
-    if !model.access_control {
+    if !model.enable_auth {
         return Ok(AuthenticatedKey { id: None });
     }
 

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -470,14 +470,15 @@ impl ModelStore for PostgresModelStore {
     async fn create(&self, input: CreateModel) -> anyhow::Result<Model> {
         let id = uuid::Uuid::new_v4().to_string();
         sqlx::query(
-            "INSERT INTO models (id, name, balance, target_provider, target_model, access_control) VALUES ($1, $2, $3, $4, $5, $6)",
+            "INSERT INTO models (id, name, balance, target_provider, target_model, enable_auth, enable_payload) VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(&id)
         .bind(input.name.trim())
         .bind(input.balance.unwrap_or_else(|| "weighted".to_string()))
         .bind(input.target_provider.trim())
         .bind(input.target_model.trim())
-        .bind(input.access_control.unwrap_or(false))
+        .bind(input.enable_auth.unwrap_or(false))
+        .bind(input.enable_payload)
         .execute(&self.pool)
         .await?;
         self.get(&id).await?.context("model missing after create")
@@ -489,17 +490,19 @@ impl ModelStore for PostgresModelStore {
         let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
-        let access_control = input.access_control.unwrap_or(current.access_control);
+        let enable_auth = input.enable_auth.unwrap_or(current.enable_auth);
+        let enable_payload = input.enable_payload.unwrap_or(current.enable_payload);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE models SET name=$1, balance=$2, target_provider=$3, target_model=$4, access_control=$5, is_enabled=$6 WHERE id=$7",
+            "UPDATE models SET name=$1, balance=$2, target_provider=$3, target_model=$4, enable_auth=$5, enable_payload=$6, is_enabled=$7 WHERE id=$8",
         )
         .bind(name.trim())
         .bind(balance.trim().to_lowercase())
         .bind(target_provider.trim())
         .bind(target_model.trim())
-        .bind(access_control)
+        .bind(enable_auth)
+        .bind(enable_payload)
         .bind(is_enabled)
         .bind(id)
         .execute(&self.pool)
@@ -1246,6 +1249,23 @@ END $$;"#,
                 .await?;
         }
 
+        // Rename access_control → enable_auth on models table
+        pg_rename_column_if_needed(
+            self.adapter.pool(),
+            "models",
+            "access_control",
+            "enable_auth",
+        )
+        .await?;
+        sqlx::query("ALTER TABLE models ADD COLUMN IF NOT EXISTS enable_payload BOOLEAN")
+            .execute(self.adapter.pool())
+            .await?;
+        // Rename settings key log_record_payloads → enable_payload
+        sqlx::query("UPDATE settings SET key = 'enable_payload' WHERE key = 'log_record_payloads'")
+            .execute(self.adapter.pool())
+            .await
+            .ok();
+
         Ok(())
     }
 
@@ -1481,7 +1501,7 @@ fn provider_select(suffix: Option<&str>) -> String {
 
 fn model_select(suffix: Option<&str>) -> String {
     let mut sql = String::from(
-        "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, false) AS access_control, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
+        "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(enable_auth, false) AS enable_auth, enable_payload, COALESCE(is_enabled, TRUE) AS is_enabled, to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS created_at FROM models",
     );
     if let Some(suffix) = suffix {
         sql.push(' ');
@@ -1602,7 +1622,8 @@ CREATE TABLE IF NOT EXISTS routes (
     balance TEXT DEFAULT 'weighted',
     target_provider TEXT NOT NULL REFERENCES providers(id),
     target_model TEXT NOT NULL,
-    access_control BOOLEAN DEFAULT FALSE,
+    enable_auth BOOLEAN DEFAULT FALSE,
+    enable_payload BOOLEAN,
     is_enabled BOOLEAN DEFAULT TRUE,
     priority INTEGER DEFAULT 0,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -472,7 +472,7 @@ struct SqliteModelStore {
 impl ModelStore for SqliteModelStore {
     async fn list(&self) -> anyhow::Result<Vec<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
+            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(enable_auth, 0) AS enable_auth, enable_payload, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -480,7 +480,7 @@ impl ModelStore for SqliteModelStore {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Model>> {
         Ok(sqlx::query_as::<_, Model>(
-            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(access_control, 0) AS access_control, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
+            "SELECT id, name, COALESCE(balance, 'weighted') AS balance, target_provider, target_model, COALESCE(enable_auth, 0) AS enable_auth, enable_payload, COALESCE(is_enabled, 1) AS is_enabled, created_at FROM models WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -491,14 +491,15 @@ impl ModelStore for SqliteModelStore {
         let id = uuid::Uuid::new_v4().to_string();
         let balance = input.balance.unwrap_or_else(|| "weighted".to_string());
         sqlx::query(
-            "INSERT INTO models (id, name, balance, target_provider, target_model, access_control) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO models (id, name, balance, target_provider, target_model, enable_auth, enable_payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&id)
         .bind(input.name.trim())
         .bind(balance)
         .bind(input.target_provider.trim())
         .bind(input.target_model.trim())
-        .bind(input.access_control.unwrap_or(false))
+        .bind(input.enable_auth.unwrap_or(false))
+        .bind(input.enable_payload)
         .execute(&self.pool)
         .await?;
         self.get(&id).await?.context("model missing after create")
@@ -510,17 +511,19 @@ impl ModelStore for SqliteModelStore {
         let balance = input.balance.unwrap_or(current.balance);
         let target_provider = input.target_provider.unwrap_or(current.target_provider);
         let target_model = input.target_model.unwrap_or(current.target_model);
-        let access_control = input.access_control.unwrap_or(current.access_control);
+        let enable_auth = input.enable_auth.unwrap_or(current.enable_auth);
+        let enable_payload = input.enable_payload.unwrap_or(current.enable_payload);
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
 
         sqlx::query(
-            "UPDATE models SET name=?, balance=?, target_provider=?, target_model=?, access_control=?, is_enabled=? WHERE id=?",
+            "UPDATE models SET name=?, balance=?, target_provider=?, target_model=?, enable_auth=?, enable_payload=?, is_enabled=? WHERE id=?",
         )
         .bind(name.trim())
         .bind(balance.trim().to_lowercase())
         .bind(target_provider.trim())
         .bind(target_model.trim())
-        .bind(access_control)
+        .bind(enable_auth)
+        .bind(enable_payload)
         .bind(is_enabled)
         .bind(id)
         .execute(&self.pool)
@@ -566,7 +569,8 @@ impl ModelSnapshotStore for SqliteModelStore {
                 id, name,
                 COALESCE(balance, 'weighted') AS balance,
                 target_provider, target_model,
-                COALESCE(access_control, 0) AS access_control,
+                COALESCE(enable_auth, 0) AS enable_auth,
+                enable_payload,
                 COALESCE(is_enabled, 1) AS is_enabled,
                 created_at
             FROM models

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -87,7 +87,8 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
                     priority: Some(2),
                 },
             ],
-            access_control: Some(true),
+            enable_auth: Some(true),
+            enable_payload: None,
         })
         .await?;
 
@@ -116,7 +117,7 @@ async fn copy_provider_can_copy_matching_route_targets_to_copied_provider() -> a
         .expect("source route should remain");
     assert_eq!(updated_model.name, "source-model");
     assert_eq!(updated_model.balance, "priority");
-    assert!(updated_model.access_control);
+    assert!(updated_model.enable_auth);
     assert_eq!(updated_model.target_provider, original.id);
     assert_eq!(updated_model.target_model, "source-upstream-model");
     assert_eq!(updated_model.targets.len(), 3);
@@ -157,7 +158,8 @@ async fn copy_provider_does_not_append_targets_by_default() -> anyhow::Result<()
             target_provider: original.id.clone(),
             target_model: "source-upstream-model".to_string(),
             targets: vec![],
-            access_control: None,
+            enable_auth: None,
+            enable_payload: None,
         })
         .await?;
 
@@ -191,7 +193,8 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
             target_provider: removed_provider.id.clone(),
             target_model: "gpt-delete".to_string(),
             targets: vec![],
-            access_control: None,
+            enable_auth: None,
+            enable_payload: None,
         })
         .await?;
     let kept_route = gw
@@ -215,7 +218,8 @@ async fn delete_provider_removes_route_associations_before_provider() -> anyhow:
                     priority: Some(2),
                 },
             ],
-            access_control: None,
+            enable_auth: None,
+            enable_payload: None,
         })
         .await?;
 

--- a/crates/nyro-core/tests/logging_spec.rs
+++ b/crates/nyro-core/tests/logging_spec.rs
@@ -141,6 +141,7 @@ fn log_entry_timestamp_is_unix_millis() {
         is_stream: false,
         stream_chunks_count: 0,
         stream_first_chunk_ms: None,
+        enable_payload: None,
     };
 }
 
@@ -182,6 +183,7 @@ fn stream_indicator_via_chunks_count() {
         is_stream: false,
         stream_chunks_count: 0,
         stream_first_chunk_ms: None,
+        enable_payload: None,
     };
 
     // Non-streaming: chunks == 0

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -57,7 +57,8 @@ AI 模型供应商配置（API endpoint、密钥、认证方式等）。
 | `balance` | TEXT | `'weighted'` | 多后端负载均衡策略：`weighted`、`priority`、`cooldown`、`latency` |
 | `target_provider` | TEXT NOT NULL | — | 默认后端 provider ID（FK → providers.id） |
 | `target_model` | TEXT NOT NULL | — | 默认后端使用的上游模型名 |
-| `access_control` | INTEGER | `0` | 是否启用 API Key 访问控制 |
+| `enable_auth` | INTEGER | `0` | 是否启用 API Key 访问控制 |
+| `enable_payload` | INTEGER | — | 是否记录载荷（headers/bodies）。NULL = 默认记录（受全局 `enable_payload` 开关控制） |
 | `is_enabled` | INTEGER | `1` | 是否启用 |
 | `priority` | INTEGER | `0` | 优先级（预留） |
 | `created_at` | TEXT | `datetime('now')` | 创建时间 |
@@ -106,7 +107,7 @@ API 密钥管理，用于代理端口的访问认证和限流。
 
 ## api_key_models
 
-API Key 与模型的访问绑定关系（M:N 关联表）。仅当 model 启用 `access_control` 时生效。
+API Key 与模型的访问绑定关系（M:N 关联表）。仅当 model 启用 `enable_auth` 时生效。
 
 | Column | Type | Description |
 |---|---|---|

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -467,7 +467,8 @@ trait VendorExtension: Send + Sync {
 | `ingress_protocol` | TEXT | 接入协议（canonical ProtocolId） |
 | `target_provider` | TEXT FK | 目标模型提供商 |
 | `target_model` | TEXT | 实际调用的模型 |
-| `access_control` | BOOLEAN | 是否启用访问控制，默认 false |
+| `enable_auth` | BOOLEAN | 是否启用访问控制，默认 false |
+| `enable_payload` | BOOLEAN | 是否记录载荷（headers/bodies），NULL 时受全局开关控制 |
 | `is_active` | BOOLEAN | 路由启用状态，默认 true |
 
 `name` 同时承担显示名称和路由匹配键两个角色。当客户端请求中的 `model` 值与某条路由的 `name` 精确匹配时，该路由被命中，请求被转发到 `target_provider` 的 `target_model`。
@@ -494,7 +495,7 @@ Key 格式：`sk-<32位hex>`，AES-256-GCM 加密存储。
    (优先级: Authorization: Bearer > x-api-key)
 2. match(ingress_protocol, model) → Route
    └── 未匹配 → GatewayError::RouteNotFound (404)
-3. if route.access_control == false:
+3. if route.enable_auth == false:
    └── 直接放行
 4. if api_key 为空 → GatewayError::Unauthorized (401)
 5. 验证 api_key:
@@ -556,7 +557,7 @@ CREATE TABLE routes (
     ingress_protocol  TEXT NOT NULL,   -- canonical ProtocolId
     target_provider   TEXT NOT NULL REFERENCES providers(id),
     target_model      TEXT NOT NULL,
-    access_control    INTEGER NOT NULL DEFAULT 0,
+    access_control    INTEGER NOT NULL DEFAULT 0,  -- renamed to enable_auth
     is_active         INTEGER NOT NULL DEFAULT 1,
     UNIQUE(ingress_protocol, name)
 );

--- a/docs/standalone/README.md
+++ b/docs/standalone/README.md
@@ -159,7 +159,7 @@ routes:
 | `type` | — | 否 | 路由类型：`chat`（默认）/ `embedding` |
 | `strategy` | — | 否 | 负载策略：`weighted`（默认）/ `priority` |
 | `targets` | — | 是 | 目标列表（至少一个） |
-| `access_control` | — | 否 | 是否启用访问控制（默认 `false`） |
+| `access_control` | — | 否 | 是否启用访问控制（默认 `false`）。别名 `enable_auth` |
 
 ### routes[].targets[]
 

--- a/src-server/src/yaml_config.rs
+++ b/src-server/src/yaml_config.rs
@@ -145,8 +145,8 @@ pub struct YamlModel {
     pub balance: String,
     #[serde(default, rename = "backends", alias = "targets")]
     pub backends: Vec<YamlModelBackend>,
-    #[serde(default)]
-    pub access_control: bool,
+    #[serde(default, alias = "access_control")]
+    pub enable_auth: bool,
     // Deprecated: route_type / type was removed; captured here only to emit a warning.
     #[serde(default, alias = "type")]
     pub route_type: Option<String>,
@@ -349,7 +349,8 @@ pub fn build_models(yaml: &YamlConfig, providers: &[Provider]) -> Vec<Model> {
                 balance: ym.balance.clone(),
                 target_provider: primary.map(|b| b.provider_id.clone()).unwrap_or_default(),
                 target_model: primary.map(|b| b.model.clone()).unwrap_or_default(),
-                access_control: ym.access_control,
+                enable_auth: ym.enable_auth,
+                enable_payload: None,
                 is_enabled: true,
                 created_at: now,
                 targets: backends,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -26,7 +26,8 @@ export interface Model {
   balance: ModelBalance;
   target_provider: string;
   target_model: string;
-  access_control: boolean;
+  enable_auth: boolean;
+  enable_payload?: boolean | null;
   is_enabled: boolean;
   created_at: string;
   targets: ModelBackend[];
@@ -232,7 +233,8 @@ export interface CreateModel {
   target_provider: string;
   target_model: string;
   targets?: CreateModelBackend[];
-  access_control?: boolean;
+  enable_auth?: boolean;
+  enable_payload?: boolean | null;
 }
 
 export interface UpdateModel {
@@ -241,7 +243,8 @@ export interface UpdateModel {
   target_provider?: string;
   target_model?: string;
   targets?: UpsertModelBackend[];
-  access_control?: boolean;
+  enable_auth?: boolean;
+  enable_payload?: boolean | null;
   is_enabled?: boolean;
 }
 
@@ -313,7 +316,8 @@ export interface ExportProvider {
 export interface ExportModel {
   name: string;
   target_model: string;
-  access_control: boolean;
+  enable_auth: boolean;
+  enable_payload?: boolean | null;
   is_enabled: boolean;
 }
 

--- a/webui/src/pages/connect.tsx
+++ b/webui/src/pages/connect.tsx
@@ -508,7 +508,7 @@ export default function ConnectPage() {
   }, [apiKeys, selectedRoute]);
 
   useEffect(() => {
-    if (!selectedRoute?.access_control) {
+    if (!selectedRoute?.enable_auth) {
       setSelectedCodeKeyId("");
       return;
     }
@@ -523,7 +523,7 @@ export default function ConnectPage() {
   );
 
   const codeEffectiveApiKey =
-    selectedRoute?.access_control ? selectedApiKey?.key ?? UNSELECTED_KEY_PLACEHOLDER : OPTIONAL_KEY_PLACEHOLDER;
+    selectedRoute?.enable_auth ? selectedApiKey?.key ?? UNSELECTED_KEY_PLACEHOLDER : OPTIONAL_KEY_PLACEHOLDER;
   const proxyPort = status?.proxy_port;
   const hasProxyPort = typeof proxyPort === "number" && Number.isFinite(proxyPort) && proxyPort > 0;
   const host = hasProxyPort ? `http://localhost:${proxyPort}` : "http://localhost:<proxy-port>";
@@ -565,7 +565,7 @@ export default function ConnectPage() {
   }, [cliRouteAnchorByTool, cliRoutes, selectedCliTool.id, selectedCliRouteId, tab]);
 
   useEffect(() => {
-    if (!selectedCliRoute?.access_control) {
+    if (!selectedCliRoute?.enable_auth) {
       setSelectedCliKeyId("");
       return;
     }
@@ -599,7 +599,7 @@ export default function ConnectPage() {
     staleTime: 60_000,
   });
   const cliEffectiveApiKey =
-    selectedCliRoute?.access_control
+    selectedCliRoute?.enable_auth
       ? selectedCliApiKey?.key ?? UNSELECTED_KEY_PLACEHOLDER
       : OPTIONAL_KEY_PLACEHOLDER;
   const cliModel = selectedCliRoute?.name ?? "gpt-4o";
@@ -608,7 +608,7 @@ export default function ConnectPage() {
     hasProxyPort &&
     selectedCliReady &&
     Boolean(selectedCliRoute) &&
-    (!selectedCliRoute?.access_control || Boolean(selectedCliApiKey));
+    (!selectedCliRoute?.enable_auth || Boolean(selectedCliApiKey));
 
   const generatedCode = codeTemplate({
     protocol: codeProtocol,
@@ -858,7 +858,7 @@ export default function ConnectPage() {
                       </div>
                     )}
                   </div>
-                  {selectedCliRoute?.access_control && (
+                  {selectedCliRoute?.enable_auth && (
                     <div className="space-y-2">
                       <p className="ml-1 text-xs leading-none font-normal text-slate-900">
                         {isZh ? "选择 API Key" : "Select API Key"}
@@ -983,7 +983,7 @@ export default function ConnectPage() {
                       : "No chat models available. Create a chat model first."}
                   </p>
                 )}
-                {selectedCliRoute?.access_control && !selectedCliApiKey && (
+                {selectedCliRoute?.enable_auth && !selectedCliApiKey && (
                   <p className="text-xs text-amber-600">
                     {isZh
                       ? "当前模型开启了访问控制，请先选择 API Key 再同步。"
@@ -1077,7 +1077,7 @@ export default function ConnectPage() {
                   />
                 </div>
 
-                {selectedRoute?.access_control && (
+                {selectedRoute?.enable_auth && (
                   <div className="space-y-2">
                     <p className="ml-1 text-xs leading-none font-normal text-slate-900">
                       {isZh ? "选择 API Key" : "Select API Key"}
@@ -1138,7 +1138,7 @@ export default function ConnectPage() {
                 </p>
               )}
 
-              {selectedRoute && !selectedRoute.access_control && (
+              {selectedRoute && !selectedRoute.enable_auth && (
                 <p className="text-xs text-slate-500">
                   {isZh
                     ? `当前模型未开启访问控制，示例中已使用占位 API Key：${OPTIONAL_KEY_PLACEHOLDER}`

--- a/webui/src/pages/models.tsx
+++ b/webui/src/pages/models.tsx
@@ -36,7 +36,8 @@ type ModelForm = {
   name: string;
   balance: ModelBalance;
   targets: ModelBackendForm[];
-  access_control: boolean;
+  enable_auth: boolean;
+  enable_payload: boolean;
 };
 
 type ModelBackendForm = {
@@ -51,7 +52,8 @@ const emptyCreate: ModelForm = {
   name: "",
   balance: "weighted",
   targets: [{ provider_id: "", model: "", weight: 100, priority: 1 }],
-  access_control: false,
+  enable_auth: false,
+  enable_payload: false,
 };
 
 function FieldLabel({ children }: { children: string }) {
@@ -342,6 +344,13 @@ export default function ModelsPage() {
     queryKey: ["providers"],
     queryFn: () => backend("get_providers"),
   });
+  const { data: globalEnablePayload } = useQuery<string | null>({
+    queryKey: ["setting", "enable_payload"],
+    queryFn: () => backend("get_setting", { key: "enable_payload" }),
+  });
+  const globalPayloadEnabled = !["false", "0", "off", "no"].includes(
+    (globalEnablePayload ?? "true").trim().toLowerCase(),
+  );
 
   const createMut = useMutation({
     mutationFn: (input: CreateModel) => backend("create_model", { input }),
@@ -416,7 +425,8 @@ export default function ModelsPage() {
       name: route.name,
       balance: route.balance ?? "weighted",
       targets,
-      access_control: route.access_control,
+      enable_auth: route.enable_auth,
+      enable_payload: route.enable_payload ?? false,
     });
   }
 
@@ -553,12 +563,23 @@ export default function ModelsPage() {
             <ModelToggleControl
               title={isZh ? "访问控制" : "Access Control"}
               isZh={isZh}
-              checked={createForm.access_control}
+              checked={createForm.enable_auth}
               checkedMessage={isZh ? "仅允许绑定模型的 API Key 访问" : "Only API keys bound to this model are allowed"}
               uncheckedMessage={isZh ? "仅允许携带 API Key 的请求访问" : "Only requests with an API key are allowed"}
-              switchId="create-route-access-control"
-              onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, access_control: checked }))}
+              switchId="create-route-enable-auth"
+              onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, enable_auth: checked }))}
             />
+            {globalPayloadEnabled && (
+              <ModelToggleControl
+                title={isZh ? "记录载荷" : "Record Payloads"}
+                isZh={isZh}
+                checked={createForm.enable_payload}
+                checkedMessage={isZh ? "记录完整的请求与响应内容" : "Log full request and response content"}
+                uncheckedMessage={isZh ? "仅记录 Token 用量等基础指标" : "Only basic metrics are logged"}
+                switchId="create-route-enable-payload"
+                onCheckedChange={(checked) => setCreateForm((prev) => ({ ...prev, enable_payload: checked }))}
+              />
+            )}
           </div>
           <div className="flex gap-3">
             <Button
@@ -676,13 +697,25 @@ export default function ModelsPage() {
                     <ModelToggleControl
                       title={isZh ? "访问控制" : "Access Control"}
                       isZh={isZh}
-                      checked={editForm.access_control}
+                      checked={editForm.enable_auth}
                       checkedMessage={isZh ? "仅允许绑定模型的 API Key 访问" : "Only API keys bound to this model are allowed"}
                       uncheckedMessage={isZh ? "仅允许携带 API Key 的请求访问" : "Only requests with an API key are allowed"}
                       onCheckedChange={(checked) =>
-                        setEditForm((prev) => (prev ? { ...prev, access_control: checked } : prev))
+                        setEditForm((prev) => (prev ? { ...prev, enable_auth: checked } : prev))
                       }
                     />
+                    {globalPayloadEnabled && (
+                      <ModelToggleControl
+                        title={isZh ? "记录载荷" : "Record Payloads"}
+                        isZh={isZh}
+                        checked={editForm.enable_payload}
+                        checkedMessage={isZh ? "记录完整的请求与响应内容" : "Log full request and response content"}
+                        uncheckedMessage={isZh ? "仅记录 Token 用量等基础指标" : "Only basic metrics are logged"}
+                        onCheckedChange={(checked) =>
+                          setEditForm((prev) => (prev ? { ...prev, enable_payload: checked } : prev))
+                        }
+                      />
+                    )}
                   </div>
                   <div className="flex gap-3">
                     <Button
@@ -734,9 +767,14 @@ export default function ModelsPage() {
                     >
                       {balanceLabel(route.balance ?? "weighted", isZh)}
                     </Badge>
-                    {route.access_control && (
+                    {route.enable_auth && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? "鉴权" : "Auth"}
+                      </Badge>
+                    )}
+                    {route.enable_payload === false && (
+                      <Badge variant="danger" className="connect-label-badge">
+                        {isZh ? "不记录载荷" : "No Payloads"}
                       </Badge>
                     )}
                     {!route.is_enabled && (
@@ -875,7 +913,8 @@ function buildCreatePayload(form: ModelForm): CreateModel {
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,
-    access_control: form.access_control,
+    enable_auth: form.enable_auth,
+    enable_payload: form.enable_payload,
   };
 }
 
@@ -894,6 +933,7 @@ function buildUpdatePayload(form: ModelForm & { id: string }): UpdateModel {
     targets,
     target_provider: primary.provider_id,
     target_model: primary.model,
-    access_control: form.access_control,
+    enable_auth: form.enable_auth,
+    enable_payload: form.enable_payload,
   };
 }

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -75,8 +75,8 @@ export default function SettingsPage() {
     queryFn: () => backend("get_setting", { key: "log_retention_days" }),
   });
   const { data: logRecordPayloadsSetting } = useQuery<string | null>({
-    queryKey: ["setting", "log_record_payloads"],
-    queryFn: () => backend("get_setting", { key: "log_record_payloads" }),
+    queryKey: ["setting", "enable_payload"],
+    queryFn: () => backend("get_setting", { key: "enable_payload" }),
   });
   const { data: proxyEnabledSetting } = useQuery<string | null>({
     queryKey: ["setting", "proxy_enabled"],
@@ -140,8 +140,8 @@ export default function SettingsPage() {
   });
   const saveLogRecordPayloads = useMutation({
     mutationFn: (value: boolean) =>
-      backend("set_setting", { key: "log_record_payloads", value: value ? "true" : "false" }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["setting", "log_record_payloads"] }),
+      backend("set_setting", { key: "enable_payload", value: value ? "true" : "false" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["setting", "enable_payload"] }),
     onError: (error: unknown) => {
       showErrorDialog("保存设置失败", "Failed to save settings", error);
     },
@@ -353,12 +353,12 @@ export default function SettingsPage() {
             </div>
             <div className="space-y-1.5">
               <label className="ml-1 flex items-center gap-1 text-xs text-slate-700">
-                {isZh ? "记录 Payloads" : "Record Payloads"}
+                {isZh ? "记录载荷" : "Record Payloads"}
                 <HelpHint
                   text={
                     isZh
-                      ? "关闭后不再记录请求头、请求体、响应头和响应体"
-                      : "When off, request/response headers and bodies are no longer recorded"
+                      ? "总开关，关闭后所有模型均不记录载荷。开启后可在单个模型中按需关闭"
+                      : "Master switch — when off, no payloads are recorded. When on, individual models can opt out"
                   }
                 />
               </label>


### PR DESCRIPTION
## Summary

将 payload 记录从全局开关迁移为 **全局总开关 + 按模型精细控制** 的分层配置，并统一 `enable_*` 命名体系。

### 核心变更

1. **新增 `enable_payload` 字段**（`models` 表）
   - AND 语义：`global.enable_payload && model.enable_payload.unwrap_or(true)`
   - 全局 OFF → 一切不记录（kill switch）
   - 全局 ON → 模型可独立关闭

2. **重命名 `access_control` → `enable_auth`**
   - 统一 `enable_auth` / `enable_payload` / `is_enabled` 命名风格
   - 通过 `#[serde(alias = "access_control")]` 保持 API 向后兼容

3. **重命名全局 setting key**
   - `log_record_payloads` → `enable_payload`
   - 与模型字段同名，概念对齐

### 语义表

| 全局 `enable_payload` | 模型 `enable_payload` | 结果 |
|----------------------|----------------------|------|
| OFF | 任意 | **不记录** |
| ON | ON / NULL | **记录** |
| ON | OFF | **不记录** |

### 前端
- 模型创建/编辑表单新增「记录载荷」toggle
- 全局关闭时自动隐藏模型级 toggle
- Settings 页面文案更新为「总开关」说明

### 向后兼容
- 数据库 migration 自动 rename/add column
- `#[serde(alias)]` 接受旧 API 字段名
- YAML 配置支持旧字段名
- 现有模型的 NULL 值默认记录（行为不变）

### Changed files (22)
- **数据库**: `db/mod.rs`, `storage/sqlite/mod.rs`, `storage/postgres/mod.rs`
- **数据结构**: `db/models.rs`, `logging/mod.rs`
- **日志管道**: `proxy/dispatcher/mod.rs`, `non_stream.rs`
- **业务层**: `admin/models.rs`, `import_export.rs`, `security.rs`, `handler.rs`, `auth.rs`
- **配置**: `yaml_config.rs`
- **前端**: `types.ts`, `models.tsx`, `connect.tsx`, `settings.tsx`
- **文档**: `schema.md`, `architecture.md`, `standalone/README.md`