### PR TITLE
feat: multi-replica production readiness (config epoch sync, health probes, webui-dir)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,6 +1975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2659,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -5741,11 +5757,20 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5927,6 +5952,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,35 @@ export NYRO_MYSQL_DSN="mysql://user:pass@host:3306/db"
 ./nyro-server-linux-x86_64 --storage-backend mysql
 ```
 
+### Multi-replica Production Deployment
+
+When running multiple `nyro-server` replicas behind a load balancer, all replicas **must** share the same database and the same admin token:
+
+| Requirement | Detail |
+|---|---|
+| Shared DB | Use `--storage-backend postgres` or `mysql` pointing to the same DSN across all replicas. SQLite cannot be shared. |
+| Unified admin token | Set the same `--admin-token` / `NYRO_ADMIN_TOKEN` on every replica. |
+| Config sync | Replicas poll the shared DB for config changes every `--config-poll-interval` seconds (default: 3 s). Route/model/provider changes propagate within one poll interval. |
+| OAuth interactive flows | The OAuth authorization callback must reach the **same replica** that initiated the session. Configure sticky sessions (session affinity) on your load balancer for the admin port (`19531`). |
+
+**Health probes:**
+
+| Endpoint | Port | Use |
+|---|---|---|
+| `GET /healthz` | proxy + admin | Liveness — always `200` |
+| `GET /readyz` | proxy + admin | Readiness — `200` if DB reachable, `503` otherwise |
+
+**Key environment variables:**
+
+```bash
+NYRO_ADMIN_TOKEN=<secret>          # Required when admin host is not loopback
+NYRO_STORAGE_BACKEND=postgres      # postgres | mysql | sqlite (default)
+NYRO_POSTGRES_DSN=postgres://...   # Required when backend=postgres
+NYRO_MYSQL_DSN=mysql://...         # Required when backend=mysql
+NYRO_CONFIG_POLL_INTERVAL=3        # Seconds between config epoch polls (default: 3, 0=disabled)
+NYRO_WEBUI_DIR=/path/to/dist       # Serve WebUI from external directory instead of embedded assets
+```
+
 ### Docker
 
 Pre-built server images are distributed via the separate [nyroway/docker-nyro](https://github.com/nyroway/docker-nyro) repository and published to Docker Hub as [nyroway/nyro](https://hub.docker.com/r/nyroway/nyro).

--- a/README_CN.md
+++ b/README_CN.md
@@ -240,6 +240,35 @@ export NYRO_MYSQL_DSN="mysql://user:pass@host:3306/db"
 ./nyro-server-linux-x86_64 --storage-backend mysql
 ```
 
