### PR TITLE
fix(gemini): gemini's from_uri message content being skipped

### DIFF
--- a/crates/nyro-core/src/protocol/codec/google/gemini/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google/gemini/decoder.rs
@@ -279,13 +279,20 @@ fn decode_content(content: GoogleContent) -> Result<Message> {
                 });
             }
             GooglePart::FileData { file_data } => {
-                let mime = file_data.mime_type.unwrap_or_default();
-                let source = if mime.starts_with("image/") || mime.is_empty() {
-                    MediaSource::Url(file_data.file_uri)
+                let mime = file_data.mime_type.clone().filter(|m| !m.is_empty());
+                let is_image = mime.as_deref().is_some_and(|m| m.starts_with("image/"));
+                let source = MediaSource::Url(file_data.file_uri);
+                if is_image {
+                    blocks.push(ContentBlock::Image {
+                        source,
+                        cache_control: None,
+                    });
                 } else {
-                    MediaSource::Url(file_data.file_uri)
-                };
-                blocks.push(ContentBlock::File { source });
+                    blocks.push(ContentBlock::File {
+                        source,
+                        media_type: mime,
+                    });
+                }
             }
             GooglePart::FunctionCall { function_call } => {
                 let id = format!("call_{}", uuid::Uuid::new_v4().simple());

--- a/crates/nyro-core/src/protocol/codec/google/gemini/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google/gemini/encoder.rs
@@ -212,6 +212,45 @@ fn encode_content_block_for_gemini(b: &ContentBlock) -> Value {
                 serde_json::json!({"fileData": {"fileUri": file_id}})
             }
         },
+        ContentBlock::File { source, media_type } => match source {
+            MediaSource::Url(url) => {
+                let mut fd = serde_json::json!({
+                    "fileData": {
+                        "fileUri": url,
+                    }
+                });
+                if let Some(mt) = media_type {
+                    fd["fileData"]["mimeType"] = serde_json::Value::String(mt.clone());
+                }
+                fd
+            }
+            MediaSource::FileId { file_id, .. } => {
+                let mut fd = serde_json::json!({
+                    "fileData": {
+                        "fileUri": file_id,
+                    }
+                });
+                if let Some(mt) = media_type {
+                    fd["fileData"]["mimeType"] = serde_json::Value::String(mt.clone());
+                }
+                fd
+            }
+            MediaSource::Base64 {
+                media_type: b64_mime,
+                data,
+            } => {
+                let mut fd = serde_json::json!({
+                    "inlineData": {
+                        "mimeType": b64_mime,
+                        "data": data,
+                    }
+                });
+                if let Some(mt) = media_type {
+                    fd["inlineData"]["mimeType"] = serde_json::Value::String(mt.clone());
+                }
+                fd
+            }
+        },
         ContentBlock::ToolUse { name, input, .. } => {
             serde_json::json!({"functionCall": {"name": name, "args": input}})
         }

--- a/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
@@ -513,7 +513,7 @@ fn encode_content_block_for_openai(b: &ContentBlock) -> Value {
             let url = media_source_to_url(source);
             serde_json::json!({"type": "input_audio", "input_audio": {"data": url}})
         }
