### PR TITLE
feat(server): add --mode flag and embed-webui cargo feature for distributed deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Build nyro-server (debug)
         run: cargo build -p nyro-server
 
+      - name: Check nyro-server slim build (no embed-webui, no webui/dist required)
+        run: cargo check -p nyro-server --no-default-features
+
       - name: Build nyro-tools (debug)
         run: cargo build -p nyro-tools
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build server check fmt fmt-check clean webui smoke smoke-storage release-check help
+.PHONY: dev build server server-slim check fmt fmt-check clean webui smoke smoke-storage release-check help
 
 # Development — start Tauri desktop app with hot reload
 dev: webui-build
@@ -11,6 +11,10 @@ build: webui-build
 # Build server binary only (release, webui embedded)
 server: webui-build
 	cargo build -p nyro-server --release
+
+# Build slim server binary (release, no embedded webui, no pnpm build required)
+server-slim:
+	cargo build -p nyro-server --release --no-default-features
 
 # Run server binary locally (debug, webui embedded)
 server-dev: webui-build
@@ -54,7 +58,8 @@ help:
 	@echo ""
 	@echo "  make dev          Start Tauri desktop app (dev mode)"
 	@echo "  make build        Build desktop app (release)"
-	@echo "  make server       Build server binary (release)"
+	@echo "  make server       Build server binary (release, webui embedded)"
+	@echo "  make server-slim  Build slim server binary (release, no embedded webui)"
 	@echo "  make server-dev   Run server binary (debug)"
 	@echo "  make webui-build  Build frontend only"
 	@echo "  make fmt          Format Rust code"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,14 @@ Nyro detects installed tools, generates the correct configuration for the select
 | Windows | x64 · ARM64 |
 | Linux | x86\_64 · aarch64 |
 
-**Server Binary** — full mode (DB + Admin API + embedded WebUI) and standalone mode (YAML config only, no DB)
+**Server Binary** — three run modes for everything from single-host to distributed deployments
+
+| Mode | Flag | Purpose |
+|---|---|---|
+| `all` (default) | `--mode all` | Proxy + Admin API + embedded WebUI in a single process |
+| `proxy` | `--mode proxy` | Data-plane only — no Admin API, no WebUI |
+| `admin` | `--mode admin` | Control-plane only — Admin API (+ optional WebUI), no proxy |
+| Standalone | `--config config.yaml` | YAML config, no DB, no Admin — minimal / edge deployments |
 
 | Platform | Architecture | Access |
 |---|---|---|