+### 多副本生产部署
+
+在负载均衡器后运行多个 `nyro-server` 副本时，所有副本**必须**共享同一数据库和相同的 admin token：
+
+| 要求 | 说明 |
+|---|---|
+| 共享数据库 | 使用 `--storage-backend postgres` 或 `mysql`，所有副本指向同一 DSN。SQLite 不支持共享。 |
+| 统一 admin token | 每个副本设置相同的 `--admin-token` / `NYRO_ADMIN_TOKEN`。 |
+| 配置同步 | 副本通过 `--config-poll-interval`（默认 3 秒）轮询共享 DB 的配置变更，路由/模型/Provider 的修改在一个轮询周期内传播。 |
+| OAuth 交互式流程 | OAuth 授权回调必须路由到**发起该 session 的同一副本**。请在负载均衡器的管理端口（`19531`）上配置 sticky session（会话亲和）。 |
+
+**健康探针：**
+
+| 端点 | 端口 | 用途 |
+|---|---|---|
+| `GET /healthz` | proxy + admin | Liveness — 固定返回 `200` |
+| `GET /readyz` | proxy + admin | Readiness — DB 可达返回 `200`，否则返回 `503` |
+
+**关键环境变量：**
+
+```bash
+NYRO_ADMIN_TOKEN=<secret>          # 当 admin host 不是 loopback 时必须设置
+NYRO_STORAGE_BACKEND=postgres      # postgres | mysql | sqlite（默认）
+NYRO_POSTGRES_DSN=postgres://...   # backend=postgres 时必须设置
+NYRO_MYSQL_DSN=mysql://...         # backend=mysql 时必须设置
+NYRO_CONFIG_POLL_INTERVAL=3        # 配置 epoch 轮询间隔（秒，默认 3，0=禁用）
+NYRO_WEBUI_DIR=/path/to/dist       # 从外部目录提供 WebUI（不填则使用嵌入资源）
+```
+
 ### Docker
 
 预构建的服务端镜像在独立仓库 [nyroway/docker-nyro](https://github.com/nyroway/docker-nyro) 中维护，发布到 Docker Hub 的 [nyroway/nyro](https://hub.docker.com/r/nyroway/nyro)。

--- a/crates/nyro-core/src/admin/api_keys.rs
+++ b/crates/nyro-core/src/admin/api_keys.rs
@@ -17,7 +17,8 @@ impl AdminService {
     pub async fn create_api_key(&self, input: CreateApiKey) -> anyhow::Result<ApiKeyWithBindings> {
         let name = normalize_name(&input.name, "api key name")?;
         self.ensure_api_key_name_unique(None, &name).await?;
-        self.api_keys_store()?
+        let result = self
+            .api_keys_store()?
             .create(CreateApiKey {
                 name,
                 rpm: input.rpm,
@@ -27,7 +28,9 @@ impl AdminService {
                 expires_at: input.expires_at,
                 model_ids: input.model_ids,
             })
-            .await
+            .await?;
+        self.bump_config_epoch().await?;
+        Ok(result)
     }
 
     pub async fn update_api_key(
@@ -50,7 +53,8 @@ impl AdminService {
         let is_enabled = input.is_enabled.unwrap_or(current.is_enabled);
         let expires_at = input.expires_at.or(current.expires_at);
 
-        self.api_keys_store()?
+        let result = self
+            .api_keys_store()?
             .update(
                 id,
                 UpdateApiKey {
@@ -64,11 +68,14 @@ impl AdminService {
                     model_ids: input.model_ids,
                 },
             )
-            .await
+            .await?;
+        self.bump_config_epoch().await?;
+        Ok(result)
     }
 
     pub async fn delete_api_key(&self, id: &str) -> anyhow::Result<()> {
         self.api_keys_store()?.delete(id).await?;
+        self.bump_config_epoch().await?;
         Ok(())
     }
     async fn ensure_api_key_name_unique(

--- a/crates/nyro-core/src/admin/import_export.rs
+++ b/crates/nyro-core/src/admin/import_export.rs
@@ -158,6 +158,10 @@ impl AdminService {
             settings_imported += 1;
         }
 
+        if providers_imported > 0 || models_imported > 0 {
+            self.bump_config_epoch().await?;
+        }
+
         Ok(ImportResult {
             providers_imported,
             models_imported,

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -29,7 +29,7 @@ mod models;
 mod oauth;
 mod observability;
 mod providers;
-mod settings;
+pub mod settings;
 
 use auth_data::*;
 use model_catalog::*;

--- a/crates/nyro-core/src/admin/models.rs
+++ b/crates/nyro-core/src/admin/models.rs
@@ -41,6 +41,7 @@ impl AdminService {
             store.set_backends(&model.id, &backends).await?;
         }
         self.reload_model_cache().await?;
+        self.bump_config_epoch().await?;
         self.get_model_by_id(&model.id).await
     }
 
@@ -83,6 +84,7 @@ impl AdminService {
             store.set_backends(id, &backends).await?;
         }
         self.reload_model_cache().await?;
+        self.bump_config_epoch().await?;
         self.get_model_by_id(id).await
     }
 
@@ -92,6 +94,7 @@ impl AdminService {
         }
         self.gw.storage.models().delete(id).await?;
         self.reload_model_cache().await?;
+        self.bump_config_epoch().await?;
         Ok(())
     }
     async fn ensure_model_name_unique(

--- a/crates/nyro-core/src/admin/oauth.rs
+++ b/crates/nyro-core/src/admin/oauth.rs
@@ -194,6 +194,17 @@ impl AdminService {
         &self,
         input: auth::CreateAuthSession,
     ) -> anyhow::Result<AuthSession> {
+        // NOTE (multi-replica): auth_sessions is an in-process HashMap. In a
+        // multi-replica deployment the OAuth callback HTTP request must reach
+        // the same replica that initiated the session (sticky session /
+        // session-affinity). A future improvement is to persist sessions in the
+        // shared DB, but for now callers must ensure session affinity.
+        if !self.gw.config.config_poll_interval.is_zero() {
+            tracing::debug!(
+                "creating oauth session in multi-replica mode \
+                 — ensure the callback reaches this replica (session affinity required)"
+            );
+        }
         let now = now_rfc3339();
         let session = AuthSession {
             id: uuid::Uuid::new_v4().to_string(),

--- a/crates/nyro-core/src/admin/providers.rs
+++ b/crates/nyro-core/src/admin/providers.rs
@@ -203,12 +203,14 @@ impl AdminService {
             self.gw.clear_ollama_capability_cache_for_provider(id).await;
         }
 
+        self.bump_config_epoch().await?;
         Ok(provider)
     }
 
     pub async fn delete_provider(&self, id: &str) -> anyhow::Result<()> {
         self.gw.storage.providers().delete(id).await?;
         self.reload_model_cache().await?;
+        self.bump_config_epoch().await?;
         self.gw.clear_ollama_capability_cache_for_provider(id).await;
         Ok(())
     }

--- a/crates/nyro-core/src/admin/settings.rs
+++ b/crates/nyro-core/src/admin/settings.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+/// Settings key used to signal config changes to other replicas.
+pub const CONFIG_EPOCH_KEY: &str = "config_epoch";
+
 impl AdminService {
     // ── Settings ──
 
@@ -9,5 +12,20 @@ impl AdminService {
 
     pub async fn set_setting(&self, key: &str, value: &str) -> anyhow::Result<()> {
         self.gw.storage.settings().set(key, value).await
+    }
+
+    /// Increment the shared `config_epoch` counter so other replicas know they
+    /// must reload their in-memory `model_cache`.
+    pub(super) async fn bump_config_epoch(&self) -> anyhow::Result<()> {
+        let store = self.gw.storage.settings();
+        let current: i64 = store
+            .get(CONFIG_EPOCH_KEY)
+            .await?
+            .as_deref()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        store
+            .set(CONFIG_EPOCH_KEY, &(current + 1).to_string())
+            .await
     }
 }

--- a/crates/nyro-core/src/config.rs
+++ b/crates/nyro-core/src/config.rs
@@ -78,6 +78,10 @@ pub struct GatewayConfig {
     pub data_dir: PathBuf,
     pub auth_key: Option<String>,
     pub storage: GatewayStorageConfig,
+    /// How often to poll the shared DB for a config epoch change and reload
+    /// `model_cache` when a change is detected. Set to `Duration::ZERO` to
+    /// disable (default for desktop / single-process deployments).
+    pub config_poll_interval: Duration,
 }
 
 impl Default for GatewayConfig {
@@ -89,6 +93,7 @@ impl Default for GatewayConfig {
             data_dir: default_data_dir(),
             auth_key: None,
             storage: GatewayStorageConfig::default(),
+            config_poll_interval: Duration::ZERO,
         }
     }
 }

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -217,6 +217,59 @@ impl Gateway {
             });
         }
 
+        if !gw.config.config_poll_interval.is_zero() {
+            let gw_poll = gw.clone();
+            let poll_interval = gw.config.config_poll_interval;
+            tokio::spawn(async move {
+                let mut known_epoch: i64 = gw_poll
+                    .storage
+                    .settings()
+                    .get(admin::settings::CONFIG_EPOCH_KEY)
+                    .await
+                    .ok()
+                    .flatten()
+                    .as_deref()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+
+                let mut interval = tokio::time::interval(poll_interval);
+                interval.tick().await; // consume the immediate first tick
+                loop {
+                    interval.tick().await;
+                    let current: i64 = match gw_poll
+                        .storage
+                        .settings()
+                        .get(admin::settings::CONFIG_EPOCH_KEY)
+                        .await
+                    {
+                        Ok(val) => val
+                            .as_deref()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0),
+                        Err(error) => {
+                            tracing::warn!("config epoch poll failed: {error}");
+                            continue;
+                        }
+                    };
+
+                    if current > known_epoch {
+                        known_epoch = current;
+                        if let Err(error) = gw_poll
+                            .model_cache
+                            .write()
+                            .await
+                            .reload(gw_poll.storage.snapshots())
+                            .await
+                        {
+                            tracing::warn!("config epoch reload failed: {error}");
+                        } else {
+                            tracing::debug!("model_cache reloaded (epoch={current})");
+                        }
+                    }
+                }
+            });
+        }
+
         Ok((gw, log_rx))
     }
 

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -242,10 +242,7 @@ impl Gateway {
                         .get(admin::settings::CONFIG_EPOCH_KEY)
                         .await
                     {
-                        Ok(val) => val
-                            .as_deref()
-                            .and_then(|v| v.parse().ok())
-                            .unwrap_or(0),
+                        Ok(val) => val.as_deref().and_then(|v| v.parse().ok()).unwrap_or(0),
                         Err(error) => {
                             tracing::warn!("config epoch poll failed: {error}");
                             continue;

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -1,7 +1,8 @@
 use axum::Router;
-use axum::extract::DefaultBodyLimit;
-use axum::http::{HeaderValue, Method, header};
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::middleware;
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
@@ -38,6 +39,8 @@ pub fn create_router(gateway: Gateway) -> Router {
         )
         .route("/v1/models", get(handler::models_list))
         .route("/health", get(health))
+        .route("/healthz", get(health))
+        .route("/readyz", get(readyz))
         .route("/", get(health));
 
     let cors = build_proxy_cors_layer(
@@ -55,6 +58,13 @@ pub fn create_router(gateway: Gateway) -> Router {
 
 async fn health() -> &'static str {
     r#"{"status":"ok"}"#
+}
+
+async fn readyz(State(gw): State<Gateway>) -> impl IntoResponse {
+    match gw.storage.bootstrap().health().await {
+        Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
+        _ => (StatusCode::SERVICE_UNAVAILABLE, r#"{"status":"unavailable"}"#),
+    }
 }
 
 fn build_proxy_cors_layer(origins: &[String], proxy_port: u16) -> CorsLayer {

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -63,7 +63,10 @@ async fn health() -> &'static str {
 async fn readyz(State(gw): State<Gateway>) -> impl IntoResponse {
     match gw.storage.bootstrap().health().await {
         Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
-        _ => (StatusCode::SERVICE_UNAVAILABLE, r#"{"status":"unavailable"}"#),
+        _ => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"status":"unavailable"}"#,
+        ),
     }
 }
 

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -2,6 +2,7 @@ use nyro_core::Gateway;
 use nyro_core::admin::CopyProviderOptions;
 use nyro_core::config::GatewayConfig;
 use nyro_core::db::models::*;
+use nyro_core::storage::StorageBootstrap as _;
 
 use std::path::PathBuf;
 
@@ -306,6 +307,127 @@ async fn build_gateway() -> anyhow::Result<Gateway> {
     };
     let (gw, _log_rx) = Gateway::new(config).await?;
     Ok(gw)
+}
+
+// ── config epoch tests ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn config_epoch_starts_at_zero_and_increments_on_model_create() -> anyhow::Result<()> {
+    let gw = build_gateway().await?;
+
+    let epoch_before: i64 = gw
+        .storage
+        .settings()
+        .get("config_epoch")
+        .await?
+        .as_deref()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let provider = gw
+        .admin()
+        .create_provider(api_key_provider_input("epoch-test-provider"))
+        .await?;
+    gw.admin()
+        .create_model(CreateModel {
+            name: "epoch-test-model".to_string(),
+            balance: Some("weighted".to_string()),
+            target_provider: provider.id.clone(),
+            target_model: "gpt-4".to_string(),
+            targets: vec![],
+            enable_auth: Some(false),
+            enable_payload: None,
+        })
+        .await?;
+
+    let epoch_after: i64 = gw
+        .storage
+        .settings()
+        .get("config_epoch")
+        .await?
+        .as_deref()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    assert!(
+        epoch_after > epoch_before,
+        "config_epoch should increment after create_model: before={epoch_before} after={epoch_after}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn config_epoch_increments_on_model_update_and_delete() -> anyhow::Result<()> {
+    let gw = build_gateway().await?;
+    let provider = gw
+        .admin()
+        .create_provider(api_key_provider_input("epoch-update-provider"))
+        .await?;
+    let model = gw
+        .admin()
+        .create_model(CreateModel {
+            name: "epoch-update-model".to_string(),
+            balance: Some("weighted".to_string()),
+            target_provider: provider.id.clone(),
+            target_model: "gpt-4".to_string(),
+            targets: vec![],
+            enable_auth: Some(false),
+            enable_payload: None,
+        })
+        .await?;
+
+    let epoch_before_update: i64 = gw
+        .storage
+        .settings()
+        .get("config_epoch")
+        .await?
+        .as_deref()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    gw.admin()
+        .update_model(
+            &model.id,
+            UpdateModel {
+                is_enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let epoch_after_update: i64 = gw
+        .storage
+        .settings()
+        .get("config_epoch")
+        .await?
+        .as_deref()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    assert!(epoch_after_update > epoch_before_update, "epoch should increment on update");
+
+    gw.admin().delete_model(&model.id).await?;
+
+    let epoch_after_delete: i64 = gw
+        .storage
+        .settings()
+        .get("config_epoch")
+        .await?
+        .as_deref()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    assert!(epoch_after_delete > epoch_after_update, "epoch should increment on delete");
+
+    Ok(())
+}
+
+// ── readyz (StorageBootstrap::health) ─────────────────────────────────────
+
+#[tokio::test]
+async fn storage_health_is_reachable_for_sqlite_gateway() -> anyhow::Result<()> {
+    let gw = build_gateway().await?;
+    let health = gw.storage.bootstrap().health().await?;
+    assert!(health.can_connect, "SQLite health check should report can_connect");
+    Ok(())
 }
 
 fn test_data_dir() -> PathBuf {

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -403,7 +403,10 @@ async fn config_epoch_increments_on_model_update_and_delete() -> anyhow::Result<
         .as_deref()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
-    assert!(epoch_after_update > epoch_before_update, "epoch should increment on update");
+    assert!(
+        epoch_after_update > epoch_before_update,
+        "epoch should increment on update"
+    );
 
     gw.admin().delete_model(&model.id).await?;
 
@@ -415,7 +418,10 @@ async fn config_epoch_increments_on_model_update_and_delete() -> anyhow::Result<
         .as_deref()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
-    assert!(epoch_after_delete > epoch_after_update, "epoch should increment on delete");
+    assert!(
+        epoch_after_delete > epoch_after_update,
+        "epoch should increment on delete"
+    );
 
     Ok(())
 }
@@ -426,7 +432,10 @@ async fn config_epoch_increments_on_model_update_and_delete() -> anyhow::Result<
 async fn storage_health_is_reachable_for_sqlite_gateway() -> anyhow::Result<()> {
     let gw = build_gateway().await?;
     let health = gw.storage.bootstrap().health().await?;
-    assert!(health.can_connect, "SQLite health check should report can_connect");
+    assert!(
+        health.can_connect,
+        "SQLite health check should report can_connect"
+    );
     Ok(())
 }
 

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -9,7 +9,7 @@ description = "Nyro AI Gateway — Standalone Server Binary"
 nyro-core = { path = "../crates/nyro-core" }
 tokio = { workspace = true }
 axum = { workspace = true }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -125,7 +125,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .route("/status", get(get_status))
         .route("/config/export", get(export_config_handler))
         .route("/config/import", axum::routing::post(import_config_handler))
-        .with_state(gateway);
+        .with_state(gateway.clone());
 
     if let Some(token) = admin_token {
         if !token.is_empty() {
@@ -135,7 +135,27 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         }
     }
 
-    Router::new().nest("/api/v1", api)
+    // Health probes are unauthenticated so K8s/load-balancers can reach them
+    // without an admin token.
+    let health_routes = Router::new()
+        .route("/healthz", get(healthz_handler))
+        .route("/readyz", get(readyz_handler))
+        .with_state(gateway);
+
+    Router::new()
+        .merge(health_routes)
+        .nest("/api/v1", api)
+}
+
+async fn healthz_handler() -> impl IntoResponse {
+    (StatusCode::OK, r#"{"status":"ok"}"#)
+}
+
+async fn readyz_handler(State(gw): State<Gateway>) -> impl IntoResponse {
+    match gw.storage.bootstrap().health().await {
+        Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
+        _ => (StatusCode::SERVICE_UNAVAILABLE, r#"{"status":"unavailable"}"#),
+    }
 }
 
 // ── Providers ──

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -142,9 +142,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .route("/readyz", get(readyz_handler))
         .with_state(gateway);
 
-    Router::new()
-        .merge(health_routes)
-        .nest("/api/v1", api)
+    Router::new().merge(health_routes).nest("/api/v1", api)
 }
 
 async fn healthz_handler() -> impl IntoResponse {
@@ -154,7 +152,10 @@ async fn healthz_handler() -> impl IntoResponse {
 async fn readyz_handler(State(gw): State<Gateway>) -> impl IntoResponse {
     match gw.storage.bootstrap().health().await {
         Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
-        _ => (StatusCode::SERVICE_UNAVAILABLE, r#"{"status":"unavailable"}"#),
+        _ => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"status":"unavailable"}"#,
+        ),
     }
 }
 

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -18,6 +18,7 @@ use nyro_core::{
 use rust_embed::RustEmbed;
 use tokio::sync::broadcast;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::services::{ServeDir, ServeFile};
 
 mod admin_routes;
 mod yaml_config;
@@ -181,6 +182,24 @@ struct Args {
     )]
     mysql_idle_timeout: Option<u64>,
 
+    // ── Multi-replica ─────────────────────────────────────────────────────────
+    #[arg(
+        long,
+        default_value_t = 3,
+        env = "NYRO_CONFIG_POLL_INTERVAL",
+        help = "Seconds between config epoch polls for multi-replica cache sync (0 = disabled)",
+        help_heading = "Multi-replica"
+    )]
+    config_poll_interval: u64,
+
+    #[arg(
+        long,
+        env = "NYRO_WEBUI_DIR",
+        help = "Serve WebUI from this directory instead of the embedded assets (optional)",
+        help_heading = "Multi-replica"
+    )]
+    webui_dir: Option<PathBuf>,
+
     // ── Standalone ────────────────────────────────────────────────────────────
     #[arg(
         long = "config",
@@ -283,6 +302,7 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
         proxy_cors_origins,
         data_dir: PathBuf::from(data_dir),
         storage: build_storage_config(args)?,
+        config_poll_interval: Duration::from_secs(args.config_poll_interval),
         ..Default::default()
     };
 
@@ -309,9 +329,17 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
 
     let admin_router = admin_routes::create_router(gateway, admin_token.clone());
 
-    let app = admin_router
-        .fallback(serve_webui)
-        .layer(build_cors_layer(&admin_cors_origins));
+    let app = if let Some(ref webui_dir) = args.webui_dir {
+        let index = webui_dir.join("index.html");
+        tracing::info!("webui  serving from directory: {}", webui_dir.display());
+        admin_router
+            .fallback_service(ServeDir::new(webui_dir).not_found_service(ServeFile::new(index)))
+            .layer(build_cors_layer(&admin_cors_origins))
+    } else {
+        admin_router
+            .fallback(serve_webui)
+            .layer(build_cors_layer(&admin_cors_origins))
+    };
 
     let admin_addr = format!("{}:{}", args.admin_host, args.admin_port);
     let listener = tokio::net::TcpListener::bind(&admin_addr).await?;


### PR DESCRIPTION
## Summary

- **Config epoch sync**: every admin write (model / provider / api-key / import) bumps a `config_epoch` counter in the shared DB; all replicas poll it every `--config-poll-interval` (default 3 s) and reload their in-memory `model_cache` when the epoch advances — no Redis required
- **Health probes**: `/healthz` (liveness, 200) and `/readyz` (readiness, 503 when DB unreachable) on both proxy and admin ports, outside the auth middleware
- **WebUI external directory**: `--webui-dir` / `NYRO_WEBUI_DIR` lets operators serve a pre-built WebUI from a mounted directory; embedded assets remain the default
- **Config poll interval**: `--config-poll-interval` / `NYRO_CONFIG_POLL_INTERVAL` (default 3 s, 0 = disabled — desktop build defaults to 0 via `GatewayConfig::default()`)
- **OAuth sticky-session note**: `auth_sens` is still in-process; code comment + docs explain that the admin load balancer must use session affinity for interactive OAuth flows
- **Multi-replica docs**: README and README_CN updated with shared-DB requirements, sticky-session caveat, probe endpoint table, and environment variable reference

## Test plan

- [ ] `cargo check -p nyro-core -p nyro-server` passes with no errors
- [ ] `cargo test -p nyro-core --test admin` — three new epoch / health tests pass
- [ ] Start two instances pointing at the same Postgres: change a route on instance A, verify instance B reflects the change within ~3 s
- [ ] `GET /readyz` returns 503 when DB is unreachable, 200 when reachable
- [ ] `GET /healthz` always returns 200
- [ ] `--webui-dir /path/to/dist` serves files from disk; unset falls back to embedded assets
- [ ] Desktop app (`src-tauri`) compiles unchanged (`GatewayConfig::default()` still works)