### PR TITLE
feat(core): deliver request-lifecycle P0 scaffolding

### DIFF
--- a/crates/nyro-core/src/lib.rs
+++ b/crates/nyro-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod error;
 pub mod integrations;
 pub mod logging;
+pub mod plugin;
 pub mod protocol;
 pub mod provider;
 pub mod proxy;

--- a/crates/nyro-core/src/plugin/mod.rs
+++ b/crates/nyro-core/src/plugin/mod.rs
@@ -1,0 +1,151 @@
+//! Unified extension kernel (P0 scaffolding for the request-lifecycle RFC).
+//!
+//! Nyro already has several compile-time, `inventory`-based registries that act
+//! as implicit plugin systems:
+//!
+//! - [`HookRegistry`] — request/response integration hooks.
+//! - [`VendorRegistry`] — provider vendor presets / adapters.
+//! - [`ProtocolRegistry`] — protocol endpoint handlers.
+//!
+//! [`PluginKernel`] is a thin, **read-only** façade that aggregates those
+//! registries behind one entry point. It does not own or replace them; it only
+//! offers a single place for future phases (`PhaseHook`, capabilities) and admin
+//! tooling to enumerate "what is loaded". Introducing it now is purely additive
+//! and changes no runtime behaviour.
+//!
+//! See `docs/design/lifecycle.md` for the full framework design.
+
+use std::sync::OnceLock;
+
+use crate::integrations::HookRegistry;
+use crate::protocol::registry::ProtocolRegistry;
+use crate::provider::VendorRegistry;
+
+/// The kind of extension capability a manifest entry represents.
+///
+/// Mirrors the capability taxonomy in the lifecycle RFC. Only the
+/// already-existing capabilities are surfaced today; `PhaseHook` /
+/// `TelemetryExporter` slots are reserved for later phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityKind {
+    /// A request-phase integration hook ([`crate::integrations::RequestHook`]).
+    RequestHook,
+    /// A response-phase integration hook ([`crate::integrations::ResponseHook`]).
+    ResponseHook,
+    /// A provider vendor preset/adapter.
+    ProviderVendor,
+    /// A protocol endpoint handler.
+    ProtocolEndpoint,
+}
+
+impl CapabilityKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CapabilityKind::RequestHook => "request_hook",
+            CapabilityKind::ResponseHook => "response_hook",
+            CapabilityKind::ProviderVendor => "provider_vendor",
+            CapabilityKind::ProtocolEndpoint => "protocol_endpoint",
+        }
+    }
+}
+
+/// A read-only description of one loaded extension.
+#[derive(Debug, Clone)]
+pub struct PluginManifest {
+    /// Stable identifier of the extension (hook name / vendor id / protocol id).
+    pub id: String,
+    /// Which capability slot this extension occupies.
+    pub capability: CapabilityKind,
+}
+
+/// Aggregated, read-only view over Nyro's compile-time extension registries.
+///
+/// Cheap to build (it only borrows the global registries) and cached as a
+/// process-wide singleton via [`PluginKernel::global`].
+pub struct PluginKernel {
+    hooks: &'static HookRegistry,
+    vendors: &'static VendorRegistry,
+    protocols: &'static ProtocolRegistry,
+}
+
+impl PluginKernel {
+    /// Process-wide kernel singleton.
+    pub fn global() -> &'static PluginKernel {
+        static KERNEL: OnceLock<PluginKernel> = OnceLock::new();
+        KERNEL.get_or_init(|| PluginKernel {
+            hooks: HookRegistry::global(),
+            vendors: VendorRegistry::global(),
+            protocols: ProtocolRegistry::global(),
+        })
+    }
+
+    /// Enumerate every loaded extension across all registries.
+    pub fn manifests(&self) -> Vec<PluginManifest> {
+        let mut out = Vec::new();
+
+        for hook in self.hooks.request_hooks() {
+            out.push(PluginManifest {
+                id: hook.name().to_string(),
+                capability: CapabilityKind::RequestHook,
+            });
+        }
+        for hook in self.hooks.response_hooks() {
+            out.push(PluginManifest {
+                id: hook.name().to_string(),
+                capability: CapabilityKind::ResponseHook,
+            });
+        }
+        for vendor in self.vendors.list_metadata() {
+            out.push(PluginManifest {
+                id: vendor.id.to_string(),
+                capability: CapabilityKind::ProviderVendor,
+            });
+        }
+        for handler in self.protocols.list() {
+            out.push(PluginManifest {
+                id: handler.id().to_string(),
+                capability: CapabilityKind::ProtocolEndpoint,
+            });
+        }
+
+        out
+    }
+
+    /// Manifests filtered to a single capability kind.
+    pub fn manifests_of(&self, kind: CapabilityKind) -> Vec<PluginManifest> {
+        self.manifests()
+            .into_iter()
+            .filter(|m| m.capability == kind)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kernel_aggregates_builtin_extensions() {
+        let kernel = PluginKernel::global();
+        let manifests = kernel.manifests();
+
+        // Built-in protocol endpoints and vendor presets are always registered,
+        // so the aggregated view must never be empty.
+        assert!(
+            !manifests.is_empty(),
+            "expected built-in extensions to be registered"
+        );
+        assert!(
+            !kernel
+                .manifests_of(CapabilityKind::ProtocolEndpoint)
+                .is_empty(),
+            "expected at least one protocol endpoint"
+        );
+        assert!(
+            !kernel
+                .manifests_of(CapabilityKind::ProviderVendor)
+                .is_empty(),
+            "expected at least one provider vendor"
+        );
+    }
+}

