### PR TITLE
feat: add clear all logs functionality

### DIFF
--- a/crates/nyro-core/src/admin/observability.rs
+++ b/crates/nyro-core/src/admin/observability.rs
@@ -13,6 +13,10 @@ impl AdminService {
     pub async fn get_log(&self, id: &str) -> anyhow::Result<Option<RequestLog>> {
         self.gw.storage.logs().find_by_id(id).await
     }
+
+    pub async fn clear_logs(&self) -> anyhow::Result<u64> {
+        self.gw.storage.logs().clear_all().await
+    }
     // ── Stats ──
 
     fn normalize_hours(hours: Option<i32>) -> Option<i32> {

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -215,6 +215,10 @@ impl LogStore for MemoryStorage {
         Ok(0)
     }
 
+    async fn clear_all(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+
     async fn stats_overview(&self, _hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         Ok(StatsOverview::default())
     }

--- a/crates/nyro-core/src/storage/mysql.rs
+++ b/crates/nyro-core/src/storage/mysql.rs
@@ -1039,6 +1039,13 @@ impl LogStore for MysqlLogStore {
         Ok(result.rows_affected())
     }
 
+    async fn clear_all(&self) -> anyhow::Result<u64> {
+        let result = sqlx::query("DELETE FROM request_logs")
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         let sql = if let Some(hours) = hours {
             format!(

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -1011,6 +1011,13 @@ impl LogStore for PostgresLogStore {
         Ok(result.rows_affected())
     }
 
+    async fn clear_all(&self) -> anyhow::Result<u64> {
+        let result = sqlx::query("DELETE FROM request_logs")
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         let sql = if let Some(hours) = hours {
             format!(

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -1102,6 +1102,13 @@ impl LogStore for SqliteLogStore {
         Ok(result.rows_affected())
     }
 
+    async fn clear_all(&self) -> anyhow::Result<u64> {
+        let result = sqlx::query("DELETE FROM request_logs")
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview> {
         if let Some(hours) = hours {
             Ok(sqlx::query_as::<_, StatsOverview>(

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -128,6 +128,7 @@ pub trait LogStore: Send + Sync {
     async fn query(&self, query: LogQuery) -> anyhow::Result<LogPage>;
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<RequestLog>>;
     async fn cleanup_before(&self, cutoff_expression: &str) -> anyhow::Result<u64>;
+    async fn clear_all(&self) -> anyhow::Result<u64>;
     async fn stats_overview(&self, hours: Option<i64>) -> anyhow::Result<StatsOverview>;
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>>;
     async fn stats_by_model(&self, hours: Option<i64>) -> anyhow::Result<Vec<ModelStats>>;

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -115,7 +115,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
             get(list_api_keys_handler).post(create_api_key_handler),
         )
         .route("/api-keys/:id", api_keys_item)
-        .route("/logs", get(query_logs_handler))
+        .route("/logs", get(query_logs_handler).delete(clear_logs_handler))
         .route("/logs/:id", get(get_log_handler))
         .route("/stats/overview", get(stats_overview))
         .route("/stats/hourly", get(stats_hourly))
@@ -531,6 +531,13 @@ async fn query_logs_handler(
     };
     match gw.admin().query_logs(q).await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
+        Err(e) => err(e),
+    }
+}
+
+async fn clear_logs_handler(State(gw): State<Gateway>) -> impl IntoResponse {
+    match gw.admin().clear_logs().await {
+        Ok(deleted) => Json(serde_json::json!({ "data": { "deleted": deleted } })).into_response(),
         Err(e) => err(e),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -324,6 +324,11 @@ pub async fn get_log(gw: State<'_, Gateway>, id: String) -> Result<Option<Reques
     gw.admin().get_log(&id).await.map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn clear_logs(gw: State<'_, Gateway>) -> Result<u64, String> {
+    gw.admin().clear_logs().await.map_err(|e| e.to_string())
+}
+
 // ── Stats ──
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             commands::delete_api_key,
             commands::query_logs,
             commands::get_log,
+            commands::clear_logs,
             commands::get_stats_overview,
             commands::get_stats_hourly,
             commands::get_stats_by_model,

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -154,6 +154,8 @@ function resolveHTTP(cmd: string, args?: Record<string, unknown>): HTTPMapping {
     }
     case "get_log":
       return { method: "GET", url: `${base}/logs/${args?.id}` };
+    case "clear_logs":
+      return { method: "DELETE", url: `${base}/logs` };
 
     case "get_stats_overview": {
       const hours = args?.hours;

--- a/webui/src/pages/logs.tsx
+++ b/webui/src/pages/logs.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, ScrollText } from "lucide-react";
+import { ChevronLeft, ChevronRight, ScrollText, Trash2 } from "lucide-react";
 
 import { backend } from "@/lib/backend";
 import type { LogPage, LogQuery, Provider, RequestLog } from "@/lib/types";
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { LogDetailDialog } from "@/components/log-detail-dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 const PAGE_SIZE = 11;
 const ALL_OPTION = "__all__";
@@ -26,10 +27,21 @@ const ALL_OPTION = "__all__";
 export default function LogsPage() {
   const { locale } = useLocale();
   const isZh = locale === "zh-CN";
+  const qc = useQueryClient();
 
   const [page, setPage] = useState(0);
   const [filter, setFilter] = useState<LogQuery>({ limit: PAGE_SIZE, offset: 0 });
   const [selected, setSelected] = useState<RequestLog | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const clearMut = useMutation({
+    mutationFn: () => backend("clear_logs"),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["logs"] });
+      setPage(0);
+      setConfirmOpen(false);
+    },
+  });
 
   const query: LogQuery = { ...filter, limit: PAGE_SIZE, offset: page * PAGE_SIZE };
 
@@ -123,6 +135,16 @@ export default function LogsPage() {
               ))}
             </SelectContent>
           </Select>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-10 w-10"
+            title={isZh ? "清空日志" : "Clear Logs"}
+            disabled={total === 0}
+            onClick={() => setConfirmOpen(true)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
         </div>
       </div>
 
@@ -284,6 +306,20 @@ export default function LogsPage() {
         onOpenChange={(open) => {
           if (!open) setSelected(null);
         }}
+      />
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={isZh ? "清空所有日志" : "Clear All Logs"}
+        description={
+          isZh
+            ? "确认清空所有请求日志？此操作不可恢复。"
+            : "All request logs will be permanently deleted. This action cannot be undone."
+        }
+        confirmText={isZh ? "清空" : "Clear"}
+        cancelText={isZh ? "取消" : "Cancel"}
+        onConfirm={() => clearMut.mutate()}
       />
     </div>
   );


### PR DESCRIPTION
FIX #209 

Add a clear all logs feature across the full stack:
- LogStore trait: add clear_all() method
- Storage backends (sqlite/postgres/mysql): implement DELETE FROM request_logs
- Memory backend: no-op implementation returning Ok(0)
- AdminService: expose clear_logs() method
- HTTP: add DELETE /api/v1/logs route and handler
- Tauri: add clear_logs IPC command
- webui backend.ts: map clear_logs to DELETE /logs
- webui logs.tsx: add icon button with ConfirmDialog and useMutation

