### PR TITLE
feat(core): request lifecycle & extension framework (P0 + P1)

### DIFF
--- a/crates/nyro-core/src/admin/extensions.rs
+++ b/crates/nyro-core/src/admin/extensions.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+impl AdminService {
+    /// Read-only snapshot of every compile-time extension registered with the
+    /// [`crate::plugin::PluginKernel`] — phase hooks, integration hooks,
+    /// provider vendors and protocol endpoints.
+    ///
+    /// Powers the admin "loaded extensions" panel. Pure in-memory aggregation;
+    /// no storage access.
+    pub async fn list_loaded_extensions(&self) -> anyhow::Result<Vec<Value>> {
+        Ok(crate::plugin::PluginKernel::global()
+            .manifests()
+            .into_iter()
+            .map(|m| {
+                serde_json::json!({
+                    "id": m.id,
+                    "capability": m.capability.as_str(),
+                })
+            })
+            .collect())
+    }
+}

--- a/crates/nyro-core/src/admin/mod.rs
+++ b/crates/nyro-core/src/admin/mod.rs
@@ -22,6 +22,7 @@ use crate::storage::traits::ProviderTestResult;
 
 mod api_keys;
 mod auth_data;
+mod extensions;
 mod import_export;
 mod model_catalog;
 mod model_data;

--- a/crates/nyro-core/src/plugin/mod.rs
+++ b/crates/nyro-core/src/plugin/mod.rs
@@ -15,6 +15,13 @@
 //!
 //! See `docs/design/lifecycle.md` for the full framework design.
 
+pub mod phase;
+
+pub use phase::{
+    HostContext, Phase, PhaseCtx, PhaseHook, PhaseHookRegistration, PhaseHookRegistry,
+    PhaseOutcome, ResponseView,
+};
+
 use std::sync::OnceLock;
 
 use crate::integrations::HookRegistry;
@@ -28,6 +35,8 @@ use crate::provider::VendorRegistry;
 /// `TelemetryExporter` slots are reserved for later phases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilityKind {
+    /// A lifecycle phase hook ([`phase::PhaseHook`]).
+    PhaseHook,
     /// A request-phase integration hook ([`crate::integrations::RequestHook`]).
     RequestHook,
     /// A response-phase integration hook ([`crate::integrations::ResponseHook`]).