--- a/crates/nyro-core/src/proxy/context.rs
+++ b/crates/nyro-core/src/proxy/context.rs
@@ -14,6 +14,8 @@
 //! - **Protocol / routing fields** – filled in progressively as the request
 //!   moves through `intake → security → planner → dispatcher`.
 
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -184,6 +186,54 @@ impl Default for TraceSink {
     }
 }
 
+// ── ContextBag ──────────────────────────────────────────────────────────────────
+
+/// Type-keyed, request-scoped scratch space shared across all phases (Nyro's
+/// equivalent of OpenResty `ngx.ctx`). Values are keyed by their concrete type,
+/// so producers and consumers agree by type rather than stringly-typed keys.
+///
+/// The bag is shared across `RequestContext` clones (like `outcome` / `trace`)
+/// so a value inserted in one phase is visible to later phases.  `get` returns a
+/// clone to avoid borrowing through the internal lock.
+#[derive(Clone, Default)]
+pub struct ContextBag(Arc<Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>>);
+
+impl ContextBag {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert (or replace) the value stored for type `T`.
+    pub fn insert<T: Any + Send + Sync>(&self, value: T) {
+        if let Ok(mut guard) = self.0.lock() {
+            guard.insert(TypeId::of::<T>(), Box::new(value));
+        }
+    }
+
+    /// Fetch a clone of the value stored for type `T`, if present.
+    pub fn get<T: Any + Send + Sync + Clone>(&self) -> Option<T> {
+        self.0
+            .lock()
+            .ok()
+            .and_then(|guard| guard.get(&TypeId::of::<T>())?.downcast_ref::<T>().cloned())
+    }
+
+    /// Returns `true` if a value of type `T` is present.
+    pub fn contains<T: Any + Send + Sync>(&self) -> bool {
+        self.0
+            .lock()
+            .map(|guard| guard.contains_key(&TypeId::of::<T>()))
+            .unwrap_or(false)
+    }
+}
+
+impl std::fmt::Debug for ContextBag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.0.lock().map(|g| g.len()).unwrap_or(0);
+        f.debug_struct("ContextBag").field("len", &len).finish()
+    }
+}
+
 // ── RequestContext ────────────────────────────────────────────────────────────
 
 /// Unified per-request context.  Stored in `axum::Extension` and cloned into
