### PR TITLE
feat(storage): support K8S external database migration workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,17 @@ Nyro is a Rust workspace for a local AI protocol gateway with a Tauri desktop ap
 - WebUI uses React, Vite, TypeScript, Radix UI primitives, TanStack Query, and Zustand.
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->
+
+### Database Changes
+
+When modifying the database schema — including changes to `INIT_SQL`, `POSTGRES_INIT_SQL`, `MYSQL_INIT_SQL` constants or the `migrate()` function in any storage backend — you **must** also:
+
+1. Update `docs/database/schema.md` to reflect the new table/column definitions.
+2. Regenerate `deploy/schema/postgres.sql` and `deploy/schema/mysql.sql` to match the final post-migration state:
+   ```bash
+   nyro-tools dump-schema --backend postgres > deploy/schema/postgres.sql
+   nyro-tools dump-schema --backend mysql    > deploy/schema/mysql.sql
+   ```
+   These files are the authoritative reference schema for DBAs. They represent the **final state** after all migrations have run (with final table names: `models`, `model_backends`, `api_key_models`).
+
+> The SQL files in `deploy/schema/` are derived reference artifacts — do not manually edit them except to update the header comment. Always regenerate from the migration source of truth.

--- a/crates/nyro-core/src/config.rs
+++ b/crates/nyro-core/src/config.rs
@@ -10,19 +10,6 @@ pub enum StorageBackendKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct SqliteStorageConfig {
-    pub migrate_on_start: bool,
-}
-
-impl Default for SqliteStorageConfig {
-    fn default() -> Self {
-        Self {
-            migrate_on_start: true,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct SqlStorageConfig {
     pub url: Option<String>,
     pub max_connections: u32,
@@ -54,7 +41,10 @@ impl Default for SqlStorageConfig {
 #[derive(Debug, Clone)]
 pub struct GatewayStorageConfig {
     pub backend: StorageBackendKind,
-    pub sqlite: SqliteStorageConfig,
+    /// Whether to run schema init + migrations on startup.
+    /// Defaults to `true` (all backends). Set to `false` to skip DDL at startup
+    /// and run migrations separately via `--migrate-only` (e.g. K8S init Job).
+    pub migrate_on_start: bool,
     pub postgres: SqlStorageConfig,
     pub mysql: SqlStorageConfig,
 }
@@ -63,7 +53,7 @@ impl Default for GatewayStorageConfig {
     fn default() -> Self {
         Self {
             backend: StorageBackendKind::Sqlite,
-            sqlite: SqliteStorageConfig::default(),
+            migrate_on_start: true,
             postgres: SqlStorageConfig::default(),
             mysql: SqlStorageConfig::default(),
         }

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -81,7 +81,7 @@ impl Gateway {
             Option<Pool<MySql>>,
         ) = match config.storage.backend {
             StorageBackendKind::Sqlite => {
-                let sqlite_storage = if config.storage.sqlite.migrate_on_start {
+                let sqlite_storage = if config.storage.migrate_on_start {
                     SqliteStorage::from_config(&config).await?
                 } else {
                     let pool = db::init_pool(&config.data_dir).await?;
@@ -123,7 +123,9 @@ impl Gateway {
         };
 
         storage.bootstrap().init().await?;
-        if !matches!(config.storage.backend, StorageBackendKind::Sqlite) {
+        if config.storage.migrate_on_start
+            && !matches!(config.storage.backend, StorageBackendKind::Sqlite)
+        {
             storage.bootstrap().migrate().await?;
         }
         let health = storage.bootstrap().health().await?;

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -62,7 +62,11 @@ async fn health() -> &'static str {
 
 async fn readyz(State(gw): State<Gateway>) -> impl IntoResponse {
     match gw.storage.bootstrap().health().await {
-        Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
+        Ok(h) if h.can_connect && h.schema_compatible => (StatusCode::OK, r#"{"status":"ok"}"#),
+        Ok(h) if h.can_connect => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"status":"schema_pending"}"#,
+        ),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,
             r#"{"status":"unavailable"}"#,

--- a/crates/nyro-core/src/storage/mysql.rs
+++ b/crates/nyro-core/src/storage/mysql.rs
@@ -60,9 +60,18 @@ impl MysqlAdapter {
 
     pub async fn health(&self) -> MysqlHealth {
         let can_connect = self.ping().await.is_ok();
+        // schema_compatible: verify the final-state `models` table exists,
+        // which confirms migrations have completed (routes → models rename done).
+        let schema_compatible = if can_connect {
+            mysql_table_exists(&self.pool, "models")
+                .await
+                .unwrap_or(false)
+        } else {
+            false
+        };
         MysqlHealth {
             can_connect,
-            schema_compatible: can_connect,
+            schema_compatible,
         }
     }
 }

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -62,9 +62,16 @@ impl PostgresAdapter {
 
     pub async fn health(&self) -> PostgresHealth {
         let can_connect = self.ping().await.is_ok();
+        // schema_compatible: verify the final-state `models` table exists,
+        // which confirms migrations have completed (routes → models rename done).
+        let schema_compatible = if can_connect {
+            pg_table_exists(&self.pool, "models").await.unwrap_or(false)
+        } else {
+            false
+        };
         PostgresHealth {
             can_connect,
-            schema_compatible: can_connect,
+            schema_compatible,
         }
     }
 }

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -1179,12 +1179,25 @@ impl StorageBootstrap for SqliteBootstrap {
     }
 
     async fn health(&self) -> anyhow::Result<StorageHealth> {
-        sqlx::query("SELECT 1").execute(&self.pool).await?;
+        let can_connect = sqlx::query("SELECT 1").execute(&self.pool).await.is_ok();
+        // schema_compatible: verify the final-state `models` table exists,
+        // which confirms migrations have completed (routes → models rename done).
+        let schema_compatible = if can_connect {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='models'",
+            )
+            .fetch_one(&self.pool)
+            .await
+            .unwrap_or(0)
+                > 0
+        } else {
+            false
+        };
         Ok(StorageHealth {
             backend: StorageBackend::Sqlite,
-            can_connect: true,
-            schema_compatible: true,
-            writable: true,
+            can_connect,
+            schema_compatible,
+            writable: can_connect,
         })
     }
 }

--- a/crates/nyro-core/tests/admin.rs
+++ b/crates/nyro-core/tests/admin.rs
@@ -2,8 +2,7 @@ use nyro_core::Gateway;
 use nyro_core::admin::CopyProviderOptions;
 use nyro_core::config::GatewayConfig;
 use nyro_core::db::models::*;
-use nyro_core::storage::StorageBootstrap as _;
-
+use nyro_core::storage::Storage as _;
 use std::path::PathBuf;
 
 use uuid::Uuid;
@@ -435,6 +434,31 @@ async fn storage_health_is_reachable_for_sqlite_gateway() -> anyhow::Result<()> 
     assert!(
         health.can_connect,
         "SQLite health check should report can_connect"
+    );
+    assert!(
+        health.schema_compatible,
+        "SQLite health check should report schema_compatible after migration"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn schema_compatible_is_false_when_migrations_skipped() -> anyhow::Result<()> {
+    // Create a SQLite pool on a fresh directory without running any migrations.
+    // Gateway::new() would fail at ModelCache load, so test directly at storage level.
+    let dir = tempfile::tempdir()?;
+    let pool = nyro_core::db::init_pool(dir.path()).await?;
+    let storage = nyro_core::storage::SqliteStorage::from_pool(pool);
+
+    let health = storage.bootstrap().health().await?;
+
+    assert!(
+        health.can_connect,
+        "should still connect to SQLite even without schema"
+    );
+    assert!(
+        !health.schema_compatible,
+        "schema_compatible must be false when models table has not been created"
     );
     Ok(())
 }

--- a/crates/nyro-tools/src/main.rs
+++ b/crates/nyro-tools/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use tracing_subscriber::EnvFilter;
 
 mod fixture;
@@ -9,6 +9,9 @@ mod record;
 mod replay;
 mod scenarios;
 
+const POSTGRES_SCHEMA_SQL: &str = include_str!("../../../deploy/schema/postgres.sql");
+const MYSQL_SCHEMA_SQL: &str = include_str!("../../../deploy/schema/mysql.sql");
+
 #[derive(Parser)]
 #[command(
     name = "nyro-tools",
@@ -17,7 +20,8 @@ mod scenarios;
     long_about = "Three subcommands for protocol-conversion testing:\n\
                   - proxy:  transparent passthrough for local debugging\n\
                   - record: scenario-driven recording against real LLM endpoints\n\
-                  - replay: persistent stub upstream that replays fixtures by replay_model"
+                  - replay: persistent stub upstream that replays fixtures by replay_model\n\
+                  - dump-schema: print the final-state DDL for a storage backend"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -34,6 +38,23 @@ enum Command {
     Replay(replay::ReplayArgs),
     /// Print scenario metadata (anchor + expected_fields per protocol) as JSON — consumed by pytest
     PrintScenarios,
+    /// Print the final-state DDL schema for the given storage backend (postgres or mysql).
+    /// Useful for DBAs to pre-create the database or review schema changes.
+    /// The output matches deploy/schema/{backend}.sql in the repository.
+    DumpSchema(DumpSchemaArgs),
+}
+
+#[derive(Parser)]
+struct DumpSchemaArgs {
+    /// Storage backend to print the schema for
+    #[arg(long, value_enum)]
+    backend: SchemaBackend,
+}
+
+#[derive(ValueEnum, Clone)]
+enum SchemaBackend {
+    Postgres,
+    Mysql,
 }
 
 #[tokio::main]
@@ -45,6 +66,14 @@ async fn main() -> Result<()> {
         Command::Record(args) => record::run(args).await,
         Command::Replay(args) => replay::run(args).await,
         Command::PrintScenarios => print_scenarios(),
+        Command::DumpSchema(args) => {
+            let sql = match args.backend {
+                SchemaBackend::Postgres => POSTGRES_SCHEMA_SQL,
+                SchemaBackend::Mysql => MYSQL_SCHEMA_SQL,
+            };
+            print!("{sql}");
+            Ok(())
+        }
     }
 }
 

--- a/deploy/schema/mysql.sql
+++ b/deploy/schema/mysql.sql
@@ -1,0 +1,160 @@
+-- Nyro AI Gateway — MySQL Final Schema
+--
+-- This file represents the authoritative final-state schema after all migrations.
+-- Use it to pre-create the database on a fresh MySQL instance before starting
+-- the server, or pass it to your DBA for review.
+--
+-- Generated from: crates/nyro-core/src/storage/mysql.rs (MYSQL_INIT_SQL + migrate())
+-- Regenerate  : nyro-tools dump-schema --backend mysql
+-- Keep in sync: update this file whenever MYSQL_INIT_SQL or the migrate() function changes.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    vendor VARCHAR(255),
+    protocol VARCHAR(255) NOT NULL,
+    base_url TEXT NOT NULL,
+    preset_key VARCHAR(255),
+    channel VARCHAR(255),
+    models_source TEXT,
+    static_models TEXT,
+    api_key TEXT NOT NULL,
+    auth_mode VARCHAR(255) NOT NULL DEFAULT 'apikey',
+    access_token TEXT,
+    refresh_token TEXT,
+    expires_at DATETIME,
+    use_proxy TINYINT(1) NOT NULL DEFAULT 0,
+    last_test_success TINYINT(1),
+    last_test_at DATETIME,
+    is_enabled TINYINT(1) DEFAULT 1,
+    priority INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Final name: models (renamed from routes)
+CREATE TABLE IF NOT EXISTS models (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    balance VARCHAR(255) DEFAULT 'weighted',
+    target_provider VARCHAR(36) NOT NULL,
+    target_model VARCHAR(255) NOT NULL,
+    enable_auth TINYINT(1) DEFAULT 0,
+    enable_payload TINYINT(1) DEFAULT NULL,
+    is_enabled TINYINT(1) DEFAULT 1,
+    priority INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (target_provider) REFERENCES providers(id)
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Final name: model_backends (renamed from route_targets)
+CREATE TABLE IF NOT EXISTS model_backends (
+    id VARCHAR(36) PRIMARY KEY,
+    model_id VARCHAR(36) NOT NULL,
+    provider_id VARCHAR(36) NOT NULL,
+    model VARCHAR(255) NOT NULL,
+    weight INTEGER DEFAULT 100,
+    priority INTEGER DEFAULT 1,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (model_id) REFERENCES models(id) ON DELETE CASCADE,
+    FOREIGN KEY (provider_id) REFERENCES providers(id)
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_model_backends_model_id ON model_backends(model_id);
+
+CREATE TABLE IF NOT EXISTS request_logs (
+    id                        VARCHAR(36) PRIMARY KEY,
+    created_at                BIGINT NOT NULL DEFAULT 0,
+    api_key_id                VARCHAR(36),
+    api_key_name              VARCHAR(255),
+    client_protocol           VARCHAR(255),
+    upstream_protocol         VARCHAR(255),
+    provider_id               VARCHAR(36),
+    provider_name             VARCHAR(255),
+    model_id                  VARCHAR(36),
+    model_name                VARCHAR(255),
+    upstream_url              TEXT,
+    client_model              VARCHAR(255),
+    upstream_model            VARCHAR(255),
+    method                    VARCHAR(255),
+    path                      TEXT,
+    client_request_headers    TEXT,
+    client_request_body       LONGTEXT,
+    client_response_headers   TEXT,
+    client_response_body      LONGTEXT,
+    upstream_request_headers  TEXT,
+    upstream_request_body     LONGTEXT,
+    upstream_response_headers TEXT,
+    upstream_response_body    LONGTEXT,
+    upstream_status_code      INTEGER,
+    client_status_code        INTEGER,
+    latency_total_ms          BIGINT,
+    latency_upstream_ms       BIGINT,
+    input_tokens              INTEGER DEFAULT 0,
+    output_tokens             INTEGER DEFAULT 0,
+    cache_read_tokens         INTEGER DEFAULT 0,
+    is_stream                 TINYINT(1) DEFAULT 0,
+    stream_chunks_count       INTEGER DEFAULT 0,
+    stream_first_chunk_ms     BIGINT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_logs_created_at ON request_logs(created_at);
+CREATE INDEX idx_logs_provider_id ON request_logs(provider_id);
+CREATE INDEX idx_logs_client_status ON request_logs(client_status_code);
+CREATE INDEX idx_logs_upstream_model ON request_logs(upstream_model);
+CREATE INDEX idx_logs_api_key ON request_logs(api_key_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+    name VARCHAR(255) PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id VARCHAR(36) PRIMARY KEY,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    rpm INTEGER,
+    rpd INTEGER,
+    tpm INTEGER,
+    tpd INTEGER,
+    is_enabled TINYINT(1) DEFAULT 1,
+    expires_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Final name: api_key_models (renamed from api_key_routes)
+CREATE TABLE IF NOT EXISTS api_key_models (
+    api_key_id VARCHAR(36) NOT NULL,
+    model_id VARCHAR(36) NOT NULL,
+    PRIMARY KEY (api_key_id, model_id),
+    FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE,
+    FOREIGN KEY (model_id) REFERENCES models(id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_api_keys_token ON api_keys(token);
+CREATE INDEX idx_api_key_models_model_id ON api_key_models(model_id);
+
+CREATE TABLE IF NOT EXISTS provider_oauth_credentials (
+    provider_id       VARCHAR(36) PRIMARY KEY,
+    driver_key        TEXT NOT NULL,
+    scheme            VARCHAR(255) NOT NULL DEFAULT '',
+    access_token      TEXT NOT NULL,
+    refresh_token     TEXT,
+    expires_at        DATETIME,
+    resource_url      TEXT,
+    subject_id        VARCHAR(255),
+    scopes            TEXT NOT NULL,
+    meta              TEXT NOT NULL,
+    status            VARCHAR(255) NOT NULL DEFAULT 'connected',
+    status_version    INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT,
+    last_refresh_at   DATETIME,
+    created_at        DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX idx_oauth_creds_status ON provider_oauth_credentials(status);
+CREATE INDEX idx_oauth_creds_expires ON provider_oauth_credentials(expires_at);

--- a/deploy/schema/postgres.sql
+++ b/deploy/schema/postgres.sql
@@ -1,0 +1,154 @@
+-- Nyro AI Gateway — PostgreSQL Final Schema
+--
+-- This file represents the authoritative final-state schema after all migrations.
+-- Use it to pre-create the database on a fresh PostgreSQL instance before starting
+-- the server, or pass it to your DBA for review.
+--
+-- Generated from: crates/nyro-core/src/storage/postgres/mod.rs (POSTGRES_INIT_SQL + migrate())
+-- Regenerate  : nyro-tools dump-schema --backend postgres
+-- Keep in sync: update this file whenever POSTGRES_INIT_SQL or the migrate() function changes.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    vendor TEXT,
+    protocol TEXT NOT NULL,
+    base_url TEXT NOT NULL,
+    preset_key TEXT,
+    channel TEXT,
+    models_source TEXT,
+    static_models TEXT,
+    api_key TEXT NOT NULL,
+    auth_mode TEXT NOT NULL DEFAULT 'apikey' CHECK (auth_mode IN ('apikey', 'oauth')),
+    access_token TEXT,
+    refresh_token TEXT,
+    expires_at TIMESTAMPTZ,
+    use_proxy BOOLEAN NOT NULL DEFAULT FALSE,
+    last_test_success BOOLEAN,
+    last_test_at TIMESTAMPTZ,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    priority INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Final name: models (renamed from routes)
+CREATE TABLE IF NOT EXISTS models (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    balance TEXT DEFAULT 'weighted',
+    target_provider TEXT NOT NULL REFERENCES providers(id),
+    target_model TEXT NOT NULL,
+    enable_auth BOOLEAN DEFAULT FALSE,
+    enable_payload BOOLEAN,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    priority INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Final name: model_backends (renamed from route_targets)
+CREATE TABLE IF NOT EXISTS model_backends (
+    id TEXT PRIMARY KEY,
+    model_id TEXT NOT NULL REFERENCES models(id) ON DELETE CASCADE,
+    provider_id TEXT NOT NULL REFERENCES providers(id),
+    model TEXT NOT NULL,
+    weight INTEGER DEFAULT 100,
+    priority INTEGER DEFAULT 1,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_backends_model_id ON model_backends(model_id);
+
+CREATE TABLE IF NOT EXISTS request_logs (
+    id                        TEXT PRIMARY KEY,
+    created_at                BIGINT NOT NULL DEFAULT 0,
+    api_key_id                TEXT,
+    api_key_name              TEXT,
+    client_protocol           TEXT,
+    upstream_protocol         TEXT,
+    provider_id               TEXT,
+    provider_name             TEXT,
+    model_id                  TEXT,
+    model_name                TEXT,
+    upstream_url              TEXT,
+    client_model              TEXT,
+    upstream_model            TEXT,
+    method                    TEXT,
+    path                      TEXT,
+    client_request_headers    TEXT,
+    client_request_body       TEXT,
+    client_response_headers   TEXT,
+    client_response_body      TEXT,
+    upstream_request_headers  TEXT,
+    upstream_request_body     TEXT,
+    upstream_response_headers TEXT,
+    upstream_response_body    TEXT,
+    upstream_status_code      INTEGER,
+    client_status_code        INTEGER,
+    latency_total_ms          BIGINT,
+    latency_upstream_ms       BIGINT,
+    input_tokens              INTEGER DEFAULT 0,
+    output_tokens             INTEGER DEFAULT 0,
+    cache_read_tokens         INTEGER DEFAULT 0,
+    is_stream                 BOOLEAN DEFAULT FALSE,
+    stream_chunks_count       INTEGER DEFAULT 0,
+    stream_first_chunk_ms     BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_logs_created_at ON request_logs(created_at);
+CREATE INDEX IF NOT EXISTS idx_logs_provider_id ON request_logs(provider_id);
+CREATE INDEX IF NOT EXISTS idx_logs_client_status ON request_logs(client_status_code);
+CREATE INDEX IF NOT EXISTS idx_logs_upstream_model ON request_logs(upstream_model);
+CREATE INDEX IF NOT EXISTS idx_logs_api_key ON request_logs(api_key_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+    name TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id TEXT PRIMARY KEY,
+    token TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    rpm INTEGER,
+    rpd INTEGER,
+    tpm INTEGER,
+    tpd INTEGER,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Final name: api_key_models (renamed from api_key_routes)
+CREATE TABLE IF NOT EXISTS api_key_models (
+    api_key_id TEXT NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+    model_id TEXT NOT NULL REFERENCES models(id) ON DELETE CASCADE,
+    PRIMARY KEY (api_key_id, model_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_token ON api_keys(token);
+CREATE INDEX IF NOT EXISTS idx_api_key_models_model_id ON api_key_models(model_id);
+
+CREATE TABLE IF NOT EXISTS provider_oauth_credentials (
+    provider_id       TEXT PRIMARY KEY REFERENCES providers(id) ON DELETE CASCADE,
+    driver_key        TEXT NOT NULL DEFAULT '',
+    scheme            TEXT NOT NULL DEFAULT '',
+    access_token      TEXT NOT NULL DEFAULT '',
+    refresh_token     TEXT,
+    expires_at        TIMESTAMPTZ,
+    resource_url      TEXT,
+    subject_id        TEXT,
+    scopes            TEXT NOT NULL DEFAULT '[]',
+    meta              TEXT NOT NULL DEFAULT '{}',
+    status            TEXT NOT NULL DEFAULT 'connected',
+    status_version    INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT,
+    last_refresh_at   TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_creds_status ON provider_oauth_credentials(status);
+CREATE INDEX IF NOT EXISTS idx_oauth_creds_expires ON provider_oauth_credentials(expires_at);

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -33,7 +33,8 @@ nyro-server
 |------|----------|--------|------|
 | `--data-dir` | `NYRO_DATA_DIR` | `~/.nyro` | 数据存储目录（SQLite 数据库存放位置） |
 | `--storage-backend` | `NYRO_STORAGE_BACKEND` | `sqlite` | 存储后端：`sqlite` / `postgres` / `mysql` |
-| `--migrate-on-start` | — | `true` | 启动时自动运行数据库迁移 |
+| `--migrate-on-start` | `NYRO_MIGRATE_ON_START` | `true` | 启动时对所有后端自动运行 schema 迁移；设为 `false` 可跳过 DDL，搭配 `--migrate-only` 独立执行迁移（适合 K8S 分权部署）|
+| `--migrate-only` | — | `false` | 执行数据库迁移后退出，不启动服务（适合 K8S Job / initContainer）|
 | `--postgres-dsn` | `NYRO_POSTGRES_DSN` | 无 | PostgreSQL 连接字符串（`--storage-backend=postgres` 时必填） |
 | `--postgres-max-connections` | — | `10` | PostgreSQL 连接池最大连接数 |
 | `--postgres-min-connections` | — | `1` | PostgreSQL 连接池最小连接数 |

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -151,7 +151,11 @@ async fn healthz_handler() -> impl IntoResponse {
 
 async fn readyz_handler(State(gw): State<Gateway>) -> impl IntoResponse {
     match gw.storage.bootstrap().health().await {
-        Ok(h) if h.can_connect => (StatusCode::OK, r#"{"status":"ok"}"#),
+        Ok(h) if h.can_connect && h.schema_compatible => (StatusCode::OK, r#"{"status":"ok"}"#),
+        Ok(h) if h.can_connect => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"status":"schema_pending"}"#,
+        ),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,
             r#"{"status":"unavailable"}"#,

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -13,10 +13,7 @@ use axum::response::Response;
 use clap::Parser;
 use nyro_core::{
     Gateway,
-    config::{
-        GatewayConfig, GatewayStorageConfig, SqlStorageConfig, SqliteStorageConfig,
-        StorageBackendKind,
-    },
+    config::{GatewayConfig, GatewayStorageConfig, SqlStorageConfig, StorageBackendKind},
     logging,
     storage::MemoryStorage,
 };
@@ -147,10 +144,20 @@ struct Args {
         long,
         default_value = "true",
         action = clap::ArgAction::Set,
-        help = "Run migrations on startup (true/false)",
+        env = "NYRO_MIGRATE_ON_START",
+        help = "Run schema migrations on startup for all backends (true/false). Set false to skip DDL at runtime and use --migrate-only separately.",
         help_heading = "Storage"
     )]
     migrate_on_start: bool,
+
+    #[arg(
+        long,
+        default_value = "false",
+        action = clap::ArgAction::SetTrue,
+        help = "Run database migrations then exit (useful as a K8S init Job or initContainer). Requires --storage-backend and corresponding DSN.",
+        help_heading = "Storage"
+    )]
+    migrate_only: bool,
 
     #[arg(
         long,
@@ -266,7 +273,39 @@ async fn main() -> anyhow::Result<()> {
         return run_standalone(config_path, &args).await;
     }
 
+    if args.migrate_only {
+        return run_migrate(&args).await;
+    }
+
     run_full(&args).await
+}
+
+// ── Migrate-only mode ─────────────────────────────────────────────────────────
+
+async fn run_migrate(args: &Args) -> anyhow::Result<()> {
+    let data_dir = shellexpand::tilde(&args.data_dir).to_string();
+
+    tracing::info!(
+        "migrate-only: connecting to {} backend",
+        args.storage_backend
+    );
+
+    let mut storage_config = build_storage_config(args)?;
+    // Ensure migrations run even if --migrate-on-start=false was passed
+    storage_config.migrate_on_start = true;
+
+    let config = GatewayConfig {
+        data_dir: PathBuf::from(data_dir),
+        storage: storage_config,
+        ..Default::default()
+    };
+
+    // Gateway::new connects to storage, runs init() + migrate(), then returns.
+    // Background tasks are spawned but the runtime exits immediately after.
+    let (_gateway, _log_rx) = Gateway::new(config).await?;
+
+    tracing::info!("migrate-only: migrations completed successfully");
+    Ok(())
 }
 
 // ── Standalone mode ───────────────────────────────────────────────────────────
@@ -614,9 +653,7 @@ fn build_storage_config(args: &Args) -> anyhow::Result<GatewayStorageConfig> {
 
     Ok(GatewayStorageConfig {
         backend,
-        sqlite: SqliteStorageConfig {
-            migrate_on_start: args.migrate_on_start,
-        },
+        migrate_on_start: args.migrate_on_start,
         postgres,
         mysql,
     })

--- a/tests/e2e/storage/conftest.py
+++ b/tests/e2e/storage/conftest.py
@@ -164,7 +164,7 @@ def build_harness(work_dir: Path) -> None:
             match backend.as_str() {
                 "sqlite" => {
                     config.storage.backend = StorageBackendKind::Sqlite;
-                    config.storage.sqlite.migrate_on_start = true;
+                    config.storage.migrate_on_start = true;
                 }
                 "postgres" => {
                     let pg_url = env::var("NYRO_STORAGE_PG_URL").context("NYRO_STORAGE_PG_URL")?;


### PR DESCRIPTION
- Centralize migrate_on_start to GatewayStorageConfig (all backends)
  - Previously only effective for SQLite; now applies to PG/MySQL too
  - Default: true (keeps existing behavior)
  - Adds NYRO_MIGRATE_ON_START env var support
- Add --migrate-only flag to nyro-server
  - Runs init()+migrate() then exits; suitable for K8S initContainer/Job
- Add deploy/schema/{postgres,mysql}.sql as DBA reference schemas
- Add nyro-tools dump-schema --backend [postgres|mysql] command
- Enhance /readyz to return 503 with schema_pending when schema_compatible=false
- Update AGENTS.md with database schema change rules
- Update docs/server/README.md with new flags documentation