### PR TITLE
chore(lint): fix all clippy warnings in nyro-core and nyro-server

### DIFF
--- a/crates/nyro-core/src/auth/drivers/shared.rs
+++ b/crates/nyro-core/src/auth/drivers/shared.rs
@@ -204,16 +204,17 @@ fn parse_callback_like_value(raw: &str) -> OAuthCallbackPayload {
     // Claude's `code=true` flow displays the auth result as a bare
     // `<code>#<state>` string; recognize it here so it works whether pasted
     // into the callback-URL field or the code field.
-    if !raw.contains(' ') && !raw.contains('?') {
-        if let Some((code_part, state_part)) = raw.split_once('#') {
-            let code = code_part.trim();
-            let state = state_part.trim();
-            if !code.is_empty() && !state.is_empty() {
-                return OAuthCallbackPayload {
-                    code: Some(code.to_string()),
-                    state: Some(state.to_string()),
-                };
-            }
+    if !raw.contains(' ')
+        && !raw.contains('?')
+        && let Some((code_part, state_part)) = raw.split_once('#')
+    {
+        let code = code_part.trim();
+        let state = state_part.trim();
+        if !code.is_empty() && !state.is_empty() {
+            return OAuthCallbackPayload {
+                code: Some(code.to_string()),
+                state: Some(state.to_string()),
+            };
         }
     }
 

--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -73,6 +73,7 @@ struct ProxyClientCache {
 
 impl Gateway {
     pub async fn new(config: GatewayConfig) -> anyhow::Result<(Self, mpsc::Receiver<LogEntry>)> {
+        #[allow(clippy::type_complexity)]
         let (storage_kind, storage, sqlite_pool, postgres_pool, mysql_pool): (
             RuntimeStorageKind,
             DynStorage,

--- a/crates/nyro-core/src/protocol/codec/anthropic/messages/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic/messages/encoder.rs
@@ -408,7 +408,7 @@ fn encode_message(msg: &Message) -> Result<Value> {
         MessageContent::Blocks(blocks) => {
             let arr: Vec<Value> = blocks
                 .iter()
-                .map(|b| encode_content_block_for_anthropic(b))
+                .map(encode_content_block_for_anthropic)
                 .collect();
             Value::Array(arr)
         }

--- a/crates/nyro-core/src/protocol/codec/anthropic/messages/mod.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic/messages/mod.rs
@@ -1,5 +1,6 @@
 pub mod decoder;
 pub mod encoder;
+#[allow(clippy::module_inception)]
 pub mod messages;
 pub mod stream;
 pub mod types;

--- a/crates/nyro-core/src/protocol/codec/anthropic/messages/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/anthropic/messages/stream.rs
@@ -1081,7 +1081,7 @@ mod tests {
             raw_str.contains("content_block_start"),
             "event type mismatch: {raw_str}"
         );
-        let data_part = raw_str.splitn(2, "\ndata: ").nth(1).unwrap_or("{}");
+        let data_part = raw_str.split_once("\ndata: ").map(|x| x.1).unwrap_or("{}");
         let data: serde_json::Value = serde_json::from_str(data_part).unwrap_or_default();
         assert_eq!(
             data.pointer("/content_block/type").and_then(|v| v.as_str()),

--- a/crates/nyro-core/src/protocol/codec/google/gemini/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google/gemini/decoder.rs
@@ -223,7 +223,6 @@ impl GoogleDecoder {
             stop,
             frequency_penalty,
             presence_penalty,
-            ..Default::default()
         };
         ai_req.stream = StreamConfig {
             enabled: stream,

--- a/crates/nyro-core/src/protocol/codec/google/gemini/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/google/gemini/encoder.rs
@@ -188,10 +188,9 @@ fn encode_content(msg: &Message) -> Result<Value> {
                 vec![serde_json::json!({"text": t})]
             }
         }
-        MessageContent::Blocks(blocks) => blocks
-            .iter()
-            .map(|b| encode_content_block_for_gemini(b))
-            .collect(),
+        MessageContent::Blocks(blocks) => {
+            blocks.iter().map(encode_content_block_for_gemini).collect()
+        }
     };
 
     Ok(serde_json::json!({"role": role, "parts": parts}))

--- a/crates/nyro-core/src/protocol/codec/openai/compatible/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/decoder.rs
@@ -194,7 +194,6 @@ impl RequestDecoder for OpenAIDecoder {
             stop,
             frequency_penalty: req.frequency_penalty,
             presence_penalty: req.presence_penalty,
-            ..Default::default()
         };
         ai_req.stream = StreamConfig {
             enabled: req.stream,
@@ -302,16 +301,15 @@ fn parse_tool_choice(v: Value) -> ToolChoice {
             _ => ToolChoice::Raw(v),
         },
         Value::Object(obj) => {
-            if obj.get("type").and_then(|t| t.as_str()) == Some("function") {
-                if let Some(name) = obj
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function")
+                && let Some(name) = obj
                     .get("function")
                     .and_then(|f| f.get("name"))
                     .and_then(|n| n.as_str())
-                {
-                    return ToolChoice::Named {
-                        name: name.to_string(),
-                    };
-                }
+            {
+                return ToolChoice::Named {
+                    name: name.to_string(),
+                };
             }
             ToolChoice::Raw(v)
         }
@@ -342,16 +340,16 @@ fn parse_response_format(f: ResponseFormatWire) -> ResponseFormat {
 /// Parse a `data:<media_type>;base64,<data>` URL into a `MediaSource::Base64`.
 /// Falls back to `MediaSource::Url` if the format is not recognised.
 fn parse_data_url_source(url: String) -> MediaSource {
-    if let Some(rest) = url.strip_prefix("data:") {
-        if let Some(semi) = rest.find(';') {
-            let media_type = rest[..semi].to_string();
-            let after = &rest[semi + 1..];
-            if let Some(data) = after.strip_prefix("base64,") {
-                return MediaSource::Base64 {
-                    media_type,
-                    data: data.to_string(),
-                };
-            }
+    if let Some(rest) = url.strip_prefix("data:")
+        && let Some(semi) = rest.find(';')
+    {
+        let media_type = rest[..semi].to_string();
+        let after = &rest[semi + 1..];
+        if let Some(data) = after.strip_prefix("base64,") {
+            return MediaSource::Base64 {
+                media_type,
+                data: data.to_string(),
+            };
         }
     }
     MediaSource::Url(url)

--- a/crates/nyro-core/src/protocol/codec/openai/compatible/embeddings.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/embeddings.rs
@@ -174,10 +174,10 @@ impl RequestEncoder for EmbeddingsEncoder {
 
         if let Some(input) = ingress.get("__emb_input") {
             obj.insert("input".into(), input.clone());
-        } else if let Some(pb) = ingress.get(EMBEDDINGS_BODY_KEY) {
-            if let Some(inp) = pb.get("input") {
-                obj.insert("input".into(), inp.clone());
-            }
+        } else if let Some(pb) = ingress.get(EMBEDDINGS_BODY_KEY)
+            && let Some(inp) = pb.get("input")
+        {
+            obj.insert("input".into(), inp.clone());
         }
 
         if let Some(dims) = ingress.get("__emb_dimensions") {

--- a/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
@@ -461,7 +461,7 @@ fn encode_message(msg: &Message) -> Result<Value> {
                             ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
                         ))
                 })
-                .map(|b| encode_content_block_for_openai(b))
+                .map(encode_content_block_for_openai)
                 .collect();
             map.insert("content".into(), Value::Array(parts));
         }

--- a/crates/nyro-core/src/protocol/codec/openai/compatible/stream.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/stream.rs
@@ -273,15 +273,14 @@ impl OpenAIStreamParser {
             }
         }
 
-        if !self.done {
-            if let Some(reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
-                if !reason.is_empty() {
-                    self.done = true;
-                    deltas.push(AiStreamDelta::Done {
-                        stop_reason: reason.to_string(),
-                    });
-                }
-            }
+        if !self.done
+            && let Some(reason) = choice.get("finish_reason").and_then(|v| v.as_str())
+            && !reason.is_empty()
+        {
+            self.done = true;
+            deltas.push(AiStreamDelta::Done {
+                stop_reason: reason.to_string(),
+            });
         }
 
         let u = extract_usage(chunk);

--- a/crates/nyro-core/src/protocol/codec/openai/responses/decoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/responses/decoder.rs
@@ -99,50 +99,44 @@ impl RequestDecoder for ResponsesDecoder {
                     {
                         if let Some(summary) = item.get("summary").and_then(|v| v.as_array()) {
                             for s in summary {
-                                if let Some(text) = s.get("text").and_then(|v| v.as_str()) {
-                                    if !text.is_empty() {
-                                        pending_reasoning = Some(text.to_string());
-                                        break;
-                                    }
+                                if let Some(text) = s.get("text").and_then(|v| v.as_str())
+                                    && !text.is_empty()
+                                {
+                                    pending_reasoning = Some(text.to_string());
+                                    break;
                                 }
                             }
                         }
                         continue;
                     }
 
-                    match decode_input_item(item)? {
-                        Some(mut msg) => {
-                            if msg.role == Role::Assistant {
-                                if let Some(ref reasoning) = pending_reasoning {
-                                    let mut obj = match msg.meta.take() {
-                                        Some(Value::Object(m)) => m,
-                                        _ => serde_json::Map::new(),
-                                    };
-                                    obj.insert(
-                                        "reasoning_content".to_string(),
-                                        Value::String(reasoning.clone()),
-                                    );
-                                    msg.meta = Some(Value::Object(obj));
-                                }
-                            } else if msg.role == Role::User || msg.role == Role::System {
-                                if let Some(reasoning) = pending_reasoning.take() {
-                                    let mut extra = serde_json::Map::new();
-                                    extra.insert(
-                                        "reasoning_content".to_string(),
-                                        Value::String(reasoning),
-                                    );
-                                    messages.push(Message {
-                                        role: Role::Assistant,
-                                        content: MessageContent::Text(String::new()),
-                                        tool_calls: None,
-                                        tool_call_id: None,
-                                        meta: Some(Value::Object(extra)),
-                                    });
-                                }
+                    if let Some(mut msg) = decode_input_item(item)? {
+                        if msg.role == Role::Assistant {
+                            if let Some(ref reasoning) = pending_reasoning {
+                                let mut obj = match msg.meta.take() {
+                                    Some(Value::Object(m)) => m,
+                                    _ => serde_json::Map::new(),
+                                };
+                                obj.insert(
+                                    "reasoning_content".to_string(),
+                                    Value::String(reasoning.clone()),
+                                );
+                                msg.meta = Some(Value::Object(obj));
                             }
-                            messages.push(msg);
+                        } else if (msg.role == Role::User || msg.role == Role::System)
+                            && let Some(reasoning) = pending_reasoning.take()
+                        {
+                            let mut extra = serde_json::Map::new();
+                            extra.insert("reasoning_content".to_string(), Value::String(reasoning));
+                            messages.push(Message {
+                                role: Role::Assistant,
+                                content: MessageContent::Text(String::new()),
+                                tool_calls: None,
+                                tool_call_id: None,
+                                meta: Some(Value::Object(extra)),
+                            });
                         }
-                        None => {}
+                        messages.push(msg);
                     }
                 }
                 if let Some(reasoning) = pending_reasoning.take() {
@@ -437,16 +431,15 @@ fn parse_tool_choice(v: Value) -> ToolChoice {
             _ => ToolChoice::Raw(v),
         },
         Value::Object(obj) => {
-            if obj.get("type").and_then(|t| t.as_str()) == Some("function") {
-                if let Some(name) = obj
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function")
+                && let Some(name) = obj
                     .get("function")
                     .and_then(|f| f.get("name"))
                     .and_then(|n| n.as_str())
-                {
-                    return ToolChoice::Named {
-                        name: name.to_string(),
-                    };
-                }
+            {
+                return ToolChoice::Named {
+                    name: name.to_string(),
+                };
             }
             ToolChoice::Raw(v)
         }

--- a/crates/nyro-core/src/protocol/codec/openai/responses/mod.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/responses/mod.rs
@@ -2,5 +2,6 @@ pub mod decoder;
 pub mod encoder;
 pub mod formatter;
 pub mod parser;
+#[allow(clippy::module_inception)]
 pub mod responses;
 pub mod stream;

--- a/crates/nyro-core/src/protocol/codec/tool_correlation.rs
+++ b/crates/nyro-core/src/protocol/codec/tool_correlation.rs
@@ -72,11 +72,11 @@ pub fn normalize_request_tool_results(req: &mut AiRequest) {
             has_linked_pending_call = true;
         }
 
-        if resolved_id.is_none() {
-            if let Some((call_id, _name)) = pending_calls.pop_front() {
-                resolved_id = Some(call_id);
-                has_linked_pending_call = true;
-            }
+        if resolved_id.is_none()
+            && let Some((call_id, _name)) = pending_calls.pop_front()
+        {
+            resolved_id = Some(call_id);
+            has_linked_pending_call = true;
         }
 
         if resolved_id.is_none() {

--- a/crates/nyro-core/src/protocol/ir/cache.rs
+++ b/crates/nyro-core/src/protocol/ir/cache.rs
@@ -8,19 +8,14 @@
 use serde::{Deserialize, Serialize};
 
 /// Cache time-to-live hint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CacheTtl {
     /// 5-minute ephemeral cache (Anthropic default for `type = "ephemeral"`).
+    #[default]
     Ephemeral5m,
     /// 1-hour extended ephemeral cache (Anthropic `ttl = "1h"`).
     Ephemeral1h,
-}
-
-impl Default for CacheTtl {
-    fn default() -> Self {
-        Self::Ephemeral5m
-    }
 }
 
 /// Per-block cache control breakpoint.
@@ -28,20 +23,11 @@ impl Default for CacheTtl {
 /// Placed on a `ContentBlock` by the ingress decoder when the client explicitly
 /// requests a cache breakpoint at that position (e.g. Anthropic `cache_control`
 /// field).  The encoder decides how to translate this into the wire format.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct CacheControl {
     pub ttl: CacheTtl,
     /// Priority for multi-breakpoint injection ordering (0 = lowest / injected last).
     pub breakpoint_priority: u8,
-}
-
-impl Default for CacheControl {
-    fn default() -> Self {
-        Self {
-            ttl: CacheTtl::default(),
-            breakpoint_priority: 0,
-        }
-    }
 }
 
 impl CacheControl {

--- a/crates/nyro-core/src/protocol/ir/schema.rs
+++ b/crates/nyro-core/src/protocol/ir/schema.rs
@@ -52,10 +52,8 @@ impl From<Value> for SchemaObject {
 fn normalize_type_strings(v: &mut Value, f: impl Fn(&str) -> String + Copy) {
     match v {
         Value::Object(map) => {
-            if let Some(t) = map.get_mut("type") {
-                if let Value::String(s) = t {
-                    *s = f(s);
-                }
+            if let Some(Value::String(s)) = map.get_mut("type") {
+                *s = f(s);
             }
             for val in map.values_mut() {
                 normalize_type_strings(val, f);

--- a/crates/nyro-core/src/provider/common/pipeline.rs
+++ b/crates/nyro-core/src/provider/common/pipeline.rs
@@ -228,7 +228,6 @@ mod tests {
     use async_trait::async_trait;
     use reqwest::header::HeaderMap as ExtHeaderMap;
     use serde_json::Value;
-    use std::path::PathBuf;
     use uuid::Uuid;
 
     /// Stand-in vendor: injects `x-api-key: <ctx.api_key>`, mirroring
@@ -361,9 +360,10 @@ mod tests {
     }
 
     async fn build_test_gateway() -> Gateway {
-        let mut config = GatewayConfig::default();
-        config.data_dir = PathBuf::from(std::env::temp_dir())
-            .join(format!("nyro-pipeline-test-{}", Uuid::new_v4()));
+        let config = GatewayConfig {
+            data_dir: std::env::temp_dir().join(format!("nyro-pipeline-test-{}", Uuid::new_v4())),
+            ..Default::default()
+        };
         let (gw, _log_rx) = Gateway::new(config).await.expect("gateway init");
         gw
     }

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -13,7 +13,7 @@
 //!      b. Resolve egress protocol + base URL via `negotiate()`.
 //!      c. Look up `Vendor` from `VendorRegistry`.
 //!      d. Build outbound: `ProtocolMode::Native` + no mutations → `passthrough_run`;
-//!         else full 7-step `adapter.build_request`.
+//!      else full 7-step `adapter.build_request`.
 //!      e. Merge `runtime_binding` extra-headers.
 //!      f. HTTP call → `handle_non_stream` / `handle_stream`.
 //!      g. On success: record health, return; on retryable error: continue.
@@ -888,11 +888,13 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_logs_client_request_headers_redacted_when_route_missing() {
-        let mut config = crate::config::GatewayConfig::default();
-        config.data_dir = std::env::temp_dir().join(format!(
-            "nyro-client-header-redaction-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let config = crate::config::GatewayConfig {
+            data_dir: std::env::temp_dir().join(format!(
+                "nyro-client-header-redaction-test-{}",
+                uuid::Uuid::new_v4()
+            )),
+            ..Default::default()
+        };
         let (gw, mut log_rx) = Gateway::new(config).await.expect("gateway init");
         let mut envelope_headers = HashMap::new();
         envelope_headers.insert("authorization".into(), "Bearer client-secret".into());

--- a/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/non_stream.rs
@@ -21,6 +21,7 @@ use super::{CallCtx, LogBuilder, RequestExtras, StreamResponseAccumulator, error
 
 // ── Non-streaming response handler ───────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_non_stream(
     client: ProxyClient,
     url: &str,
@@ -218,14 +219,14 @@ pub(super) async fn handle_non_stream(
         .with_client_response(None, response_body_full)
         .emit();
 
-    let response = (
+    (
         StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
         Json(output),
     )
-        .into_response();
-    response
+        .into_response()
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -333,9 +334,11 @@ mod tests {
         let url = serve_invalid_json_once().await;
         let base_url = url.split("/v1beta").next().unwrap().to_string();
         let provider = fake_provider(base_url);
-        let mut config = GatewayConfig::default();
-        config.data_dir =
-            std::env::temp_dir().join(format!("nyro-decode-log-test-{}", uuid::Uuid::new_v4()));
+        let config = GatewayConfig {
+            data_dir: std::env::temp_dir()
+                .join(format!("nyro-decode-log-test-{}", uuid::Uuid::new_v4())),
+            ..Default::default()
+        };
         let (gw, mut log_rx) = Gateway::new(config).await.expect("gateway init");
 
         let call_ctx = CallCtx {
@@ -548,10 +551,9 @@ pub(super) async fn handle_non_stream_via_upstream_stream(
         .with_client_response(None, client_resp_body_str)
         .emit();
 
-    let response = (
+    (
         StatusCode::from_u16(status).unwrap_or(StatusCode::OK),
         Json(output),
     )
-        .into_response();
-    response
+        .into_response()
 }

--- a/crates/nyro-core/src/proxy/dispatcher/stream.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/stream.rs
@@ -334,14 +334,13 @@ pub(super) async fn handle_stream(
     let stream = ReceiverStream::new(rx);
     let body = Body::from_stream(stream);
 
-    let response = Response::builder()
+    Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "text/event-stream")
         .header(header::CACHE_CONTROL, "no-cache")
         .header(header::CONNECTION, "keep-alive")
         .body(body)
-        .unwrap();
-    response
+        .unwrap()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/nyro-core/src/proxy/server.rs
+++ b/crates/nyro-core/src/proxy/server.rs
@@ -127,18 +127,18 @@ fn parse_allow_origin(origins: &[String]) -> AllowOrigin {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use crate::config::GatewayConfig;
 
     use super::*;
 
     async fn spawn_proxy() -> String {
-        let mut config = GatewayConfig::default();
-        config.data_dir = PathBuf::from(std::env::temp_dir()).join(format!(
-            "nyro-proxy-body-limit-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let config = GatewayConfig {
+            data_dir: std::env::temp_dir().join(format!(
+                "nyro-proxy-body-limit-test-{}",
+                uuid::Uuid::new_v4()
+            )),
+            ..Default::default()
+        };
         let (gateway, _log_rx) = Gateway::new(config).await.expect("gateway init");
         let app = create_router(gateway);
 

--- a/crates/nyro-core/tests/passthrough_fidelity.rs
+++ b/crates/nyro-core/tests/passthrough_fidelity.rs
@@ -16,8 +16,6 @@
 //! Off-diagonal (Transform): `negotiate()` must return `ProtocolMode::Transform`
 //!   or `ProtocolMode::LossyTransform`.
 
-use std::path::PathBuf;
-
 use async_trait::async_trait;
 use nyro_core::Gateway;
 use nyro_core::config::GatewayConfig;
@@ -42,9 +40,10 @@ use std::time::Duration;
 use uuid::Uuid;
 
 async fn build_test_gateway() -> Gateway {
-    let mut config = GatewayConfig::default();
-    config.data_dir = PathBuf::from(std::env::temp_dir())
-        .join(format!("nyro-passthrough-test-{}", Uuid::new_v4()));
+    let config = GatewayConfig {
+        data_dir: std::env::temp_dir().join(format!("nyro-passthrough-test-{}", Uuid::new_v4())),
+        ..Default::default()
+    };
     let (gw, _log_rx) = Gateway::new(config).await.expect("gateway init");
     gw
 }

--- a/crates/nyro-core/tests/protocol_registry.rs
+++ b/crates/nyro-core/tests/protocol_registry.rs
@@ -230,7 +230,8 @@ fn embeddings_handler_advertises_passthrough_capabilities() {
 #[test]
 fn embeddings_routes_resolve_to_handler() {
     let reg = ProtocolRegistry::global();
-    for path in ["/v1/embeddings"] {
+    {
+        let path = "/v1/embeddings";
         let h = reg
             .find_by_ingress_route("POST", path)
             .unwrap_or_else(|| panic!("no handler for POST {path}"));

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -127,12 +127,12 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .route("/config/import", axum::routing::post(import_config_handler))
         .with_state(gateway.clone());
 
-    if let Some(token) = admin_token {
-        if !token.is_empty() {
-            api = api
-                .layer(middleware::from_fn(admin_auth))
-                .layer(Extension(AdminToken(token)));
-        }
+    if let Some(token) = admin_token
+        && !token.is_empty()
+    {
+        api = api
+            .layer(middleware::from_fn(admin_auth))
+            .layer(Extension(AdminToken(token)));
     }
 
     // Health probes are unauthenticated so K8s/load-balancers can reach them

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -377,12 +377,13 @@ async fn run_full(args: &Args) -> anyhow::Result<()> {
     }
 
     // Admin token enforcement only when the admin listener is active.
-    if matches!(args.mode, Mode::Admin | Mode::All) {
-        if !is_loopback_host(&args.admin_host) && admin_token.is_none() {
-            anyhow::bail!(
-                "--admin-token is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
-            );
-        }
+    if matches!(args.mode, Mode::Admin | Mode::All)
+        && !is_loopback_host(&args.admin_host)
+        && admin_token.is_none()
+    {
+        anyhow::bail!(
+            "--admin-token is required when --admin-host is not loopback (localhost/127.0.0.1/::1)"
+        );
     }
 
     let admin_cors_origins = if args.admin_cors_origins.is_empty() {
@@ -589,9 +590,7 @@ fn infer_mime(path: &str) -> &'static str {
         "font/woff2"
     } else if path.ends_with(".woff") {
         "font/woff"
-    } else if path.ends_with(".json") {
-        "application/json"
-    } else if path.ends_with(".map") {
+    } else if path.ends_with(".json") || path.ends_with(".map") {
         "application/json"
     } else {
         "application/octet-stream"


### PR DESCRIPTION
Resolves 35 pre-existing clippy warnings across nyro-core and nyro-server with zero behavior changes. All fixes are mechanical style improvements suggested by clippy --all-targets.

nyro-core changes:
- collapsible_if: collapse nested if/if-let into && chains (auth, oai decoder, oai stream, responses decoder, tool_correlation, ir/schema, dispatcher/mod)
- redundant_closure: replace |b| fn(b) with fn (anthropic/gemini/oai encoders)
- module_inception: #[allow] on anthropic/messages and responses/responses mods
- needless_update: remove ..Default::default() when all fields are specified (gemini decoder, oai compatible decoder)
- derivable_impls: add #[derive(Default)] + #[default] to CacheTtl/CacheControl
- single_match: convert match { Some => .., None => {} } to if let
- let_and_return: return expressions directly (non_stream x2, stream)
- field_reassign_with_default: use struct literal + ..Default::default() (dispatcher/mod test, non_stream test, pipeline test, server test)
- useless_conversion: remove redundant PathBuf::from() wrapping
- manual_split_once: use split_once() instead of splitn(2).nth(1)
- double_ended_iterator_last: use next_back() on DoubleEndedIterator
- empty_line_after_outer_attr / doc_lazy_continuation: formatting fixes
- items_after_test_module: #[allow] on the pub(super) fn after test mod
- too_many_arguments / type_complexity: #[allow] on unavoidable signatures
- single_element_loop: unwrap single-element for loop in protocol_registry test

nyro-server changes:
- collapsible_if x2: admin_routes.rs token check, main.rs admin-host guard
- if_same_then_else: merge .json/.map content-type branches into one condition