@@ -221,6 +271,9 @@ pub struct RequestContext {
     pub outcome: Arc<OnceLock<RequestOutcome>>,
     /// Lightweight trace log.
     pub trace: TraceSink,
+    /// Type-keyed request-scoped scratch space (Nyro's `ngx.ctx`), shared
+    /// across clones and visible to every pipeline phase.
+    pub extensions: ContextBag,
 }
 
 impl RequestContext {
@@ -239,6 +292,7 @@ impl RequestContext {
             auth_subject: None,
             outcome: Arc::new(OnceLock::new()),
             trace: TraceSink::new(),
+            extensions: ContextBag::new(),
         }
     }
 

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -71,6 +71,7 @@ pub async fn dispatch_pipeline(
     envelope: RawEnvelope,
     request: AiRequest,
     ingress: ProtocolId,
+    mut ctx: RequestContext,
 ) -> Response {
     // Derive logging strings from envelope.
     let method_owned = envelope.method.clone();
@@ -224,9 +225,11 @@ pub async fn dispatch_pipeline(
         };
 
         // Resolve egress protocol + base URL via negotiate().
+        // The request-scoped `ctx` is threaded end-to-end from the ingress
+        // middleware (no per-target throwaway context); negotiate records its
+        // trace/egress decision onto it.
         let provider_protocols = ProviderProtocols::from_provider(&provider);
-        let mut req_ctx = RequestContext::new(ingress, std::time::Duration::from_secs(30));
-        let plan = match negotiate(ingress, None, Some(&provider_protocols), &mut req_ctx) {
+        let plan = match negotiate(ingress, None, Some(&provider_protocols), &mut ctx) {
             Ok(p) => p,
             Err(e) => {
                 last_response = Some(e.render(None));
@@ -438,7 +441,7 @@ pub async fn dispatch(
     ingress: ProtocolId,
     method: &'static str,
     path: &'static str,
-    _ctx: &mut RequestContext,
+    ctx: &mut RequestContext,
 ) -> Response {
     let flat_headers: std::collections::HashMap<String, String> = headers
         .iter()
@@ -456,7 +459,7 @@ pub async fn dispatch(
         Err(e) => return log_decode_error(&gw, &envelope, ingress, e),
     };
 
-    dispatch_pipeline(gw, headers, envelope, request, ingress).await
+    dispatch_pipeline(gw, headers, envelope, request, ingress, ctx.clone()).await
 }
 
 // ── Handler context types ─────────────────────────────────────────────────────
@@ -914,6 +917,10 @@ mod tests {
             envelope,
             request,
             OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+            crate::proxy::context::RequestContext::new(
+                OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+                std::time::Duration::from_secs(30),
+            ),
         )
         .await;
 

--- a/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
+++ b/crates/nyro-core/src/proxy/ingress/anthropic_messages/messages.rs
@@ -41,6 +41,7 @@ pub async fn handler(
         envelope,
         request,
         ANTHROPIC_MESSAGES_2023_06_01,
+        ctx.0,
     )
     .await
 }

--- a/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
+++ b/crates/nyro-core/src/proxy/ingress/google_generative/generate_content.rs
@@ -57,6 +57,7 @@ pub async fn handler(
         envelope,
         request,
         GOOGLE_GEMINI_GENERATE_CONTENT_V1BETA,
+        ctx.0,
     )
     .await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/chat_completions.rs
@@ -48,6 +48,7 @@ pub async fn handler(
         envelope,
         request,
         OPENAI_COMPATIBLE_CHAT_COMPLETIONS_V1,
+        ctx.0,
     )
     .await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_compatible/embeddings.rs
@@ -41,6 +41,7 @@ pub async fn handler(
         envelope,
         request,
         OPENAI_COMPATIBLE_EMBEDDINGS_V1,
+        ctx.0,
     )
     .await
 }

--- a/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
+++ b/crates/nyro-core/src/proxy/ingress/openai_responses/responses.rs
@@ -33,5 +33,5 @@ pub async fn handler(
         Ok(r) => r,
         Err(e) => return log_decode_error(&gw, &envelope, OPENAI_RESPONSES_V1, e),
     };
-    dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1).await
+    dispatch_pipeline(gw, headers, envelope, request, OPENAI_RESPONSES_V1, ctx.0).await
 }

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -1,0 +1,263 @@
+# Nyro 请求生命周期与扩展框架设计 RFC
+
+> 状态:Draft · 关联文档:[observability.md](./observability.md)(可观测性 exporter 是本框架的 `TelemetryExporter` capability)、[architecture.md](./architecture.md)
+
+---
+
+## 1. 背景与目标
+
+Nyro 正在从"本地代理网关"演进为工业级 AI 网关。当前的请求处理散落在 `proxy/dispatcher`、`integrations/hooks`、`provider`、`protocol` 等模块,扩展点(`RequestHook`/`ResponseHook`、`Vendor`、`EndpointHandler`)各自为政,缺少一个统一的**请求生命周期执行模型**。
+
+本 RFC 定义一套 **固定阶段(Phase)+ 原生逻辑(Native)+ 阶段 Hook + 全程 Context** 的请求处理管线,借鉴 nginx / OpenResty 的分阶段思想,但采用 Nyro 原生语义(操作协议中立 IR,而非字节流)。
+
+### 设计目标
+
+- **用固定的少数阶段覆盖完整请求生命周期**:新需求是"往已有阶段挂 Hook",而不是不断新增阶段。
+- **原生逻辑与扩展分离**:每个阶段有网关自带的原生步骤(authn / 路由 / 负载均衡 / 上游调用 / 日志),Hook 是挂在其旁的外部插入点。
+- **Context 贯穿全局**:一个 `RequestContext`(Nyro 版 `ngx.ctx`)从创建到销毁贯穿所有阶段,承载身份、路由、扩展数据与 `request_id` 关联。
+- **可治理 / 可观测**:扩展统一纳管(manifest、能力列表),可在 admin 列出;失败隔离明确。
+- **向后兼容**:现有 `HookRegistry` / `VendorRegistry` / `ProtocolRegistry` 平滑纳入。
+
+### 非目标
+
+- 首版不做动态加载 / WASM 形式的扩展(见 §9 执行模型决策,预留演进)。
+
+---
+
+## 2. 核心模型:请求生命周期管线
+
+每个阶段 = **原生步骤(Native)** + 紧随其后的 **阶段 Hook 插入点**。Context 全程贯穿。
+
+```
+Context 创建
+  │
+  ├─ OnRequest    [native: 抽取请求自带信息 → ctx]   → OnRequestHook   (改写 / 规范化 / 打标记)
+  ├─ OnAccess     [native: authn + 路由解析 + authz → ctx] → OnAccessHook (鉴权 / 限流 / 拦截)
+  ├─ OnUpstream   [native: 负载均衡选节点 + 解析 provider/凭证/egress → ctx] → OnUpstreamHook (短路 / 改节点)
+  ├─ OnResponse   [native: 上游 HTTP 调用 + 收响应 + decode→IR + 转客户端协议;状态/usage/延迟 → ctx] → OnResponseHook (响应整形 / 流式逐 chunk)
+  └─ OnLog        [native(async): 从 ctx 读快照 → LogBuilder.emit → DB] → OnLogHook(async) (metrics / trace / 投递外部组件)
+  │
+Context 销毁  (TelemetryGuard / ctx Drop,flush)
+```
+
+```mermaid
+flowchart TD
+    CC["Context 创建"] --> R
+    subgraph p1 [OnRequest]
+        R["native: 抽取 model/headers/IP/ingress 协议 → ctx"] --> RH["OnRequestHook"]
+    end
+    subgraph p2 [OnAccess]
+        A["native: authn + match_model 路由 + authz → ctx"] --> AH["OnAccessHook"]
+    end
+    subgraph p3 [OnUpstream]
+        U["native: LB 选节点 + provider/凭证/egress/actual_model → ctx"] --> UH["OnUpstreamHook"]
+    end
+    subgraph p4 [OnResponse]
+        S["native: 上游 HTTP + decode→IR + 转客户端协议;状态/usage/延迟 → ctx"] --> SH["OnResponseHook"]
+    end
+    subgraph p5 [OnLog]
+        L["native(async): 从 ctx 读快照 → LogBuilder.emit → DB"] --> LH["OnLogHook(async)"]
+    end
+    RH --> A
+    AH --> U
+    UH -->|"ShortCircuit 直接产出"| S
+    UH --> S
+    SH --> L
+    AH -->|"Reject"| L
+    LH --> CD["Context 销毁"]
+```
+
+---
+
+## 3. 各阶段详解(映射 Nyro 现状)
+
+| 阶段 | 原生逻辑(对应代码) | 注入 ctx | Hook 能做什么 | 可见上下文 |
+|---|---|---|---|---|
+| **OnRequest** | decode → `AiRequest`;抽取 model 名、headers、IP、ingress 协议 | routing key、原始信息 | 改写 routing key、参数规范化/钳制、内容预处理、按 ingress 协议分支、打标记 | 原始 `AiRequest` + headers/IP + ingress 协议(**无**身份/路由) |
+| **OnAccess** | authn(`find_api_key`,`dispatcher/auth.rs`)+ 路由解析(`match_model`,`dispatcher/mod.rs:99`)+ authz(`enable_auth`/model 绑定/rpm·配额) | `api_key_id`、鉴权参数、`model_id`、`route` | 自定义鉴权、限流、配额、内容拦截(可 `Reject`) | + 身份 + 路由 |
+| **OnUpstream** | 负载均衡选节点(`TargetSelector::select_ordered`)+ 解析 provider/凭证/egress/`actual_model`(`dispatcher/mod.rs:207`)。**不含 HTTP 调用** | 选中 target、上游 model | 短路产出(语义缓存/mock,可 `ShortCircuit`)、改节点、覆盖上游 model | + 选中节点 |
+| **OnResponse** | 上游 HTTP 调用 + 收响应 + decode → IR(`AiResponse`/`AiStreamDelta`)+ 转客户端协议(`non_stream.rs`/`stream.rs`) | `ResponseStats`(状态码、usage、上游延迟/TTFB、chunk 数)+ `outcome` | 响应整形;**流式逐 chunk 改 `AiStreamDelta`** | + 响应 |
+| **OnLog** | 异步:从 ctx 读快照 → `LogBuilder.emit()` → DB(`dispatcher/mod.rs:682`、`logging/mod.rs`) | —(消费端,不注入) | 派生/投递 metrics、trace、日志到外部组件 | 只读 ctx 快照 |
+
+> 现状缺口与修正:当前 `RequestHook` 跑在路由+鉴权**之后**,改不了路由 → 归入 `OnRequestHook`(路由前);流式无 hook → `OnResponseHook` 补齐。
+
+---
+
+## 4. PhaseCtx:贯穿全局的请求上下文(Nyro 版 ngx.ctx)
+
+Nyro 现有 `[proxy/context.rs](../../crates/nyro-core/src/proxy/context.rs)` 的 `RequestContext` 已是"每请求、逐阶段填充、Extension 传递"的设计(含 `request_id` / `deadline` / `cancellation` / write-once `outcome` / `trace`),理念等价于 OpenResty `ngx.ctx`,但有三个缺口需补齐:
+
+- **未真正贯穿**:`dispatch_pipeline` 不接收中间件注入的 ctx,而是在 target 循环内**每个 target 重建临时 ctx** 仅供 `negotiate()`(`dispatcher/mod.rs:228`),legacy `dispatch` 直接 `_ctx` 忽略 → 需端到端贯穿同一个 `RequestContext`。
+- **无任意键值袋**:只有固定 typed 字段,插件无处暂存跨阶段数据 → 新增**类型化扩展袋**(`http::Extensions` 或 TypeMap,按类型 `get/insert::<T: Any + Send + Sync>()`,避免 stringly-typed)。
+- **trace 是占位**:注释已写明将被 OpenTelemetry 取代 → 由 [observability.md](./observability.md) 接管。
+
+每个阶段 Hook 的唯一入参 `PhaseCtx` 定义为:
+
+```rust
+pub struct PhaseCtx<'a> {
+    pub req_ctx: &'a mut RequestContext,        // 贯穿全局的请求上下文 + 类型化扩展袋
+    pub request: &'a mut AiRequest,             // OnRequest/OnAccess/OnUpstream 可用
+    pub response: ResponseView<'a>,             // OnResponse: &mut AiResponse | &mut AiStreamDelta
+    pub host: &'a HostContext<'a>,              // storage/settings/metrics/http 稳定边界
+}
+```
+
+### 解析归原生,改写归 Hook(关键原则)
+
+`api_key_id` / `model_id` / `route` 的**解析(resolve)是原生边界步骤**,不是 Hook 的自由动作:
+
+- **OnRequestHook** 改写 `request.model`(routing key);
+- **OnAccess 原生** 再用改写后的值 `match_model` 解析出 `model_id`/`route` 注入 ctx。
+
+否则若 Hook 中途自行解析 model_id,会被后续改写作废(desync)。`request_id` 由此天然贯穿 metrics / trace / log,与 [observability.md](./observability.md) 闭环。
+
+### authn 的归位
+
+从设计原则看 **认证(authn)≠ 鉴权(authz)**:
+
+- **authn**(凭证 → 身份,`find_api_key`,只需原始凭证):best-effort 解析,有凭证才查;
+- **authz**(是否放行:`enable_auth` 强制 / model 绑定 / 配额):OnAccess 决策。
+
+首版将两者都放在 **OnAccess 原生**(顺序:authn → 路由 → authz)。这是有意识的取舍:`OnRequestHook` 阶段**拿不到身份**,做不了"按 api_key 路由"。若将来需要身份感知路由,把 authn 提前到 OnRequest 之前即可,是增量改动,不破坏阶段集合。
+
+> 性能注:`model_id` 解析走内存 `model_cache`(零 DB 成本);`api_key_id` 解析当前**直查 DB 且无缓存**(`storage/sqlite/mod.rs:834`),配额计数(`request_count_since`)也必须实时查 DB。可后续为 api_key 加 epoch 失效内存缓存,但配额计数是限流的固有实时代价。
+
+### 响应侧状态注入 ctx(ResponseStats)
+
+`RequestContext` 现已有粗粒度 `outcome: OnceLock<RequestOutcome>`(终态 + `status_code()`),但 `usage`/延迟/TTFB/chunk 数目前由 `LogBuilder`/`LogExtras`/`LogEntry` 单独携带、**未进 ctx**。为让 OnLog 与 OnLogHook 读同一份快照,OnResponse 原生应把响应侧状态注入扩展袋:
+
+```rust
+pub struct ResponseStats {
+    pub client_status: u16,
+    pub upstream_status: Option<u16>,
+    pub usage: Usage,
+    pub upstream_latency_ms: Option<i64>,
+    pub ttfb_ms: Option<i64>,           // 流式首 chunk
+    pub stream_chunks: u32,
+}
+```
+
+**职责分层**:
+- **ctx = 请求作用域的权威状态**(多阶段/Hook 共享):OnResponse 写,OnLog 与 OnLogHook 读。
+- **`LogEntry` = 序列化落库目标**:由 OnLog 原生**从 ctx 构建**,而非反向。
+- 这样原生 DB 落库与 OnLogHook 外部投递读的是**同一份 ctx 快照**,口径一致,`request_id` 贯穿。
+
+---
+
+## 5. 五个钉死的语义细节
+
+固定阶段集合要真正覆盖完整生命周期,以下语义必须明确:
+
+1. **失败重试循环归原生**:现状 target 循环(发请求→失败→换节点重发,`dispatcher/mod.rs:198-414`)。线性阶段不表达"回退重选",故约定:重试是 **OnUpstream(选节点)↔ OnResponse(调用)之间的原生控制流**,对外仍是单次生命周期。Hook 默认 **per-request**(只见最终胜出 attempt);需要 per-attempt 时在 OnUpstream 内部加,不外溢成新阶段。
+2. **HTTP 调用落在 OnResponse 原生开头**,OnUpstream 原生只"选节点"。这样 `OnUpstreamHook`(选完节点、调用之前)才能**短路**(缓存命中直接产出,跳过上游)。
+3. **authn 折进 OnAccess = 取舍**:OnRequestHook 无身份(见 §4)。
+4. **OnResponseHook 在流式下被反复调用**(每个 `AiStreamDelta` 一次),不是单次回调;实现上按"多次回调"设计。
+5. **OnLog 无条件执行**(像 nginx LOG):无论 OnAccess 拒绝、OnUpstream 短路、还是上游失败,流程都汇聚到 OnLog 再销毁 Context。
+
+---
+
+## 6. 扩展层:统一 Plugin + Capability
+
+阶段 Hook 是**数据面**的扩展点;Nyro 还有数据面之外的扩展点(provider、protocol、telemetry exporter)。它们都用**同一套 inventory 模式**收编为统一的 Plugin + Capability 中枢。
+
+```mermaid
+flowchart TD
+    subgraph host [Host - nyro-core]
+        K["PluginKernel<br/>统一注册中枢"]
+        HC["HostContext<br/>稳定边界:storage/config/metrics/http"]
+    end
+    subgraph caps [Capability = 扩展点]
+        PH["PhaseHook 五阶段<br/>OnRequest/OnAccess/OnUpstream/OnResponse/OnLog"]
+        VEN["ProviderVendor = Vendor/Extension"]
+        PROTO["ProtocolEndpoint = EndpointHandler"]
+        EXP["TelemetryExporter = ExporterFactory"]
+    end
+    subgraph future [演进留白 - 非首版]
+        WASM["WasmRuntime (sandbox)"]
+    end
+    K --> PH & VEN & PROTO & EXP
+    HC -.稳定边界.-> K
+    K -.future.-> WASM
+```
+
+核心抽象(注意:命名用 **Hook**,与现有 `HookRegistry` 一致;不用 Filter):
+
+```rust
+pub enum Phase { OnRequest, OnAccess, OnUpstream, OnResponse, OnLog }
+
+#[async_trait]
+pub trait PhaseHook: Send + Sync {
+    fn phase(&self) -> Phase;
+    async fn run(&self, ctx: &mut PhaseCtx<'_>) -> PhaseOutcome;
+}
+
+pub enum PhaseOutcome {
+    Continue,                                   // 进入下一个 Hook
+    ShortCircuit(axum::response::Response),     // 直接产出响应(仅 OnUpstream)
+    Reject(crate::error::GatewayError),         // 拒绝请求(仅 OnAccess)
+}
+
+pub trait Plugin: Send + Sync + 'static {
+    fn manifest(&self) -> &PluginManifest;      // id / version / capabilities
+    fn init(&self, host: &HostContext) -> anyhow::Result<()> { Ok(()) }
+}
+```
+
+### 执行顺序与优先级(YAGNI)
+
+- authn 在 OnAccess 之后,身份+路由已就绪,**OnAccess 的 Hook 统一在原生之后单点插入,无需 pre/post 优先级**。
+- 同阶段多个 Hook 之间:首版用**确定性注册顺序**;只有当出现"过滤器链组合"(主要是 `OnResponse` 流式整形,A 的输出喂给 B)时,才引入显式优先级。**不提前引入。**
+
+---
+
+## 7. 与现有扩展点的兼容映射
+
+- `RequestHook` / `ResponseHook` → `PhaseHook`:`RequestHook` 归 `OnRequest`/`OnAccess`,`ResponseHook` 归 `OnResponse`;`HookRegistry` 成为 kernel 内部委派,现有 `#[async_trait]` 签名与 `HookContext` 兼容(过渡期双轨)。
+- `Vendor` / `VendorExtension` → `ProviderVendor`;`VendorRegistry::resolve()` 三级解析原样保留。
+- `EndpointHandler` → `ProtocolEndpoint`;`ProtocolRegistry` 路由/别名表不动。
+- `ExporterFactory` → `TelemetryExporter`,与 [observability.md](./observability.md) 衔接。
+- **兼容策略**:首版只新增聚合层,不重写底层 registry → 调用点零改动、可分阶段迁移。
+
+---
+
+## 8. 模块布局
+
+新增 `crates/nyro-core/src/plugin/`(扩展中枢)与 `proxy` 内的阶段执行器:
+
+| 文件 | 职责 |
+|---|---|
+| `plugin/mod.rs` | `Plugin` / `PluginManifest` / `CapabilityKind` / `PluginKernel::global()` |
+| `plugin/host.rs` | `HostContext` 稳定边界(决定未来 WASM 可行性) |
+| `plugin/registry.rs` | `PluginKernel`:聚合 `HookRegistry` / `VendorRegistry` / `ProtocolRegistry` + exporter |
+| `proxy/phase.rs` | `Phase` / `PhaseHook` / `PhaseOutcome` / `PhaseCtx` 与链执行器 |
+
+配套改造:`[proxy/context.rs](../../crates/nyro-core/src/proxy/context.rs)` 给 `RequestContext` 加类型化扩展袋;`dispatch_pipeline` 改为端到端贯穿同一个 `RequestContext`,并按五阶段重排原生步骤(消除 target 循环内临时重建)。`lib.rs` 增加 `pub mod plugin;`。
+
+---
+
+## 9. 执行模型决策
+
+- **首版**:编译期 / 进程内(inventory + trait object),零开销、类型安全、与现状一致。
+- **不采纳(首版)**:cdylib 动态库 —— Rust 无稳定 ABI,跨版本崩溃风险、桌面分发风险高。
+- **未来留白**:WASM 沙箱(Envoy / Higress 路线)实现真正热插拔 + 安全隔离;前提是 `HostContext` 边界稳定 → 故首版把"边界设计"列为最高优先。
+
+---
+
+## 10. 治理与风险
+
+- **治理**:统一 manifest 支撑 admin "已加载扩展 / 版本 / 能力 / 启停";按 capability 启停可复用 settings 表(对齐 `[admin/settings.rs](../../crates/nyro-core/src/admin/settings.rs)` 的 config_epoch 机制)。
+- **失败隔离**:仅 `OnAccess` 可拒绝、仅 `OnUpstream` 可短路;`OnResponse` / `OnLog` / exporter 错误仅记录不影响主流量(沿用 hooks.rs 既定语义)。
+- **风险**:避免过度设计 —— WASM / 动态加载不进首版;保持 `nyro-core` 传输无关,binary 只负责注册。
+
+---
+
+## 11. 分阶段路线
+
+- **Phase 0 ✅ 已交付**:`RequestContext` 端到端贯穿 `dispatch_pipeline` + 类型化扩展袋(行为不变);`PluginKernel` 聚合现有 registry(纯新增)。
+  - `[proxy/context.rs](../../crates/nyro-core/src/proxy/context.rs)`:新增 `ContextBag`(类型键、跨 clone 共享、`insert/get/contains::<T>`),挂到 `RequestContext.extensions`,保持 `Clone/Debug`。
+  - `[proxy/dispatcher/mod.rs](../../crates/nyro-core/src/proxy/dispatcher/mod.rs)`:`dispatch_pipeline` 新增 `ctx: RequestContext` 入参,由 5 个 ingress shell 透传中间件注入的 ctx;移除 target 循环内每 target 重建的临时 ctx,`negotiate()` 改用贯穿 ctx(trace/egress 不再被丢弃)。
+  - `[plugin/mod.rs](../../crates/nyro-core/src/plugin/mod.rs)`:新增 `PluginKernel`(只读聚合 `HookRegistry`/`VendorRegistry`/`ProtocolRegistry`)+ `PluginManifest`/`CapabilityKind`,`lib.rs` 增 `pub mod plugin;`。
+  - 验证:`cargo check`/`clippy --all-targets` 零告警,`cargo test -p nyro-core` 全绿,行为零变更。
+- **Phase 1**:落地五阶段 `PhaseHook` + `PhaseOutcome` + `PhaseCtx`,按五阶段重排 `dispatch_pipeline` 原生步骤;统一 manifest 与 admin "已加载扩展" 只读视图。
+- **Phase 2**:补齐流式 `OnResponseHook`(`AiStreamDelta` per-chunk)与示例扩展(限流 / 语义缓存);按需引入 Hook 链优先级。
+- **Phase 3(留白)**:WASM 运行时,在稳定 `HostContext` 之上接入,业务与内置扩展零改动。

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -1,0 +1,199 @@
+# Nyro 可观测性框架设计 RFC
+
+> 状态:Draft · 关联文档:[lifecycle.md](./lifecycle.md)(本框架的 `TelemetryExporter` 是其扩展层的一个 capability)、[architecture.md](./architecture.md)
+
+---
+
+## 1. 背景与目标
+
+Nyro 正在从"本地代理网关"演进为工业级 AI 网关。当前可观测性能力分散且有限:
+
+- `tracing` subscriber 在三个 binary 各自初始化、过滤器不统一(`src-server/src/main.rs`、`src-tauri/src/lib.rs`、`crates/nyro-tools`)。
+- 结构化请求日志走独立数据面:`LogBuilder.emit()` → `send_log()` → `mpsc` → `logging::run_collector()` → DB(`crates/nyro-core/src/logging/mod.rs`)。
+- **没有** metrics / OpenTelemetry 任何依赖;`proxy/context.rs` 的 `TraceEvent` 注释明确写明 "P2-F will replace with OpenTelemetry"。
+
+本 RFC 设计一套以 **OpenTelemetry 为统一底座** 的框架级可观测性架构。
+
+### 设计目标
+
+- **业务解耦**:业务代码只面向 Facade(typed instrument 句柄 + `tracing` 宏),不感知具体后端。
+- **三信号统一**:metrics / traces / logs 共用一套 OTel SDK 与 `Resource`,通过 `request_id` 语义关联。
+- **配置可插拔**:按配置启停每个信号、挂载任意多个 exporter(OTLP / Prometheus / stdout / 复用 DB log)。
+- **传输层无关**:`nyro-core` 拥有全部可观测逻辑,binary 只调用 `observability::init()`。
+- **默认零开销**:未启用时所有信号走 no-op provider;启用时用预注册 instrument(原子变量)+ 批量异步导出,规避锁竞争。
+
+### 非目标
+
+- 不引入动态加载/WASM 形式的 exporter(由 [lifecycle.md](./lifecycle.md) 统筹未来演进)。
+- 不替换现有 DB 审计日志;DB log 被纳入框架成为一个一等 exporter,而非废弃。
+
+---
+
+## 2. 三层 / 三信号架构
+
+本框架采用 **Facade(门面)+ Pipeline(管线)+ Exporter(导出器)** 三层,统一承载 metrics / traces / logs 三信号。
+
+```mermaid
+flowchart TD
+    subgraph facade [L1 Facade 业务门面]
+        M["NyroMetrics handle<br/>requests_total / latency / tokens"]
+        T["tracing 宏 + span helpers"]
+        L["LogBuilder.emit() 既有结构化日志"]
+    end
+    subgraph pipeline [L2 Telemetry Pipeline 核心]
+        P["ObservabilityProvider<br/>MeterProvider / TracerProvider / LoggerProvider"]
+        CFG["ObservabilityConfig 解析 + Resource"]
+    end
+    subgraph exporters [L3 Exporter 插件层 - TelemetryExporter capability]
+        OTLP["OtlpExporter (gRPC/HTTP)"]
+        PROM["PrometheusExporter (pull /metrics)"]
+        STD["StdoutExporter (local/console)"]
+        DBLOG["DbLogExporter (复用 logging::run_collector)"]
+    end
+    M --> P
+    T --> P
+    L --> P
+    CFG --> P
+    P --> OTLP & PROM & STD & DBLOG
+    OTLP --> EXT["外部 OTel Collector / Jaeger / Tempo / Loki"]
+    PROM --> SCRAPE["Prometheus 抓取"]
+    DBLOG --> DB["Nyro SQLite/PG/MySQL logs 表"]
+```
+
+- **L1 Facade**:`NyroMetrics`(进程内一次性创建的 typed instrument 句柄)+ `tracing` 生态 + 既有 `LogBuilder`。业务侧禁止直接 import 任何 exporter。
+- **L2 Pipeline**:`ObservabilityProvider` 从 `ObservabilityConfig` 构建三个 OTel provider,组装 `Resource`(`service.name`/`service.version`/`deployment.environment`),返回 `TelemetryGuard`(Drop 时 flush)。
+- **L3 Exporter**:统一 `ExporterFactory` 抽象 + 注册表(沿用现有 `inventory` 模式,见 `integrations/hooks.rs`),新 exporter 通过注册即插入,无需改核心。该层即扩展框架的 `TelemetryExporter` capability(见 [lifecycle.md](./lifecycle.md))。
+
+---
+
+## 3. 内核 vs 插件:职责边界
+
+可观测性功能不是一刀切做成插件。**"测什么 / 在哪测" 是框架内核职责;"上报到哪、额外测什么" 是插件职责。**
+
+| 关注点 | 归属 | 说明 |
+|---|---|---|
+| OTel SDK 初始化、三 Provider、`Resource` | 内核(常驻 core) | 必须始终在场、与管线深耦合 |
+| `request_id` / trace 上下文贯穿 | 内核 | 由 `PhaseCtx`/`RequestContext` 承载(见 lifecycle.md) |
+| 核心指标权威埋点 | 内核 | `LogBuilder.emit()` 派生 requests_total / latency / tokens,单点埋点 |
+| 新增上报后端(OTLP/Prometheus/...) | 插件 | `TelemetryExporter` capability,配置即插拔 |
+| 自定义业务指标 / 日志富化 / 采样 | 插件 | `OnLog` PhaseFilter,拿只读快照异步打点 |
+
+---
+
+## 4. 核心抽象 (Traits)
+
+不重新发明 metric 数据模型:以 OTel SDK 类型为通用语言(`opentelemetry::metrics::{Meter, Counter, Histogram}`)。`ExporterFactory` 只负责把对应 OTel exporter 接到 provider 上。
+
+```rust
+// crates/nyro-core/src/observability/exporter/mod.rs
+pub enum SignalKind { Metrics, Traces, Logs }
+
+/// 一个 exporter 工厂:声明支持哪些信号,从配置片段构建并挂入 pipeline builder。
+pub trait ExporterFactory: Send + Sync {
+    fn kind(&self) -> &'static str;                 // "otlp" | "prometheus" | "stdout" | "nyro-db"
+    fn supports(&self, signal: SignalKind) -> bool;
+    fn install(&self, cfg: &ExporterConfig, builder: &mut PipelineBuilder) -> anyhow::Result<()>;
+}
+
+/// `inventory` 注册记录,与 RequestHookRegistration 模式一致。
+pub struct ExporterRegistration {
+    pub make: fn() -> Box<dyn ExporterFactory>,
+}
+inventory::collect!(ExporterRegistration);
+```
+
+`DbLogExporter` 把现有 `logging::run_collector()` → DB(`crates/nyro-core/src/logging/mod.rs`)封装为框架内的一等 log exporter,实现"既有审计日志"与"新可观测框架"的统一,而非另起炉灶。
+
+---
+
+## 5. 模块布局
+
+新增 `crates/nyro-core/src/observability/`:
+
+| 文件 | 职责 |
+|---|---|
+| `mod.rs` | 公开 API:`init(cfg) -> Result<TelemetryGuard>`、`metrics() -> &NyroMetrics`、`shutdown()` |
+| `config.rs` | `ObservabilityConfig` 全套 serde 结构(见 §6) |
+| `resource.rs` | 构建 OTel `Resource` |
+| `metrics.rs` | `NyroMetrics` typed instrument 注册表(预注册,低分配) |
+| `tracing.rs` | 统一 subscriber 装配:`EnvFilter` + fmt layer + `tracing-opentelemetry` layer;span helpers |
+| `logs.rs` | log 信号桥接(DB sink 默认 + 可选 OTLP logs) |
+| `pipeline.rs` | `PipelineBuilder`,按配置遍历 `ExporterFactory` 装配三 provider |
+| `exporter/{mod,otlp,prometheus,stdout,db_log}.rs` | trait + 内置工厂 |
+
+`lib.rs` 增加 `pub mod observability;`,`Gateway` 启动序列持有 `TelemetryGuard`。
+
+---
+
+## 6. 配置 Schema(serde,英文默认值)
+
+挂到 `GatewayConfig`(`crates/nyro-core/src/config.rs`)新增 `observability: ObservabilityConfig`,并贯通三种配置来源:`src-server` CLI/env、`src-server/src/yaml_config.rs`、`src-tauri` 默认。
+
+```yaml
+observability:
+  enabled: false                 # 总开关,默认关闭(桌面端默认全禁用,保证数据不离开本机)
+  service_name: "nyro"           # 默认英文
+  resource_attributes:
+    deployment.environment: "production"
+
+  metrics:
+    enabled: false
+    exporters: ["prometheus"]    # prometheus | otlp | stdout
+    prometheus:
+      listen: "127.0.0.1:9090"
+      path: "/metrics"
+    otlp:
+      endpoint: "http://127.0.0.1:4317"
+      protocol: "grpc"           # grpc | http
+      interval_secs: 30
+
+  traces:
+    enabled: false
+    exporters: ["otlp"]
+    sampler: "parent_based_traceid_ratio"
+    ratio: 0.1
+
+  logs:
+    exporters: ["nyro-db"]       # 默认保持现状(DB 审计);可加 "otlp"
+```
+
+设计说明:大部分为启动期静态配置;预留 admin `settings` 表运行时开关(对齐现有 `enable_payload` / `config_epoch` 热更新机制,`admin/settings.rs`)作为后续阶段。
+
+---
+
+## 7. 与现有代码的插桩对接点
+
+| 层级 | 文件 | 插桩内容 |
+|---|---|---|
+| 根 span / request_id 关联 | `proxy/context.rs::inject_context` | 用真实 OTel span 替换占位 `TraceEvent`/`TraceSink` |
+| 编排阶段 span + 指标 | `proxy/dispatcher/` | route/auth/hooks/target/upstream 各阶段 |
+| 指标单一发射点 | `LogBuilder::emit()`(`dispatcher/mod.rs`) | 从 `LogEntry`(已含 latency / usage / upstream_status / stream metrics)派生 `requests_total`、`latency_histogram`、`tokens_total`、`upstream_status` |
+| 健康 gauge | `router/health.rs` | target 熔断状态 |
+| 自定义观测 | `OnLogHook`(见 lifecycle.md) | 业务侧扩展埋点 |
+
+---
+
+## 8. 生命周期与性能防御
+
+- **初始化**:三 binary 统一改为 `observability::init(&cfg.observability)`,返回 `TelemetryGuard` 持有至进程退出。
+- **关闭**:Drop / 显式 `shutdown()` 触发批处理 flush(`BatchSpanProcessor` / periodic reader)。
+- **性能**:
+  1. 预注册 instrument(原子,无每调用分配)。
+  2. 批量异步导出,无重锁(避免 `std::sync::Mutex` 高频争用)。
+  3. **强制低基数**:禁止将 `api_key_id`、`user_id`、`timestamp`、model 实例等高基数动态变量作为 metric label;高基数信息只进 DB log / trace attribute。
+
+---
+
+## 9. 分阶段落地路线
+
+- **Phase 0**:配置 schema + 模块骨架 + 统一 subscriber init(默认禁用 / no-op,零行为变更)。
+- **Phase 1**:metrics 信号 —— `NyroMetrics` + Prometheus(`/metrics` 路由)+ OTLP;从 `LogBuilder::emit()` 与 dispatcher 发射。
+- **Phase 2**:traces 信号 —— `tracing-opentelemetry` 桥接,真实 span 取代 `TraceEvent`,OTLP traces。
+- **Phase 3**:logs 信号 —— OTLP log 桥接与 DB 并存;admin UI 运行时开关。
+
+---
+
+## 10. 依赖与风险
+
+- **新增 crate**:`opentelemetry`、`opentelemetry_sdk`、`opentelemetry-otlp`、`tracing-opentelemetry`;Prometheus 拉取用 `opentelemetry-prometheus` 或 `prometheus` crate(该 crate 生态版本需在实现期校准)。
+- **风险**:OTel Rust API 仍在演进 → 通过自有 `ExporterFactory` / `PipelineBuilder` 抽象隔离上游 breaking change;桌面端默认全禁用以保证"数据不离开本机"承诺。


### PR DESCRIPTION
Thread a single RequestContext end-to-end through dispatch_pipeline (forwarded from all 5 ingress shells, dropping the per-target throwaway context) and add a type-keyed ContextBag scratch space. Introduce a read-only PluginKernel aggregating the Hook/Vendor/Protocol registries.

Also add the lifecycle and observability design RFCs. Behaviour unchanged; check/clippy/test all green.