### PR TITLE
fix(codec): skip cross-protocol internal keys in extra field passthrough

### DIFF
--- a/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
@@ -99,7 +99,12 @@ impl RequestEncoder for OpenAIEncoder {
         }
 
         // Passthrough any remaining unknown extra fields.
+        // Skip cross-protocol internal keys (e.g. __anthropic_*, __google_*)
+        // that are only meaningful to their respective codecs.
         for (k, v) in ingress {
+            if k.starts_with("__anthropic_") || k.starts_with("__google_") {
+                continue;
+            }
             obj.entry(k.clone()).or_insert_with(|| v.clone());
         }
 

--- a/crates/nyro-core/src/protocol/codec/openai/responses/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/responses/encoder.rs
@@ -153,8 +153,13 @@ impl RequestEncoder for ResponsesEncoder {
         }
 
         // Passthrough remaining unknown extra fields.
+        // Skip cross-protocol internal keys (e.g. __anthropic_*, __google_*)
+        // that are only meaningful to their respective codecs.
         for (k, v) in ingress {
-            if SKIP_FROM_EXTRA.contains(&k.as_str()) {
+            if SKIP_FROM_EXTRA.contains(&k.as_str())
+                || k.starts_with("__anthropic_")
+                || k.starts_with("__google_")
+            {
                 continue;
             }
             obj.entry(k.clone()).or_insert_with(|| v.clone());


### PR DESCRIPTION
## Problem

When encoding requests through the OpenAI compatible or Responses codecs, cross-protocol internal keys (e.g. `__anthropic_*`, `__google_*`) that are only meaningful to their respective codecs were being passed through in the extra field passthrough loop. This could cause unexpected behavior when proxying between different LLM protocols.

Fixes #221

## Fix

Filter out keys starting with `__anthropic_` or `__google_` in both:

- `crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs`
- `crates/nyro-core/src/protocol/codec/openai/responses/encoder.rs`

The Responses encoder already had a `SKIP_FROM_EXTRA` mechanism; this extends both encoders to consistently skip cross-protocol internal keys.