### PR TITLE
fix(ci): sync storage e2e harness with renamed struct fields and add MySQL backend

### DIFF
--- a/.github/workflows/storage-backends.yml
+++ b/.github/workflows/storage-backends.yml
@@ -2,14 +2,14 @@ name: Storage Backends
 
 on:
   schedule:
-    # Daily at 03:00 UTC — runs against both SQLite and pgvector/Postgres.
+    # Daily at 03:00 UTC — runs against SQLite, Postgres, and MySQL.
     - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       backend:
-        description: 'Backend(s) to test: sqlite, postgres, or both'
+        description: 'Backend(s) to test: sqlite, postgres, mysql, or all'
         required: false
-        default: 'sqlite postgres'
+        default: 'sqlite postgres mysql'
 
 concurrency:
   group: storage-backends-${{ github.ref }}
@@ -23,7 +23,7 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: postgres:16
         env:
           POSTGRES_USER: nyro
           POSTGRES_PASSWORD: nyro
@@ -32,6 +32,21 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: nyro
+          MYSQL_DATABASE: nyro_test
+          MYSQL_USER: nyro
+          MYSQL_PASSWORD: nyro
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -58,7 +73,12 @@ jobs:
       - name: Run storage E2E tests (sqlite)
         run: python3 -m pytest tests/e2e/storage/test_storage.py -vv -s -rA -m storage -k sqlite
 
-      - name: Run storage E2E tests (postgres / pgvector)
+      - name: Run storage E2E tests (postgres)
         run: python3 -m pytest tests/e2e/storage/test_storage.py -vv -s -rA -m storage -k postgres
         env:
           DB_URL: postgresql://nyro:nyro@localhost:5432/nyro_test
+
+      - name: Run storage E2E tests (mysql)
+        run: python3 -m pytest tests/e2e/storage/test_storage.py -vv -s -rA -m storage -k mysql
+        env:
+          MYSQL_URL: mysql://nyro:nyro@localhost:3306/nyro_test

--- a/tests/e2e/storage/conftest.py
+++ b/tests/e2e/storage/conftest.py
@@ -47,6 +47,24 @@ def load_pg_url() -> str | None:
     return None
 
 
+def load_mysql_url() -> str | None:
+    for key in ("MYSQL_URL",):
+        value = os.environ.get(key)
+        if value:
+            return value
+
+    env_file = REPO_ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            key, value = stripped.split("=", 1)
+            if key.strip() == "MYSQL_URL":
+                return value.strip().strip("'\"")
+    return None
+
+
 class _MockHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -108,7 +126,7 @@ def build_harness(work_dir: Path) -> None:
         nyro-core = {{ path = "{REPO_ROOT / 'crates/nyro-core'}" }}
         reqwest = {{ version = "0.12", features = ["json"] }}
         serde_json = "1"
