### PR TITLE
style(webui): use code label style for model name in model list

### DIFF
--- a/webui/src/pages/models.tsx
+++ b/webui/src/pages/models.tsx
@@ -755,7 +755,7 @@ export default function ModelsPage() {
                   </div>
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
-                      <span className="inline-flex h-5 items-center font-semibold text-slate-900">{route.name}</span>
+                      <code className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600">{route.name}</code>
                     {route.targets && route.targets.length > 1 && (
                       <Badge variant="success" className="connect-label-badge">
                         {isZh ? `共 ${route.targets.length} 个目标` : `${route.targets.length} Targets`}


### PR DESCRIPTION
## Changes

- 将模型列表中「名称」的展示样式从普通粗体文本改为 `<code>` 标签样式（圆角灰色背景），与提供商列表中「厂商」的 Label 样式保持一致。

## Before

`route.name` 渲染为 `<span font-semibold>`，纯文本效果。

## After

`route.name` 渲染为 `<code rounded bg-slate-100>`，标签（Tag）效果。