### PR TITLE
chore: remove 8 unused Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,15 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,28 +230,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1266,17 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,12 +1752,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "glob-match"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "gobject-sys"
@@ -2703,12 +2655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,16 +2745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,8 +2832,6 @@ name = "nyro-core"
 version = "1.7.6"
 dependencies = [
  "anyhow",
- "arc-swap",
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -2905,10 +2839,8 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs 6.0.0",
- "eventsource-stream",
  "futures",
  "gcp_auth",
- "glob-match",
  "inventory",
  "rand 0.8.5",
  "reqwest 0.12.28",
@@ -2938,7 +2870,6 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
- "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2969,7 +2900,6 @@ name = "nyro-tools"
 version = "1.7.6"
 dependencies = [
  "anyhow",
- "async-trait",
  "axum",
  "base64 0.22.1",
  "bytes",
@@ -2980,9 +2910,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/crates/nyro-core/Cargo.toml
+++ b/crates/nyro-core/Cargo.toml
@@ -20,19 +20,15 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 
-eventsource-stream = "0.2"
-async-stream = "0.3"
 tokio-stream = "0.1"
 futures = "0.3"
 bytes = "1"
-glob-match = "0.2"
 dirs = "6"
 base64 = "0.22"
 rand = "0.8"
 sha2 = "0.10"
 dashmap = "6"
 inventory = "0.3"
-arc-swap = "1"
 gcp_auth = "0.12.6"
 
 [dev-dependencies]

--- a/crates/nyro-tools/Cargo.toml
+++ b/crates/nyro-tools/Cargo.toml
@@ -19,14 +19,11 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
-async-trait = { workspace = true }
 
 clap = { version = "4", features = ["derive", "env"] }
 base64 = "0.22"
 bytes = "1"
 futures = "0.3"
-tokio-stream = "0.1"
 walkdir = "2"
 url = "2"
 uuid = { workspace = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,6 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
-tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary

Remove unused Rust dependencies detected by `cargo-machete` and verified manually.

## Removed

| Crate | Dependencies Removed |
|---|---|
| **nyro-core** | `arc-swap`, `async-stream`, `eventsource-stream`, `glob-match` |
| **nyro-tools** | `async-trait`, `thiserror`, `tokio-stream` |
| **nyro-desktop** | `tokio` |

**Note:** `futures` in nyro-core was flagged by `cargo-machete` but is actually used (`futures::StreamExt`), so it was kept.

## Verification

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (259 tests passed)