@@ -196,7 +203,7 @@ Download the latest installer for your platform from [GitHub Releases](https://g
 curl -LO https://github.com/nyroway/nyro/releases/latest/download/nyro-server-linux-x86_64
 chmod +x nyro-server-linux-x86_64
 
-# Start (localhost only, no auth required)
+# Start (localhost only, no auth required) — default all mode
 ./nyro-server-linux-x86_64
 
 # Start (network-exposed, auth required)
@@ -205,7 +212,16 @@ chmod +x nyro-server-linux-x86_64
   --admin-host 0.0.0.0 \
   --admin-token YOUR_ADMIN_TOKEN
 
-# Standalone mode (YAML config, no DB/Admin/WebUI)
+# Proxy-only mode — binds :19530 only, no Admin API, no WebUI
+./nyro-server-linux-x86_64 --mode proxy
+
+# Admin-only mode — binds :19531 only (for internal systems to consume the control plane)
+./nyro-server-linux-x86_64 \
+  --mode admin \
+  --admin-host 0.0.0.0 \
+  --admin-token YOUR_ADMIN_TOKEN
+
+# Standalone mode (YAML config, no DB/Admin/WebUI; --mode is ignored)
 ./nyro-server-linux-x86_64 --config config.yaml
 ```
 
@@ -261,12 +277,13 @@ When running multiple `nyro-server` replicas behind a load balancer, all replica
 **Key environment variables:**
 
 ```bash
+NYRO_MODE=all                      # all (default) | proxy | admin
 NYRO_ADMIN_TOKEN=<secret>          # Required when admin host is not loopback
 NYRO_STORAGE_BACKEND=postgres      # postgres | mysql | sqlite (default)
 NYRO_POSTGRES_DSN=postgres://...   # Required when backend=postgres
 NYRO_MYSQL_DSN=mysql://...         # Required when backend=mysql
 NYRO_CONFIG_POLL_INTERVAL=3        # Seconds between config epoch polls (default: 3, 0=disabled)
-NYRO_WEBUI_DIR=/path/to/dist       # Serve WebUI from external directory instead of embedded assets
+NYRO_WEBUI_DIR=/path/to/dist       # Serve WebUI from external directory instead of embedded assets (admin/all modes only)
 ```
 
 ### Docker

--- a/README_CN.md
+++ b/README_CN.md
@@ -150,7 +150,14 @@ Nyro 会自动检测已安装工具，为所选路由生成正确配置并一键
 | Windows | x64 · ARM64 |
 | Linux | x86_64 · aarch64 |
 
-**服务端二进制** — 完整模式（DB + Admin API + 内嵌 WebUI）和 Standalone 模式（纯 YAML 配置，无 DB）
+**服务端二进制** — 支持三种运行模式，适配从单机到分布式的各类场景
+
+| 模式 | 启动方式 | 用途 |
+|---|---|---|
+| `all`（默认）| `--mode all` | Proxy + Admin API + 内嵌 WebUI，单进程全功能 |
+| `proxy` | `--mode proxy` | 仅代理调度，无 Admin、无 WebUI，适合纯流量转发节点 |
+| `admin` | `--mode admin` | 仅 Admin API（+ 可选 WebUI），适合公司内部系统对接控制面 |
+| Standalone | `--config config.yaml` | 纯 YAML 配置，无 DB、无 Admin，适合边缘/最小化部署 |
 
 | 平台 | 架构 | 访问 |
 |---|---|---|
@@ -196,7 +203,7 @@ irm https://raw.githubusercontent.com/nyroway/nyro/master/scripts/install/instal
 curl -LO https://github.com/nyroway/nyro/releases/latest/download/nyro-server-linux-x86_64
 chmod +x nyro-server-linux-x86_64
 
-# 启动（仅 localhost，无需鉴权）
+# 启动（仅 localhost，无需鉴权）— 默认 all 模式
 ./nyro-server-linux-x86_64
 
 # 启动（暴露到网络，必须鉴权）
@@ -205,7 +212,16 @@ chmod +x nyro-server-linux-x86_64
   --admin-host 0.0.0.0 \
   --admin-token YOUR_ADMIN_TOKEN
 
-# Standalone 模式（YAML 配置，无 DB/Admin/WebUI）
+# 仅代理模式 — 只启动 :19530，无 Admin API、无 WebUI
+./nyro-server-linux-x86_64 --mode proxy
+
+# 仅 Admin 模式 — 只启动 :19531（供内部系统对接控制面）
+./nyro-server-linux-x86_64 \
+  --mode admin \
+  --admin-host 0.0.0.0 \
+  --admin-token YOUR_ADMIN_TOKEN
+
+# Standalone 模式（YAML 配置，无 DB/Admin/WebUI；忽略 --mode）
 ./nyro-server-linux-x86_64 --config config.yaml
 ```
 
@@ -261,12 +277,13 @@ export NYRO_MYSQL_DSN="mysql://user:pass@host:3306/db"
 **关键环境变量：**
 
 ```bash
+NYRO_MODE=all                      # all（默认）| proxy | admin
 NYRO_ADMIN_TOKEN=<secret>          # 当 admin host 不是 loopback 时必须设置
 NYRO_STORAGE_BACKEND=postgres      # postgres | mysql | sqlite（默认）
 NYRO_POSTGRES_DSN=postgres://...   # backend=postgres 时必须设置
 NYRO_MYSQL_DSN=mysql://...         # backend=mysql 时必须设置
 NYRO_CONFIG_POLL_INTERVAL=3        # 配置 epoch 轮询间隔（秒，默认 3，0=禁用）
-NYRO_WEBUI_DIR=/path/to/dist       # 从外部目录提供 WebUI（不填则使用嵌入资源）
+NYRO_WEBUI_DIR=/path/to/dist       # 从外部目录提供 WebUI（不填则使用嵌入资源；仅 admin/all 模式）
 ```
 
 ### Docker

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -18,12 +18,15 @@ Claude Code · Codex CLI · Gemini CLI · OpenCode
     MiniMax · xAI · Zhipu · Ollama · ...
 ```
 
-**两种部署形态：**
+**部署形态：**
 
 | 形态 | 实现 | 适用场景 |
 |---|---|---|
 | Desktop | Tauri v2 桌面应用（macOS / Windows / Linux） | 个人开发者，零部署，数据不离开本机 |
-| Server | 独立 Rust 二进制，HTTP 管理 API + WebUI | 自托管、团队共享 |
+| Server `--mode all` | 独立 Rust 二进制，Proxy + Admin API + 内嵌 WebUI | 自托管、团队共享（默认） |
+| Server `--mode proxy` | 同上，仅启动代理端口 `:19530` | 分布式纯调度节点，无管理面 |
+| Server `--mode admin` | 同上，仅启动管理端口 `:19531` | 公司内部系统对接控制面；可搭配 `--no-default-features`（slim）去除内嵌 WebUI |
+| Server Standalone | `--config config.yaml`，MemoryStorage，无 Admin | 边缘/最小化部署，YAML 静态配置 |
 
 核心原则：`nyro-core` 只暴露纯 Rust API（struct + async fn），**不感知传输层**。Desktop 版通过 Tauri IPC 调用，Server 版通过 HTTP REST 调用。
 

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -20,4 +20,8 @@ anyhow = { workspace = true }
 serde_yaml = "0.9"
 indexmap = { version = "2", features = ["serde"] }
 chrono = { workspace = true }
-rust-embed = { version = "8", features = ["compression"] }
+rust-embed = { version = "8", features = ["compression"], optional = true }
+
+[features]
+default = ["embed-webui"]
+embed-webui = ["dep:rust-embed"]

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -2,8 +2,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::Router;
+#[cfg(feature = "embed-webui")]
 use axum::body::Body;
-use axum::http::{HeaderValue, Method, StatusCode, header};
+#[cfg(feature = "embed-webui")]
+use axum::http::StatusCode;
+use axum::http::{HeaderValue, Method, header};
+#[cfg(feature = "embed-webui")]
 use axum::response::Response;
 use clap::Parser;
 use nyro_core::{
@@ -15,22 +20,50 @@ use nyro_core::{
     logging,
     storage::MemoryStorage,
 };
-use rust_embed::RustEmbed;
 use tokio::sync::broadcast;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 
+#[cfg(feature = "embed-webui")]
+use rust_embed::RustEmbed;
+
 mod admin_routes;
 mod yaml_config;
 
+#[cfg(feature = "embed-webui")]
 #[derive(RustEmbed)]
 #[folder = "../webui/dist/"]
 struct WebUiAssets;
+
+// ── Run mode ──────────────────────────────────────────────────────────────────
+
+#[derive(clap::ValueEnum, Clone, Default, PartialEq)]
+enum Mode {
+    /// Start both proxy and admin listeners (default).
+    #[default]
+    All,
+    /// Start only the proxy (data plane). Admin API and WebUI are disabled.
+    Proxy,
+    /// Start only the admin listener (control plane + optional WebUI). No proxy.
+    Admin,
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
 
 #[derive(Parser)]
 #[command(name = "nyro-server", version, about = "Nyro AI Gateway — Server Mode")]
 struct Args {
     // ── Server ────────────────────────────────────────────────────────────────
+    #[arg(
+        long,
+        default_value = "all",
+        env = "NYRO_MODE",
+        value_enum,
+        help = "Run mode: all | proxy | admin",
+        help_heading = "Server"
+    )]
+    mode: Mode,
+
     #[arg(
         long,
         default_value = "127.0.0.1",
@@ -150,7 +183,7 @@ struct Args {
     )]
     postgres_idle_timeout: Option<u64>,
 
-    // ── MySQL ────────────────────────────────────────────────────────────────
+    // ── MySQL ─────────────────────────────────────────────────────────────────
     #[arg(
         long,
         env = "NYRO_MYSQL_DSN",
@@ -195,7 +228,7 @@ struct Args {
     #[arg(
         long,
         env = "NYRO_WEBUI_DIR",
-        help = "Serve WebUI from this directory instead of the embedded assets (optional)",
+        help = "Serve WebUI from this directory instead of the embedded assets (optional; applies to admin/all modes)",
         help_heading = "Multi-replica"
     )]
     webui_dir: Option<PathBuf>,
@@ -204,11 +237,13 @@ struct Args {
     #[arg(
         long = "config",
         short = 'c',
-        help = "Path to YAML config file for standalone mode (no DB, no admin API)",
+        help = "Path to YAML config file for standalone mode (no DB, no admin API); --mode is ignored when this flag is set",
         help_heading = "Standalone"
     )]
     config_file: Option<String>,
 }
+
+// ── Entry point ───────────────────────────────────────────────────────────────
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -218,17 +253,28 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
     if let Some(ref config_path) = args.config_file {
+        if args.mode != Mode::All {
+            tracing::warn!(
+                "standalone mode (--config) is active; --mode={} is ignored",
+                match args.mode {
+                    Mode::Proxy => "proxy",
+                    Mode::Admin => "admin",
+                    Mode::All => "all",
+                }
+            );
+        }
         return run_standalone(config_path, &args).await;
     }
 
     run_full(&args).await
 }
 
+// ── Standalone mode ───────────────────────────────────────────────────────────
+
 async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
     tracing::info!("standalone mode: loading {config_path}");
     let yaml = yaml_config::YamlConfig::load(config_path)?;
 
-    // Standalone mode: proxy address comes exclusively from YAML
     let proxy_host = yaml.server.proxy_host.clone();
     let proxy_port = yaml.server.proxy_port;
 
@@ -275,14 +321,29 @@ async fn run_standalone(config_path: &str, args: &Args) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ── Full mode (DB-backed, mode-aware) ─────────────────────────────────────────
+
 async fn run_full(args: &Args) -> anyhow::Result<()> {
     let data_dir = shellexpand::tilde(&args.data_dir).to_string();
     let admin_token = args.admin_token.clone().filter(|t| !t.trim().is_empty());
 
-    if !is_loopback_host(&args.admin_host) && admin_token.is_none() {
-        anyhow::bail!(
-            "--admin-token is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
-        );
+    // Warn about args that are irrelevant in proxy-only mode.
+    if args.mode == Mode::Proxy {
+        if admin_token.is_some() {
+            tracing::warn!("--mode proxy: --admin-token is ignored (no admin listener)");
+        }
+        if args.webui_dir.is_some() {
+            tracing::warn!("--mode proxy: --webui-dir is ignored (no admin listener)");
+        }
+    }
+
+    // Admin token enforcement only when the admin listener is active.
+    if matches!(args.mode, Mode::Admin | Mode::All) {
+        if !is_loopback_host(&args.admin_host) && admin_token.is_none() {
+            anyhow::bail!(
+                "--admin-token is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
+            );
+        }
     }
 
     let admin_cors_origins = if args.admin_cors_origins.is_empty() {
@@ -308,64 +369,108 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
 
     let (gateway, log_rx) = Gateway::new(config).await?;
 
-    let gw_proxy = gateway.clone();
     let storage_for_logs = gateway.storage.clone();
-    let (shutdown_tx, _) = broadcast::channel::<()>(1);
-    let proxy_shutdown = shutdown_tx.subscribe();
-    let admin_shutdown_tx = shutdown_tx.clone();
-
-    let proxy_task = tokio::spawn(async move {
-        if let Err(e) = gw_proxy
-            .start_proxy_with_shutdown(wait_for_shutdown(proxy_shutdown))
-            .await
-        {
-            tracing::error!("proxy server error: {e}");
-        }
-    });
-
     tokio::spawn(async move {
         logging::run_collector(log_rx, storage_for_logs).await;
     });
 
-    let admin_router = admin_routes::create_router(gateway, admin_token.clone());
+    match args.mode {
+        Mode::Proxy => {
+            let proxy_addr = format!("{}:{}", args.proxy_host, args.proxy_port);
+            tracing::info!("mode=proxy  proxy → http://{proxy_addr}");
+            tracing::info!("admin API and WebUI are disabled in proxy mode");
+            gateway.start_proxy_with_shutdown(shutdown_signal()).await?;
+        }
 
-    let app = if let Some(ref webui_dir) = args.webui_dir {
-        let index = webui_dir.join("index.html");
-        tracing::info!("webui  serving from directory: {}", webui_dir.display());
-        admin_router
-            .fallback_service(ServeDir::new(webui_dir).not_found_service(ServeFile::new(index)))
-            .layer(build_cors_layer(&admin_cors_origins))
-    } else {
-        admin_router
-            .fallback(serve_webui)
-            .layer(build_cors_layer(&admin_cors_origins))
-    };
+        Mode::Admin => {
+            let admin_addr = format!("{}:{}", args.admin_host, args.admin_port);
+            let admin_router = admin_routes::create_router(gateway, admin_token.clone());
+            let app = build_admin_app(admin_router, &args.webui_dir, &admin_cors_origins);
+            let listener = tokio::net::TcpListener::bind(&admin_addr).await?;
+            tracing::info!("mode=admin  admin → http://{admin_addr}");
+            if admin_token.is_none() {
+                tracing::warn!("admin API auth disabled: set --admin-token for production");
+            }
+            axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
+        }
 
-    let admin_addr = format!("{}:{}", args.admin_host, args.admin_port);
-    let listener = tokio::net::TcpListener::bind(&admin_addr).await?;
+        Mode::All => {
+            let (shutdown_tx, _) = broadcast::channel::<()>(1);
+            let proxy_shutdown = shutdown_tx.subscribe();
+            let admin_shutdown_tx = shutdown_tx.clone();
 
-    let proxy_bind_addr = format!("{}:{}", args.proxy_host, args.proxy_port);
-    tracing::info!("proxy  → http://{proxy_bind_addr}");
-    tracing::info!("webui  → http://{admin_addr}");
+            let gw_proxy = gateway.clone();
+            let proxy_task = tokio::spawn(async move {
+                if let Err(e) = gw_proxy
+                    .start_proxy_with_shutdown(wait_for_shutdown(proxy_shutdown))
+                    .await
+                {
+                    tracing::error!("proxy server error: {e}");
+                }
+            });
 
-    if admin_token.is_none() {
-        tracing::warn!("admin API auth disabled: set --admin-token for production");
+            let admin_router = admin_routes::create_router(gateway, admin_token.clone());
+            let app = build_admin_app(admin_router, &args.webui_dir, &admin_cors_origins);
+            let admin_addr = format!("{}:{}", args.admin_host, args.admin_port);
+            let listener = tokio::net::TcpListener::bind(&admin_addr).await?;
+
+            let proxy_addr = format!("{}:{}", args.proxy_host, args.proxy_port);
+            tracing::info!("mode=all  proxy → http://{proxy_addr}");
+            tracing::info!("mode=all  admin → http://{admin_addr}");
+
+            if admin_token.is_none() {
+                tracing::warn!("admin API auth disabled: set --admin-token for production");
+            }
+
+            let admin_result = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    shutdown_signal().await;
+                    let _ = admin_shutdown_tx.send(());
+                })
+                .await;
+
+            let _ = shutdown_tx.send(());
+            if let Err(error) = proxy_task.await {
+                tracing::error!("proxy server task failed: {error}");
+            }
+
+            admin_result?;
+        }
     }
-    let admin_result = axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            shutdown_signal().await;
-            let _ = admin_shutdown_tx.send(());
-        })
-        .await;
 
-    let _ = shutdown_tx.send(());
-    if let Err(error) = proxy_task.await {
-        tracing::error!("proxy server task failed: {error}");
-    }
-
-    admin_result?;
     Ok(())
 }
+
+// ── Admin app builder (three-state webui) ─────────────────────────────────────
+
+fn build_admin_app(
+    admin_router: Router,
+    webui_dir: &Option<PathBuf>,
+    cors_origins: &[String],
+) -> Router {
+    if let Some(dir) = webui_dir {
+        let index = dir.join("index.html");
+        tracing::info!("webui  serving from directory: {}", dir.display());
+        admin_router
+            .fallback_service(ServeDir::new(dir).not_found_service(ServeFile::new(index)))
+            .layer(build_cors_layer(cors_origins))
+    } else {
+        #[cfg(feature = "embed-webui")]
+        {
+            admin_router
+                .fallback(serve_webui)
+                .layer(build_cors_layer(cors_origins))
+        }
+        #[cfg(not(feature = "embed-webui"))]
+        {
+            admin_router.layer(build_cors_layer(cors_origins))
+        }
+    }
+}
+
+// ── Shutdown helpers ──────────────────────────────────────────────────────────
 
 async fn shutdown_signal() {
     let ctrl_c = async {
@@ -399,8 +504,9 @@ async fn wait_for_shutdown(mut shutdown: broadcast::Receiver<()>) {
     let _ = shutdown.recv().await;
 }
 
-// ── WebUI (embedded) ──────────────────────────────────────────────────────────
+// ── WebUI (embedded, feature-gated) ──────────────────────────────────────────
 
+#[cfg(feature = "embed-webui")]
 async fn serve_webui(uri: axum::http::Uri) -> Response {
     let path = uri.path().trim_start_matches('/');
     let file_path = if path.is_empty() { "index.html" } else { path };
@@ -413,22 +519,20 @@ async fn serve_webui(uri: axum::http::Uri) -> Response {
                 .body(Body::from(content.data.into_owned()))
                 .unwrap()
         }
-        None => {
-            // SPA fallback: serve index.html for any unmatched path
-            match WebUiAssets::get("index.html") {
-                Some(content) => Response::builder()
-                    .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-                    .body(Body::from(content.data.into_owned()))
-                    .unwrap(),
-                None => Response::builder()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(Body::empty())
-                    .unwrap(),
-            }
-        }
+        None => match WebUiAssets::get("index.html") {
+            Some(content) => Response::builder()
+                .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(Body::from(content.data.into_owned()))
+                .unwrap(),
+            None => Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty())
+                .unwrap(),
+        },
     }
 }
 
+#[cfg(feature = "embed-webui")]
 fn infer_mime(path: &str) -> &'static str {
     if path.ends_with(".html") {
         "text/html; charset=utf-8"


### PR DESCRIPTION
- Add `--mode proxy|admin|all` (env NYRO_MODE, default all) so proxy and admin listeners can be started independently; enables separate horizontal scaling of the data plane and control plane.
- Gate rust-embed / WebUiAssets behind `embed-webui` Cargo feature (on by default); slim builds (`--no-default-features`) no longer require a webui/dist artifact, removing the mandatory pnpm build step.
- `--config` (standalone YAML mode) takes priority and ignores --mode with a warn log when the two flags are combined.
- Add `make server-slim` target for local slim builds.
- Add CI step to verify slim build compiles without webui/dist.
- Update README (EN/CN) and architecture.md with deployment mode table, --mode usage examples, and NYRO_MODE env var.