-        sqlx = {{ version = "0.8", features = ["runtime-tokio", "postgres"] }}
+        sqlx = {{ version = "0.8", features = ["runtime-tokio", "postgres", "mysql"] }}
         tokio = {{ version = "1", features = ["macros", "rt-multi-thread", "time"] }}
         """
     ).strip() + "\n"
@@ -125,6 +143,7 @@ def build_harness(work_dir: Path) -> None:
         use nyro_core::{logging, Gateway};
         use reqwest::StatusCode;
         use sqlx::postgres::PgPoolOptions;
+        use sqlx::mysql::MySqlPoolOptions;
 
         #[tokio::main]
         async fn main() -> anyhow::Result<()> {
@@ -170,6 +189,14 @@ def build_harness(work_dir: Path) -> None:
                         ..Default::default()
                     };
                 }
+                "mysql" => {
+                    let mysql_url = env::var("NYRO_STORAGE_MYSQL_URL").context("NYRO_STORAGE_MYSQL_URL")?;
+                    config.storage.backend = StorageBackendKind::Mysql;
+                    config.storage.mysql = SqlStorageConfig {
+                        url: Some(mysql_url),
+                        ..Default::default()
+                    };
+                }
                 other => anyhow::bail!("unknown backend: {other}"),
             }
 
@@ -198,7 +225,8 @@ def build_harness(work_dir: Path) -> None:
                 target_provider: provider.id.clone(),
                 target_model: "gpt-4o-mini".to_string(),
                 targets: vec![],
-                access_control: Some(true),
+                enable_auth: Some(true),
+                enable_payload: None,
             }).await?;
 
             let api_key = admin.create_api_key(CreateApiKey {
@@ -225,7 +253,7 @@ def build_harness(work_dir: Path) -> None:
             let no_key = client.post(&url).json(&payload).send().await?;
             ensure!(no_key.status() == StatusCode::UNAUTHORIZED, "missing key should 401");
 
-            let ok = client.post(&url).bearer_auth(&api_key.key).json(&payload).send().await?;
+            let ok = client.post(&url).bearer_auth(&api_key.token).json(&payload).send().await?;
             ensure!(ok.status() == StatusCode::OK, "valid key should 200");
             let body: serde_json::Value = ok.json().await?;
             ensure!(body["choices"][0]["message"]["content"].as_str() == Some("ok"), "content mismatch");
@@ -264,6 +292,7 @@ def run_harness(
     upstream_port: int,
     work_dir: Path,
     pg_url: str | None = None,
+    mysql_url: str | None = None,
 ) -> str:
     env = os.environ.copy()
     env["NYRO_STORAGE_BACKEND"] = backend
@@ -276,6 +305,11 @@ def run_harness(
             raise RuntimeError("postgres backend requires DB_URL or DATABASE_URL")
         env["NYRO_STORAGE_PG_URL"] = pg_url
         env["NYRO_STORAGE_PG_SCHEMA"] = make_isolated_schema()
+
+    if backend == "mysql":
+        if not mysql_url:
+            raise RuntimeError("mysql backend requires MYSQL_URL")
+        env["NYRO_STORAGE_MYSQL_URL"] = mysql_url
 
     proc = subprocess.run(
         ["cargo", "run", "--quiet", "--manifest-path", str(work_dir / "Cargo.toml")],
@@ -305,6 +339,7 @@ def storage_runtime() -> dict[str, object]:
                 "upstream_port": upstream_port,
                 "work_dir": tmpdir,
                 "pg_url": load_pg_url(),
+                "mysql_url": load_mysql_url(),
                 "run_harness": run_harness,
             }
     finally:

--- a/tests/e2e/storage/test_storage.py
+++ b/tests/e2e/storage/test_storage.py
@@ -7,11 +7,15 @@ import pytest
 
 @pytest.mark.e2e
 @pytest.mark.storage
-@pytest.mark.parametrize("backend", ["sqlite", "postgres"], ids=["sqlite", "postgres"])
+@pytest.mark.parametrize("backend", ["sqlite", "postgres", "mysql"], ids=["sqlite", "postgres", "mysql"])
 def test_storage_backend_equivalence(storage_runtime: dict[str, object], backend: str) -> None:
     pg_url = storage_runtime["pg_url"]
+    mysql_url = storage_runtime["mysql_url"]
+
     if backend == "postgres" and not pg_url:
         pytest.skip("postgres backend requires DB_URL or DATABASE_URL")
+    if backend == "mysql" and not mysql_url:
+        pytest.skip("mysql backend requires MYSQL_URL")
 
     run_harness: Callable[..., str] = storage_runtime["run_harness"]  # type: ignore[assignment]
     output = run_harness(
@@ -19,6 +23,7 @@ def test_storage_backend_equivalence(storage_runtime: dict[str, object], backend
         upstream_port=storage_runtime["upstream_port"],
         work_dir=storage_runtime["work_dir"],
         pg_url=pg_url,
+        mysql_url=mysql_url,
     )
 
     assert f"backend={backend}" in output


### PR DESCRIPTION
## Summary

Fix the storage E2E test harness which broke after recent struct field renames, and add MySQL backend coverage.

## Changes

### Bug fixes
- `CreateModel`: `access_control` → `enable_auth` (serde alias not valid in Rust struct literal), added missing `enable_payload` field
- `ApiKeyWithBindings`: `.key` → `.token` (field was renamed)

### MySQL support
- Added MySQL backend branch in `conftest.py` harness (`NYRO_STORAGE_MYSQL_URL`)
- Added `load_mysql_url()` helper
- Added `"mysql"` to parametrized test in `test_storage.py`
- Added MySQL 8 service container and test step in `storage-backends.yml`

### CI cleanup
- Replaced `pgvector/pgvector:pg16` image with `postgres:16` (pgvector extension is not used by the codebase)

## Verification

- Python syntax validated for both `conftest.py` and `test_storage.py`
- CI will validate full build + test across all three backends