### PR TITLE
fix(core): Anthropic to OpenAI function calling failure

### DIFF
--- a/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
+++ b/crates/nyro-core/src/protocol/codec/openai/compatible/encoder.rs
@@ -450,25 +450,40 @@ fn encode_message(msg: &Message) -> Result<Value> {
             map.insert("content".into(), Value::String(t.clone()));
         }
         MessageContent::Blocks(blocks) => {
-            // Strip Thinking blocks for assistant messages — they are surfaced
-            // via the top-level `reasoning_content` field carried in `meta`
-            // (see anthropic::messages decoder). Emitting them as plain text
-            // would duplicate reasoning into the visible content and break
-            // upstreams like Xiaomi Mimo that require strict thinking-mode
-            // round-tripping via `reasoning_content`.
-            let filter_thinking = msg.role == Role::Assistant;
+            // For assistant messages, strip blocks that are already expressed
+            // elsewhere in the OpenAI shape:
+            //   - Thinking / RedactedThinking: surfaced via the top-level
+            //     `reasoning_content` field carried in `meta` (see the Anthropic
+            //     messages decoder). Emitting them as plain text would duplicate
+            //     reasoning and break strict thinking-mode upstreams.
+            //   - ToolUse: already expressed via the `tool_calls` array below.
+            //     Encoding it into `content` would produce `{type:"function"}`,
+            //     which OpenAI chat/completions rejects with
+            //     "unknown variant `function`, expected `text`". This is the
+            //     root cause of tool calls failing in Anthropic Messages →
+            //     OpenAI cross-protocol conversion (the Anthropic decoder
+            //     carries `tool_use` in BOTH `content` and `tool_calls`).
+            let strip_for_assistant = msg.role == Role::Assistant;
             let parts: Vec<Value> = blocks
                 .iter()
                 .filter(|b| {
-                    !(filter_thinking
+                    !(strip_for_assistant
                         && matches!(
                             b,
-                            ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
+                            ContentBlock::Thinking { .. }
+                                | ContentBlock::RedactedThinking { .. }
+                                | ContentBlock::ToolUse { .. }
                         ))
                 })
                 .map(encode_content_block_for_openai)
                 .collect();
-            map.insert("content".into(), Value::Array(parts));
+            if !parts.is_empty() {
+                map.insert("content".into(), Value::Array(parts));
+            }
+            // An assistant turn that carries only tool calls / thinking has no
+            // textual content — leave `content` unset (OpenAI accepts its
+            // absence when `tool_calls` is present) rather than emitting `[]`,
+            // which some strict upstreams reject.
         }
     }
 

--- a/crates/nyro-core/tests/protocol_conversion.rs
+++ b/crates/nyro-core/tests/protocol_conversion.rs
@@ -2260,3 +2260,122 @@ fn gemini_encoder_file_data_with_mime_type_emits_mime_type() {
     );
     assert_eq!(fd["mimeType"].as_str(), Some("application/pdf"));
 }
+
+#[test]
+fn anthropic_to_openai_strips_tool_use_from_content_array() {
+    // Regression for Anthropic Messages → OpenAI Chat Completions cross-protocol
+    // conversion: the Anthropic decoder carries an assistant `tool_use` BOTH in
+    // `content` blocks AND in `tool_calls`. The OpenAI encoder must NOT emit the
+    // ToolUse block into the `content` array (OpenAI only accepts text/image/...
+    // part types there) — otherwise strict upstreams reject with:
+    //   400 "messages[N]: unknown variant `function`, expected `text`".
+    // The tool call must instead live solely in the `tool_calls` array.
+    let raw = serde_json::json!({
+        "model": "deepseek-v4-flash",
+        "max_tokens": 1024,
+        "tools": [{
+            "name": "Bash",
+            "description": "run a shell command",
+            "input_schema": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}}
+            }
+        }],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "list the project files"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Sure, listing files."},
+                    {"type": "tool_use", "id": "call_a", "name": "Bash", "input": {"command": "ls -la"}}
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_a", "content": "file1\nfile2"}
+                ]
+            }
+        ]
+    });
+
+    let ir = AnthropicDecoder
+        .decode_request(raw)
+        .expect("decode anthropic request");
+
+    let (body, _) = OpenAIEncoder
+        .encode_request(&ir)
+        .expect("encode openai body");
+
+    let msgs = body
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .expect("messages array");
+
+    // (a) No assistant content part may carry type:"function" (the bug).
+    for (i, m) in msgs.iter().enumerate() {
+        if m.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        if let Some(arr) = m.get("content").and_then(|v| v.as_array()) {
+            for part in arr {
+                let ty = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                assert_ne!(
+                    ty, "function",
+                    "assistant[{i}] content leaked a `function` part into content array: {part:?}"
+                );
+            }
+        }
+    }
+
+    // (b) The tool call survives intact in tool_calls (id / name / arguments).
+    let call = msgs
+        .iter()
+        .filter_map(|m| m.get("tool_calls").and_then(|v| v.as_array()))
+        .flatten()
+        .find(|tc| tc.get("id").and_then(|v| v.as_str()) == Some("call_a"))
+        .expect("tool_call call_a must be preserved in tool_calls");
+    assert_eq!(call.get("type").and_then(|v| v.as_str()), Some("function"));
+    assert_eq!(
+        call.get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(|v| v.as_str()),
+        Some("Bash")
+    );
+    let args = call
+        .get("function")
+        .and_then(|f| f.get("arguments"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        args.contains("ls -la"),
+        "tool call arguments must survive, got: {args}"
+    );
+
+    // (c) tool_result message is correlated back to the same id.
+    let tool_msg = msgs
+        .iter()
+        .find(|m| m.get("role").and_then(|v| v.as_str()) == Some("tool"))
+        .expect("tool message present");
+    assert_eq!(
+        tool_msg.get("tool_call_id").and_then(|v| v.as_str()),
+        Some("call_a")
+    );
+
+    // (d) tool definitions survive.
+    let tools = body
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .expect("tools array");
+    assert_eq!(
+        tools[0].get("type").and_then(|v| v.as_str()),
+        Some("function")
+    );
+    assert_eq!(
+        tools[0]
+            .get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(|v| v.as_str()),
+        Some("Bash")
+    );
+}


### PR DESCRIPTION
- OpenAI encoder 剔除 assistant content 中多余的 ToolUse 块，避免向上游发出非法 {type:"function"} 触发 400
- 纯工具调用消息省略 content 字段，避免空数组被严格上游拒绝
- 补充跨协议工具调用回归测试