-        ContentBlock::File { source } => {
+        ContentBlock::File { source, .. } => {
             let url = media_source_to_url(source);
             serde_json::json!({"type": "file", "file": {"url": url}})
         }

--- a/crates/nyro-core/src/protocol/ir/request.rs
+++ b/crates/nyro-core/src/protocol/ir/request.rs
@@ -84,6 +84,8 @@ pub enum ContentBlock {
     },
     File {
         source: MediaSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        media_type: Option<String>,
     },
 
     // ── Reasoning / thinking ─────────────────────────────────────────────────

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -20,8 +20,8 @@ use nyro_core::protocol::ids::{
 use nyro_core::protocol::ir::usage::Usage;
 use nyro_core::protocol::ir::{
     AiRequest, AiResponse as IrAiResponse, AiStreamDelta as IrStreamDelta,
-    ContentBlock as IrContentBlock, Message, MessageContent as IrMessageContent, Role as IrRole,
-    StreamConfig, ToolCall, ToolSpec,
+    ContentBlock as IrContentBlock, MediaSource, Message, MessageContent as IrMessageContent,
+    Role as IrRole, StreamConfig, ToolCall, ToolSpec,
 };
 use nyro_core::protocol::{
     RequestDecoder, RequestEncoder, ResponseDecoder, ResponseEncoder, StreamResponseDecoder,
@@ -1978,4 +1978,135 @@ fn codex_parallel_calls_with_intermediate_text_anthropic_egress() {
             );
         }
     }
+}
+
+#[test]
+fn gemini_file_data_round_trip_preserves_uri_and_mime_type() {
+    use nyro_core::protocol::codec::google::gemini::decoder::GoogleDecoder;
+
+    // Simulate an inbound request with a PDF fileData part.
+    let inbound = serde_json::json!({
+        "contents": [{
+            "role": "user",
+            "parts": [{
+                "fileData": {
+                    "fileUri": "https://example.com/doc.pdf",
+                    "mimeType": "application/pdf"
+                }
+            }]
+        }]
+    });
+
+    // Decode to IR, then re-encode.
+    let mut req = GoogleDecoder.decode_request(inbound).expect("decode");
+    req.meta.source_protocol = Some(GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA);
+    let (outbound, _) = GoogleEncoder.encode_request(&req).expect("encode");
+
+    let parts = outbound["contents"][0]["parts"].as_array().expect("parts");
+    let fd = &parts[0]["fileData"];
+    assert_eq!(
+        fd["fileUri"].as_str(),
+        Some("https://example.com/doc.pdf"),
+        "fileUri must survive round-trip"
+    );
+    assert_eq!(
+        fd["mimeType"].as_str(),
+        Some("application/pdf"),
+        "mimeType must survive round-trip"
+    );
+}
+
+#[test]
+fn gemini_decoder_file_data_routes_image_to_image_block() {
+    use nyro_core::protocol::codec::google::gemini::decoder::GoogleDecoder;
+
+    let body = serde_json::json!({
+        "contents": [{
+            "role": "user",
+            "parts": [{
+                "fileData": {
+                    "fileUri": "https://example.com/photo.jpg",
+                    "mimeType": "image/jpeg"
+                }
+            }]
+        }]
+    });
+
+    let decoder = GoogleDecoder;
+    let req = decoder.decode_request(body).expect("decode");
+
+    let msg = &req.messages[0];
+    match &msg.content {
+        IrMessageContent::Blocks(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            match &blocks[0] {
+                IrContentBlock::Image { source, .. } => match source {
+                    MediaSource::Url(url) => {
+                        assert_eq!(url, "https://example.com/photo.jpg");
+                    }
+                    _ => panic!("expected MediaSource::Url"),
+                },
+                other => panic!("expected ContentBlock::Image for image/ mimeType, got {other:?}"),
+            }
+        }
+        other => panic!("expected Blocks, got {other:?}"),
+    }
+}
+
+#[test]
+fn gemini_encoder_file_data_without_mime_type_omits_mime_type() {
+    let messages = vec![Message {
+        role: IrRole::User,
+        content: IrMessageContent::Blocks(vec![IrContentBlock::File {
+            source: MediaSource::Url("https://example.com/unknown.bin".into()),
+            media_type: None,
+        }]),
+        tool_calls: None,
+        tool_call_id: None,
+        meta: None,
+    }];
+    let req = AiRequest::new("gemini-2.5-flash", messages);
+
+    let (body, _) = GoogleEncoder.encode_request(&req).expect("encode");
+
+    let parts = body["contents"][0]["parts"]
+        .as_array()
+        .expect("parts array");
+    let fd = &parts[0]["fileData"];
+    assert_eq!(
+        fd["fileUri"].as_str(),
+        Some("https://example.com/unknown.bin")
+    );
+    assert!(
+        fd.get("mimeType").is_none(),
+        "mimeType must be absent when media_type is None"
+    );
+}
+
+#[test]
+fn gemini_encoder_file_data_with_mime_type_emits_mime_type() {
+    let messages = vec![Message {
+        role: IrRole::User,
+        content: IrMessageContent::Blocks(vec![IrContentBlock::File {
+            source: MediaSource::Url("https://example.com/report.pdf".into()),
+            media_type: Some("application/pdf".into()),
+        }]),
+        tool_calls: None,
+        tool_call_id: None,
+        meta: None,
+    }];
+    let req = AiRequest::new("gemini-2.5-flash", messages);
+
+    let (body, _) = GoogleEncoder.encode_request(&req).expect("encode");
+
+    let parts = body["contents"][0]["parts"]
+        .as_array()
+        .expect("parts array");
+    assert_eq!(parts.len(), 1);
+    let fd = &parts[0]["fileData"];
+    assert_eq!(
+        fd["fileUri"].as_str(),
+        Some("https://example.com/report.pdf")
+    );
+    assert_eq!(fd["mimeType"].as_str(), Some("application/pdf"));
 }


### PR DESCRIPTION
Adds proper handling for Gemini's `fileData` content parts so that file URIs and MIME types round-trip correctly through the protocol layer.

Let me know if I've to add more things.

Fixes #193 