@@ -41,6 +50,7 @@ pub enum CapabilityKind {
 impl CapabilityKind {
     pub fn as_str(self) -> &'static str {
         match self {
+            CapabilityKind::PhaseHook => "phase_hook",
             CapabilityKind::RequestHook => "request_hook",
             CapabilityKind::ResponseHook => "response_hook",
             CapabilityKind::ProviderVendor => "provider_vendor",
@@ -63,6 +73,7 @@ pub struct PluginManifest {
 /// Cheap to build (it only borrows the global registries) and cached as a
 /// process-wide singleton via [`PluginKernel::global`].
 pub struct PluginKernel {
+    phase_hooks: &'static PhaseHookRegistry,
     hooks: &'static HookRegistry,
     vendors: &'static VendorRegistry,
     protocols: &'static ProtocolRegistry,
@@ -73,6 +84,7 @@ impl PluginKernel {
     pub fn global() -> &'static PluginKernel {
         static KERNEL: OnceLock<PluginKernel> = OnceLock::new();
         KERNEL.get_or_init(|| PluginKernel {
+            phase_hooks: PhaseHookRegistry::global(),
             hooks: HookRegistry::global(),
             vendors: VendorRegistry::global(),
             protocols: ProtocolRegistry::global(),
@@ -83,6 +95,12 @@ impl PluginKernel {
     pub fn manifests(&self) -> Vec<PluginManifest> {
         let mut out = Vec::new();
 
+        for hook in self.phase_hooks.all() {
+            out.push(PluginManifest {
+                id: hook.name().to_string(),
+                capability: CapabilityKind::PhaseHook,
+            });
+        }
         for hook in self.hooks.request_hooks() {
             out.push(PluginManifest {
                 id: hook.name().to_string(),

--- a/crates/nyro-core/src/plugin/phase.rs
+++ b/crates/nyro-core/src/plugin/phase.rs
@@ -1,0 +1,194 @@
+//! Phase-hook type skeleton (lifecycle RFC P1-a).
+//!
+//! This module defines the *data-plane* extension contract from
+//! `docs/design/lifecycle.md` — the fixed five-phase model and the `PhaseHook`
+//! trait plugins implement, plus a compile-time registry mirroring the existing
+//! `inventory`-based registries.
+//!
+//! P1-a scope: **types + registration only**. Nothing here is wired into
+//! `dispatch_pipeline` yet (that is P1-c), so introducing it is purely additive
+//! and changes no runtime behaviour. `PhaseCtx` / `HostContext` are the stable
+//! boundary the future pipeline will hand to hooks.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::error::GatewayError;
+use crate::protocol::ir::{AiRequest, AiResponse, AiStreamDelta};
+use crate::proxy::context::RequestContext;
+use async_trait::async_trait;
+use axum::response::Response;
+
+/// The fixed set of request-lifecycle phases (Nyro's analogue of nginx's
+/// processing phases). The set is intentionally closed: new behaviour is added
+/// via hooks within a phase, not by inventing new phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Phase {
+    /// Shape the routing key from request-only data (e.g. model alias rewrite).
+    OnRequest,
+    /// Native authn → routing → authz; the only phase that may reject.
+    OnAccess,
+    /// Target selection / load balancing; hooks here may short-circuit.
+    OnUpstream,
+    /// Upstream call + response handling (per-chunk for streaming).
+    OnResponse,
+    /// Unconditional terminal phase: logs, metrics, telemetry dispatch.
+    OnLog,
+}
+
+impl Phase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::OnRequest => "on_request",
+            Phase::OnAccess => "on_access",
+            Phase::OnUpstream => "on_upstream",
+            Phase::OnResponse => "on_response",
+            Phase::OnLog => "on_log",
+        }
+    }
+}
+
+/// What a hook sees of the response, depending on phase and mode.
+///
+/// Phases before the upstream call see [`ResponseView::Pending`]; non-stream
+/// `OnResponse` sees [`ResponseView::Full`]; streaming `OnResponse` is invoked
+/// once per [`AiStreamDelta`] (see lifecycle RFC §5.4).
+pub enum ResponseView<'a> {
+    /// No response yet (OnRequest / OnAccess / OnUpstream).
+    Pending,
+    /// A fully-buffered non-streaming response.
+    Full(&'a mut AiResponse),
+    /// One streaming delta; the hook is called repeatedly.
+    Stream(&'a mut AiStreamDelta),
+}
+
+/// Stable host boundary handed to hooks: storage / config / metrics / http.
+///
+/// Backed by the already-aggregating [`crate::Gateway`]; kept as a distinct
+/// newtype so the surface stays stable even if `Gateway` internals change and
+/// so a future WASM runtime can be bridged against the same boundary.
+pub struct HostContext<'a> {
+    pub gateway: &'a crate::Gateway,
+}
+
+impl<'a> HostContext<'a> {
+    pub fn new(gateway: &'a crate::Gateway) -> Self {
+        Self { gateway }
+    }
+}
+
+/// The mutable, request-scoped context handed to every [`PhaseHook`].
+///
+/// `req_ctx` is the end-to-end [`RequestContext`] (with its type-keyed
+/// `extensions` bag); `request` is the protocol-neutral IR; `response` reflects
+/// the current phase; `host` is the stable host boundary.
+pub struct PhaseCtx<'a> {
+    pub req_ctx: &'a mut RequestContext,
+    pub request: &'a mut AiRequest,
+    pub response: ResponseView<'a>,
+    pub host: &'a HostContext<'a>,
+}
+
+/// Control-flow signal returned by a hook.
+pub enum PhaseOutcome {
+    /// Proceed to the next hook / native step.
+    Continue,
+    /// Produce a response directly, skipping the upstream call (OnUpstream).
+    ShortCircuit(Response),
+    /// Reject the request with a typed error (OnAccess).
+    Reject(GatewayError),
+}
+
+/// A data-plane plugin that runs within one lifecycle phase.
+#[async_trait]
+pub trait PhaseHook: Send + Sync {
+    /// Stable identifier, used for manifests / diagnostics.
+    fn name(&self) -> &'static str;
+    /// Which phase this hook attaches to.
+    fn phase(&self) -> Phase;
+    /// Execute the hook against the mutable phase context.
+    async fn run(&self, ctx: &mut PhaseCtx<'_>) -> PhaseOutcome;
+}
+
+/// Compile-time registration entry (mirrors `RequestHookRegistration` etc.).
+pub struct PhaseHookRegistration {
+    pub make: fn() -> Arc<dyn PhaseHook>,
+}
+
+inventory::collect!(PhaseHookRegistration);
+
+/// Process-wide registry of all submitted [`PhaseHook`]s.
+pub struct PhaseHookRegistry {
+    hooks: Vec<Arc<dyn PhaseHook>>,
+}
+
+impl PhaseHookRegistry {
+    /// Build (once) and return the global registry from all `inventory`
+    /// submissions across the linked crates.
+    pub fn global() -> &'static PhaseHookRegistry {
+        static REGISTRY: OnceLock<PhaseHookRegistry> = OnceLock::new();
+        REGISTRY.get_or_init(|| {
+            let hooks = inventory::iter::<PhaseHookRegistration>
+                .into_iter()
+                .map(|reg| (reg.make)())
+                .collect();
+            PhaseHookRegistry { hooks }
+        })
+    }
+
+    /// All registered hooks, in deterministic registration order.
+    pub fn all(&self) -> &[Arc<dyn PhaseHook>] {
+        &self.hooks
+    }
+
+    /// Hooks attached to a given phase, in deterministic registration order.
+    pub fn for_phase(&self, phase: Phase) -> Vec<&Arc<dyn PhaseHook>> {
+        self.hooks.iter().filter(|h| h.phase() == phase).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyOnRequestHook;
+
+    #[async_trait]
+    impl PhaseHook for DummyOnRequestHook {
+        fn name(&self) -> &'static str {
+            "test-dummy-on-request"
+        }
+        fn phase(&self) -> Phase {
+            Phase::OnRequest
+        }
+        async fn run(&self, _ctx: &mut PhaseCtx<'_>) -> PhaseOutcome {
+            PhaseOutcome::Continue
+        }
+    }
+
+    inventory::submit! {
+        PhaseHookRegistration { make: || Arc::new(DummyOnRequestHook) }
+    }
+
+    #[test]
+    fn registry_collects_submitted_hook_under_correct_phase() {
+        let reg = PhaseHookRegistry::global();
+        assert!(
+            reg.all()
+                .iter()
+                .any(|h| h.name() == "test-dummy-on-request"),
+            "submitted hook must appear in the registry"
+        );
+        assert!(
+            reg.for_phase(Phase::OnRequest)
+                .iter()
+                .any(|h| h.name() == "test-dummy-on-request"),
+            "hook must be grouped under its declared phase"
+        );
+        assert!(
+            reg.for_phase(Phase::OnLog)
+                .iter()
+                .all(|h| h.name() != "test-dummy-on-request"),
+            "hook must not leak into other phases"
+        );
+    }
+}

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -241,11 +241,17 @@ pub async fn dispatch_pipeline(
         PhaseOutcome::Reject(e) => {
             let resp = e.render(None);
             let status = resp.status().as_u16() as i32;
-            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, auth_key.id.as_deref(), start)
-                .stream_flag(is_stream)
-                .status_i32(status)
-                .with_req_extras(&req_extras)
-                .emit();
+            LogBuilder::from_dispatch(
+                &gw,
+                &ingress_str,
+                &request_model,
+                auth_key.id.as_deref(),
+                start,
+            )
+            .stream_flag(is_stream)
+            .status_i32(status)
+            .with_req_extras(&req_extras)
+            .emit();
             return resp;
         }
     }

--- a/crates/nyro-core/src/proxy/dispatcher/mod.rs
+++ b/crates/nyro-core/src/proxy/dispatcher/mod.rs
@@ -39,6 +39,9 @@ use serde_json::Value;
 use crate::Gateway;
 use crate::db::models::Provider;
 use crate::error::{AuthFailure, GatewayError};
+use crate::plugin::phase::{
+    HostContext, Phase, PhaseCtx, PhaseHookRegistry, PhaseOutcome, ResponseView,
+};
 use crate::protocol::ProviderProtocols;
 use crate::protocol::ids::ProtocolId;
 use crate::protocol::ir::Usage;
@@ -50,6 +53,46 @@ use crate::proxy::context::RequestContext;
 use crate::proxy::observability::{LogExtras, send_log};
 use crate::proxy::planner::{ProtocolMode, negotiate};
 use crate::router::TargetSelector;
+
+// ── Phase hook dispatch (lifecycle RFC P1-c) ────────────────────────────────────
+
+/// Run every registered [`crate::plugin::phase::PhaseHook`] for `phase` in
+/// deterministic order, threading the shared [`PhaseCtx`]. Returns the first
+/// non-`Continue` outcome (short-circuit / reject), or `Continue` when all hooks
+/// pass or none are registered.
+///
+/// Zero-overhead no-op when no phase hooks are registered, which is the default
+/// in production builds — so inserting these call sites is behaviour-neutral
+/// until a plugin opts in.
+async fn run_phase_hooks(
+    phase: Phase,
+    req_ctx: &mut RequestContext,
+    request: &mut AiRequest,
+    response: ResponseView<'_>,
+    host: &HostContext<'_>,
+) -> PhaseOutcome {
+    let registry = PhaseHookRegistry::global();
+    if registry.all().is_empty() {
+        return PhaseOutcome::Continue;
+    }
+    let hooks = registry.for_phase(phase);
+    if hooks.is_empty() {
+        return PhaseOutcome::Continue;
+    }
+    let mut pctx = PhaseCtx {
+        req_ctx,
+        request,
+        response,
+        host,
+    };
+    for hook in hooks {
+        match hook.run(&mut pctx).await {
+            PhaseOutcome::Continue => {}
+            outcome => return outcome,
+        }
+    }
+    PhaseOutcome::Continue
+}
 
 // ── Public entry points ───────────────────────────────────────────────────────
 
@@ -91,6 +134,25 @@ pub async fn dispatch_pipeline(
     };
     let mut request = request;
     let start = Instant::now();
+
+    // ── OnRequest phase ──────────────────────────────────────────────────────
+    // Hooks run before the routing key is derived, so they may reshape the
+    // request (e.g. rewrite `request.model`) before route lookup / auth.
+    let host = HostContext::new(&gw);
+    match run_phase_hooks(
+        Phase::OnRequest,
+        &mut ctx,
+        &mut request,
+        ResponseView::Pending,
+        &host,
+    )
+    .await
+    {
+        PhaseOutcome::Continue => {}
+        PhaseOutcome::ShortCircuit(resp) => return resp,
+        PhaseOutcome::Reject(e) => return e.render(None),
+    }
+
     let request_model = request.model.clone();
     let is_stream = request.stream.enabled;
     let ingress_str = ingress.to_string();
@@ -159,6 +221,32 @@ pub async fn dispatch_pipeline(
                 .emit();
                 return error_response(500, &e.to_string());
             }
+        }
+    }
+
+    // ── OnAccess phase ───────────────────────────────────────────────────────
+    // Identity (auth_key) and route are resolved; hooks may enforce access
+    // policy and reject the request before any upstream work begins.
+    match run_phase_hooks(
+        Phase::OnAccess,
+        &mut ctx,
+        &mut request,
+        ResponseView::Pending,
+        &host,
+    )
+    .await
+    {
+        PhaseOutcome::Continue => {}
+        PhaseOutcome::ShortCircuit(resp) => return resp,
+        PhaseOutcome::Reject(e) => {
+            let resp = e.render(None);
+            let status = resp.status().as_u16() as i32;
+            LogBuilder::from_dispatch(&gw, &ingress_str, &request_model, auth_key.id.as_deref(), start)
+                .stream_flag(is_stream)
+                .status_i32(status)
+                .with_req_extras(&req_extras)
+                .emit();
+            return resp;
         }
     }
 
@@ -268,6 +356,28 @@ pub async fn dispatch_pipeline(
             }
         };
 
+        // ── OnUpstream phase ─────────────────────────────────────────────────
+        // Target + vendor are selected but the upstream call has not happened.
+        // Hooks may short-circuit here (e.g. cache hit) to skip the upstream.
+        // Runs per-attempt inside the retry loop (see lifecycle RFC §5.1).
+        // NOTE: must run before `ctx` below shadows the threaded RequestContext.
+        match run_phase_hooks(
+            Phase::OnUpstream,
+            &mut ctx,
+            &mut request_for_target,
+            ResponseView::Pending,
+            &host,
+        )
+        .await
+        {
+            PhaseOutcome::Continue => {}
+            PhaseOutcome::ShortCircuit(resp) => return resp,
+            PhaseOutcome::Reject(e) => {
+                last_response = Some(e.render(None));
+                continue;
+            }
+        }
+
         let credential = provider_runtime.access_token.clone();
         let ctx = ProviderCtx {
             provider: &provider,
@@ -365,6 +475,9 @@ pub async fn dispatch_pipeline(
             enable_payload: route.enable_payload,
             start,
         };
+        // OnResponse / OnLog phase hooks are deferred to P2: OnResponse must
+        // handle per-chunk streaming mutations (`AiStreamDelta`) and OnLog needs
+        // the unified log-path (`ResponseStats` in ctx). Native handling below.
         let response = if is_stream {
             handle_stream(
                 client,

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -259,5 +259,9 @@ pub trait Plugin: Send + Sync + 'static {
   - `[plugin/mod.rs](../../crates/nyro-core/src/plugin/mod.rs)`:新增 `PluginKernel`(只读聚合 `HookRegistry`/`VendorRegistry`/`ProtocolRegistry`)+ `PluginManifest`/`CapabilityKind`,`lib.rs` 增 `pub mod plugin;`。
   - 验证:`cargo check`/`clippy --all-targets` 零告警,`cargo test -p nyro-core` 全绿,行为零变更。
 - **Phase 1**:落地五阶段 `PhaseHook` + `PhaseOutcome` + `PhaseCtx`,按五阶段重排 `dispatch_pipeline` 原生步骤;统一 manifest 与 admin "已加载扩展" 只读视图。
+  - **P1-a ✅ 已交付(类型骨架,纯新增)**:`[plugin/phase.rs](../../crates/nyro-core/src/plugin/phase.rs)` 定义 `Phase`/`PhaseOutcome`/`ResponseView`/`HostContext`/`PhaseCtx` + `PhaseHook` trait + `PhaseHookRegistration`(`inventory::collect!`)+ `PhaseHookRegistry`(`global()`/`all()`/`for_phase()`);`PluginKernel` 增 `CapabilityKind::PhaseHook` 并枚举 phase hook 槽位。**未接线 dispatch**,零行为变更;`clippy --all-targets` 零告警,新增 2 个单测通过。
+  - **P1-b ✅ 已交付(只读视图)**:`AdminService::list_loaded_extensions()`(聚合 `PluginKernel.manifests()` → `{id, capability}`)→ server `GET /api/v1/system/extensions` + tauri `get_loaded_extensions` 命令;WebUI 新增只读页 `[extensions.tsx](../../webui/src/pages/extensions.tsx)`(路由 `/extensions` + 侧栏入口,按 capability 分组展示)。
+  - **P1-c ✅ 已交付(请求侧三相位插点)**:`dispatch_pipeline` 在 `OnRequest`(派生路由键前)/`OnAccess`(鉴权后)/`OnUpstream`(选定 provider+vendor、构建 outbound 前,在 `ProviderCtx` 遮蔽 `RequestContext` 之前)三个原生边界插入 `run_phase_hooks()`,统一处理 `PhaseOutcome`(Continue / ShortCircuit→直接返回 / Reject→渲染+落日志)。空注册表时零分配 no-op,生产行为中性;`OnUpstream` 为 per-attempt(循环内)。
+  - **OnResponse / OnLog 插点归 P2**:`OnResponse` 需处理流式 per-chunk(`AiStreamDelta`),`OnLog` 需先统一日志路径(`ResponseStats` 入 ctx),已在响应处理处留 TODO。
 - **Phase 2**:补齐流式 `OnResponseHook`(`AiStreamDelta` per-chunk)与示例扩展(限流 / 语义缓存);按需引入 Hook 链优先级。
 - **Phase 3(留白)**:WASM 运行时,在稳定 `HostContext` 之上接入,业务与内置扩展零改动。

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -52,6 +52,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .delete(delete_api_key_handler);
 
     let mut api = Router::new()
+        .route("/system/extensions", get(list_loaded_extensions))
         .route("/providers/presets", get(list_provider_presets))
         .route(
             "/providers",
@@ -174,6 +175,13 @@ async fn list_providers(State(gw): State<Gateway>) -> impl IntoResponse {
 
 async fn list_provider_presets(State(gw): State<Gateway>) -> impl IntoResponse {
     match gw.admin().list_provider_presets().await {
+        Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
+        Err(e) => err(e),
+    }
+}
+
+async fn list_loaded_extensions(State(gw): State<Gateway>) -> impl IntoResponse {
+    match gw.admin().list_loaded_extensions().await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
         Err(e) => err(e),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -35,6 +35,16 @@ pub async fn get_provider_presets(
 }
 
 #[tauri::command]
+pub async fn get_loaded_extensions(
+    gw: State<'_, Gateway>,
+) -> Result<Vec<serde_json::Value>, String> {
+    gw.admin()
+        .list_loaded_extensions()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn create_provider(
     gw: State<'_, Gateway>,
     input: CreateProvider,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ pub fn run() {
             commands::get_providers,
             commands::get_provider,
             commands::get_provider_presets,
+            commands::get_loaded_extensions,
             commands::create_provider,
             commands::copy_provider,
             commands::update_provider,

--- a/webui/src/components/layout/sidebar.tsx
+++ b/webui/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   BarChart3,
   KeyRound,
   Plug,
+  Puzzle,
   ChevronLeft,
   Settings,
   MessageSquarePlus,
@@ -26,6 +27,7 @@ const NAV_ITEMS = [
   { type: "divider" as const },
   { label: "Logs", path: "/logs", icon: ScrollText },
   { label: "Stats", path: "/stats", icon: BarChart3 },
+  { label: "Extensions", path: "/extensions", icon: Puzzle },
   { type: "divider" as const },
   { label: "Settings", path: "/settings", icon: Settings },
   {
@@ -134,7 +136,9 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                             ? "日志"
                             : label === "Stats"
                               ? "统计"
-                              : "系统设置"
+                              : label === "Extensions"
+                                ? "扩展"
+                                : "系统设置"
                     : label}
                 </span>
               )}

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -64,6 +64,8 @@ function resolveHTTP(cmd: string, args?: Record<string, unknown>): HTTPMapping {
       return { method: "GET", url: `${base}/providers` };
     case "get_provider_presets":
       return { method: "GET", url: `${base}/providers/presets` };
+    case "get_loaded_extensions":
+      return { method: "GET", url: `${base}/system/extensions` };
     case "create_provider":
       return { method: "POST", url: `${base}/providers`, body: args?.input as Record<string, unknown> };
     case "copy_provider":

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -17,6 +17,7 @@ const ApiKeysPage = lazy(() => import("@/pages/api-keys"));
 const LogsPage = lazy(() => import("@/pages/logs"));
 const StatsPage = lazy(() => import("@/pages/stats"));
 const SettingsPage = lazy(() => import("@/pages/settings"));
+const ExtensionsPage = lazy(() => import("@/pages/extensions"));
 const ConnectPage = lazy(() => import("@/pages/connect"));
 const LoginPage = lazy(() => import("@/pages/login"));
 
@@ -49,6 +50,7 @@ createRoot(document.getElementById("root")!).render(
                   <Route path="logs" element={<LogsPage />} />
                   <Route path="stats" element={<StatsPage />} />
                   <Route path="connect" element={<ConnectPage />} />
+                  <Route path="extensions" element={<ExtensionsPage />} />
                   <Route path="settings" element={<SettingsPage />} />
                 </Route>
               </Routes>

--- a/webui/src/pages/extensions.tsx
+++ b/webui/src/pages/extensions.tsx
@@ -1,0 +1,120 @@
+import { useQuery } from "@tanstack/react-query";
+import { Puzzle } from "lucide-react";
+
+import { backend } from "@/lib/backend";
+import { useLocale } from "@/lib/i18n";
+import { Badge } from "@/components/ui/badge";
+
+type LoadedExtension = {
+  id: string;
+  capability: string;
+};
+
+const CAPABILITY_ORDER = [
+  "phase_hook",
+  "request_hook",
+  "response_hook",
+  "provider_vendor",
+  "protocol_endpoint",
+] as const;
+
+const CAPABILITY_LABELS: Record<string, { zh: string; en: string }> = {
+  phase_hook: { zh: "阶段 Hook", en: "Phase Hooks" },
+  request_hook: { zh: "请求 Hook", en: "Request Hooks" },
+  response_hook: { zh: "响应 Hook", en: "Response Hooks" },
+  provider_vendor: { zh: "提供商 Vendor", en: "Provider Vendors" },
+  protocol_endpoint: { zh: "协议端点", en: "Protocol Endpoints" },
+};
+
+export default function ExtensionsPage() {
+  const { locale } = useLocale();
+  const isZh = locale === "zh-CN";
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["loaded-extensions"],
+    queryFn: () => backend<LoadedExtension[]>("get_loaded_extensions"),
+  });
+
+  const extensions = data ?? [];
+
+  const grouped = new Map<string, LoadedExtension[]>();
+  for (const ext of extensions) {
+    const bucket = grouped.get(ext.capability) ?? [];
+    bucket.push(ext);
+    grouped.set(ext.capability, bucket);
+  }
+
+  const orderedCapabilities = [
+    ...CAPABILITY_ORDER.filter((cap) => grouped.has(cap)),
+    ...[...grouped.keys()].filter(
+      (cap) => !CAPABILITY_ORDER.includes(cap as (typeof CAPABILITY_ORDER)[number]),
+    ),
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">
+            {isZh ? "已加载扩展" : "Loaded Extensions"}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {isZh
+              ? "编译期注册的内置扩展(只读)"
+              : "Compile-time registered built-in extensions (read-only)"}
+          </p>
+        </div>
+        <Badge variant="secondary" className="text-xs">
+          {isZh ? `共 ${extensions.length} 项` : `${extensions.length} total`}
+        </Badge>
+      </div>
+
+      {isLoading && (
+        <div className="glass rounded-2xl p-6 text-sm text-slate-500">
+          {isZh ? "加载中..." : "Loading..."}
+        </div>
+      )}
+
+      {isError && (
+        <div className="glass rounded-2xl p-6 text-sm text-red-500">
+          {isZh ? "加载扩展列表失败" : "Failed to load extensions"}
+        </div>
+      )}
+
+      {!isLoading && !isError && extensions.length === 0 && (
+        <div className="glass rounded-2xl p-6 text-sm text-slate-500">
+          {isZh ? "暂无已加载扩展" : "No extensions loaded"}
+        </div>
+      )}
+
+      {!isLoading &&
+        !isError &&
+        orderedCapabilities.map((capability) => {
+          const items = grouped.get(capability) ?? [];
+          const label = CAPABILITY_LABELS[capability];
+          const title = label ? (isZh ? label.zh : label.en) : capability;
+          return (
+            <div key={capability} className="glass rounded-2xl p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <Puzzle className="h-4 w-4 text-slate-500" />
+                <h2 className="text-sm font-semibold text-slate-900">{title}</h2>
+                <Badge variant="outline" className="text-[10px]">
+                  {items.length}
+                </Badge>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {items.map((ext) => (
+                  <span
+                    key={`${capability}:${ext.id}`}
+                    className="rounded-lg border border-slate-200/80 bg-white/60 px-2.5 py-1 font-mono text-xs text-slate-700"
+                  >
+                    {ext.id}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+    </div>
+  );
+}


### PR DESCRIPTION
P0: thread a single RequestContext end-to-end through dispatch_pipeline (forwarded from all 5 ingress shells, dropping the per-target throwaway) and add a type-keyed ContextBag scratch space; add a read-only PluginKernel aggregating the Hook/Vendor/Protocol registries.

P1-a: define the phase-hook skeleton (Phase / PhaseOutcome / PhaseCtx / HostContext / PhaseHook + inventory-based PhaseHookRegistry).

P1-b: expose a read-only "loaded extensions" view end-to-end (AdminService::list_loaded_extensions -> server /system/extensions + tauri get_loaded_extensions -> WebUI /extensions page + sidebar entry).

P1-c: insert OnRequest / OnAccess / OnUpstream phase-hook points into dispatch_pipeline with unified PhaseOutcome handling. No-op when nd. OnResponse/OnLog deferred to P2.

Also add the lifecycle and observability design RFCs. check/clippy/test all green.