### PR TITLE
feat(logs): adds API key-level observability to the admin UI and fixes cache hit rate reporting.

### DIFF
--- a/crates/nyro-core/src/admin/observability.rs
+++ b/crates/nyro-core/src/admin/observability.rs
@@ -58,7 +58,10 @@ impl AdminService {
             .await
     }
 
-    pub async fn get_stats_by_api_key(&self, hours: Option<i32>) -> anyhow::Result<Vec<ApiKeyStats>> {
+    pub async fn get_stats_by_api_key(
+        &self,
+        hours: Option<i32>,
+    ) -> anyhow::Result<Vec<ApiKeyStats>> {
         self.gw
             .storage
             .logs()

--- a/crates/nyro-core/src/admin/observability.rs
+++ b/crates/nyro-core/src/admin/observability.rs
@@ -57,4 +57,12 @@ impl AdminService {
             .stats_by_provider(Self::normalize_hours(hours).map(i64::from))
             .await
     }
+
+    pub async fn get_stats_by_api_key(&self, hours: Option<i32>) -> anyhow::Result<Vec<ApiKeyStats>> {
+        self.gw
+            .storage
+            .logs()
+            .stats_by_api_key(Self::normalize_hours(hours).map(i64::from))
+            .await
+    }
 }

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -424,6 +424,17 @@ pub struct ProviderStats {
     pub avg_duration_ms: f64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ApiKeyStats {
+    pub api_key_id: String,
+    pub api_key_name: String,
+    pub request_count: i64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub last_used_at: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestResult {
     pub success: bool,

--- a/crates/nyro-core/src/db/models.rs
+++ b/crates/nyro-core/src/db/models.rs
@@ -379,6 +379,7 @@ pub struct LogQuery {
     pub model: Option<String>,
     pub status_min: Option<i32>,
     pub status_max: Option<i32>,
+    pub api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -6,7 +6,7 @@ use tokio::sync::RwLock;
 
 use crate::db::models::{
     CreateModel, CreateProvider, LogPage, LogQuery, Model, ModelStats, OAuthCredential, Provider,
-    ProviderStats, RequestLog, StatsHourly, StatsOverview, UpdateModel, UpdateProvider,
+    ProviderStats, ApiKeyStats, RequestLog, StatsHourly, StatsOverview, UpdateModel, UpdateProvider,
     UpsertOAuthCredential,
 };
 use crate::logging::LogEntry;
@@ -232,6 +232,10 @@ impl LogStore for MemoryStorage {
     }
 
     async fn stats_by_provider(&self, _hours: Option<i64>) -> anyhow::Result<Vec<ProviderStats>> {
+        Ok(vec![])
+    }
+
+    async fn stats_by_api_key(&self, _hours: Option<i64>) -> anyhow::Result<Vec<ApiKeyStats>> {
         Ok(vec![])
     }
 }

--- a/crates/nyro-core/src/storage/memory.rs
+++ b/crates/nyro-core/src/storage/memory.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use tokio::sync::RwLock;
 
 use crate::db::models::{
-    CreateModel, CreateProvider, LogPage, LogQuery, Model, ModelStats, OAuthCredential, Provider,
-    ProviderStats, ApiKeyStats, RequestLog, StatsHourly, StatsOverview, UpdateModel, UpdateProvider,
-    UpsertOAuthCredential,
+    ApiKeyStats, CreateModel, CreateProvider, LogPage, LogQuery, Model, ModelStats,
+    OAuthCredential, Provider, ProviderStats, RequestLog, StatsHourly, StatsOverview, UpdateModel,
+    UpdateProvider, UpsertOAuthCredential,
 };
 use crate::logging::LogEntry;
 

--- a/crates/nyro-core/src/storage/mysql.rs
+++ b/crates/nyro-core/src/storage/mysql.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::db::models::{
     ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats,
+    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
     RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
     UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
@@ -1095,6 +1095,19 @@ impl LogStore for MysqlLogStore {
             "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, CAST(COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS SIGNED) AS error_count, CAST(COALESCE(AVG(latency_total_ms), 0) AS DOUBLE) AS avg_duration_ms FROM request_logs GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC".to_string()
         };
         Ok(sqlx::query_as::<_, ProviderStats>(&sql)
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    async fn stats_by_api_key(&self, hours: Option<i64>) -> anyhow::Result<Vec<ApiKeyStats>> {
+        let sql = if let Some(hours) = hours {
+            format!(
+                "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, CAST(COALESCE(SUM(input_tokens), 0) AS SIGNED) AS total_input_tokens, CAST(COALESCE(SUM(output_tokens), 0) AS SIGNED) AS total_output_tokens, CAST(COALESCE(SUM(cache_read_tokens), 0) AS SIGNED) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' AND created_at >= UNIX_TIMESTAMP(NOW() - INTERVAL {hours} HOUR) * 1000 GROUP BY api_key_id, api_key_name ORDER BY request_count DESC"
+            )
+        } else {
+            "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, CAST(COALESCE(SUM(input_tokens), 0) AS SIGNED) AS total_input_tokens, CAST(COALESCE(SUM(output_tokens), 0) AS SIGNED) AS total_output_tokens, CAST(COALESCE(SUM(cache_read_tokens), 0) AS SIGNED) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' GROUP BY api_key_id, api_key_name ORDER BY request_count DESC".to_string()
+        };
+        Ok(sqlx::query_as::<_, ApiKeyStats>(&sql)
             .fetch_all(&self.pool)
             .await?)
     }

--- a/crates/nyro-core/src/storage/mysql.rs
+++ b/crates/nyro-core/src/storage/mysql.rs
@@ -6,10 +6,10 @@ use sqlx::{MySql, Pool};
 use std::time::Duration;
 
 use crate::db::models::{
-    ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
-    RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
-    UpsertOAuthCredential, is_valid_provider_auth_mode,
+    ApiKey, ApiKeyStats, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend,
+    CreateProvider, LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider,
+    ProviderStats, RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel,
+    UpdateProvider, UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
 use crate::logging::LogEntry;
 use crate::storage::sql::config::SqlBackendConfig;

--- a/crates/nyro-core/src/storage/mysql.rs
+++ b/crates/nyro-core/src/storage/mysql.rs
@@ -990,6 +990,11 @@ impl LogStore for MysqlLogStore {
             data_sql.push_str(" AND client_status_code <= ?");
             bind_values.push(status_max.to_string());
         }
+        if let Some(api_key) = query.api_key.filter(|v| !v.is_empty()) {
+            count_sql.push_str(" AND api_key_id = ?");
+            data_sql.push_str(" AND api_key_id = ?");
+            bind_values.push(api_key);
+        }
 
         data_sql.push_str(" ORDER BY created_at DESC LIMIT ? OFFSET ?");
 

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::db::models::{
     ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats,
+    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
     RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
     UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
@@ -1068,6 +1068,19 @@ impl LogStore for PostgresLogStore {
             "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms)::FLOAT8, 0) AS avg_duration_ms FROM request_logs GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC".to_string()
         };
         Ok(sqlx::query_as::<_, ProviderStats>(&sql)
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    async fn stats_by_api_key(&self, hours: Option<i64>) -> anyhow::Result<Vec<ApiKeyStats>> {
+        let sql = if let Some(hours) = hours {
+            format!(
+                "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' AND created_at >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '{hours} hours') * 1000 GROUP BY api_key_id, api_key_name ORDER BY request_count DESC"
+            )
+        } else {
+            "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' GROUP BY api_key_id, api_key_name ORDER BY request_count DESC".to_string()
+        };
+        Ok(sqlx::query_as::<_, ApiKeyStats>(&sql)
             .fetch_all(&self.pool)
             .await?)
     }

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -959,6 +959,12 @@ impl LogStore for PostgresLogStore {
             bind_values.push(status_max.to_string());
             idx += 1;
         }
+        if let Some(api_key) = query.api_key.filter(|v| !v.is_empty()) {
+            count_sql.push_str(&format!(" AND api_key_id = ${idx}"));
+            data_sql.push_str(&format!(" AND api_key_id = ${idx}"));
+            bind_values.push(api_key);
+            idx += 1;
+        }
 
         data_sql.push_str(&format!(
             " ORDER BY created_at DESC LIMIT ${idx} OFFSET ${}",

--- a/crates/nyro-core/src/storage/postgres/mod.rs
+++ b/crates/nyro-core/src/storage/postgres/mod.rs
@@ -6,10 +6,10 @@ use sqlx::{Pool, Postgres};
 use std::time::Duration;
 
 use crate::db::models::{
-    ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
-    RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
-    UpsertOAuthCredential, is_valid_provider_auth_mode,
+    ApiKey, ApiKeyStats, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend,
+    CreateProvider, LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider,
+    ProviderStats, RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel,
+    UpdateProvider, UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
 use crate::logging::LogEntry;
 use crate::storage::sql::config::SqlBackendConfig;

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -1053,6 +1053,11 @@ impl LogStore for SqliteLogStore {
             data_sql.push_str(" AND client_status_code <= ?");
             bind_values.push(status_max.to_string());
         }
+        if let Some(api_key) = query.api_key.filter(|v| !v.is_empty()) {
+            count_sql.push_str(" AND api_key_id = ?");
+            data_sql.push_str(" AND api_key_id = ?");
+            bind_values.push(api_key);
+        }
 
         data_sql.push_str(" ORDER BY created_at DESC LIMIT ? OFFSET ?");
         let mut count_query = sqlx::query_scalar::<_, i64>(&count_sql);

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 use crate::config::GatewayConfig;
 use crate::db;
 use crate::db::models::{
-    ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
-    RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
-    UpsertOAuthCredential, is_valid_provider_auth_mode,
+    ApiKey, ApiKeyStats, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend,
+    CreateProvider, LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider,
+    ProviderStats, RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel,
+    UpdateProvider, UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
 use crate::logging::LogEntry;
 use crate::storage::traits::{

--- a/crates/nyro-core/src/storage/sqlite/mod.rs
+++ b/crates/nyro-core/src/storage/sqlite/mod.rs
@@ -9,7 +9,7 @@ use crate::config::GatewayConfig;
 use crate::db;
 use crate::db::models::{
     ApiKey, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
-    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats,
+    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
     RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
     UpsertOAuthCredential, is_valid_provider_auth_mode,
 };
@@ -1168,6 +1168,23 @@ impl LogStore for SqliteLogStore {
         } else {
             Ok(sqlx::query_as::<_, ProviderStats>(
                 "SELECT COALESCE(provider_name, provider_id, '') AS provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN client_status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(AVG(latency_total_ms), 0.0) AS avg_duration_ms FROM request_logs GROUP BY COALESCE(provider_name, provider_id, '') ORDER BY request_count DESC",
+            )
+            .fetch_all(&self.pool)
+            .await?)
+        }
+    }
+
+    async fn stats_by_api_key(&self, hours: Option<i64>) -> anyhow::Result<Vec<ApiKeyStats>> {
+        if let Some(hours) = hours {
+            Ok(sqlx::query_as::<_, ApiKeyStats>(
+                "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' AND created_at >= CAST(strftime('%s', 'now', ?) AS INTEGER) * 1000 GROUP BY api_key_id, api_key_name ORDER BY request_count DESC",
+            )
+            .bind(format!("-{hours} hours"))
+            .fetch_all(&self.pool)
+            .await?)
+        } else {
+            Ok(sqlx::query_as::<_, ApiKeyStats>(
+                "SELECT COALESCE(api_key_id, '') AS api_key_id, COALESCE(api_key_name, api_key_id, '') AS api_key_name, COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS total_input_tokens, COALESCE(SUM(output_tokens), 0) AS total_output_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, MAX(created_at) AS last_used_at FROM request_logs WHERE api_key_id IS NOT NULL AND api_key_id <> '' GROUP BY api_key_id, api_key_name ORDER BY request_count DESC",
             )
             .fetch_all(&self.pool)
             .await?)

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use crate::db::models::{
     ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider, LogPage,
-    LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats,
+    LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
     RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
     UpsertOAuthCredential,
 };
@@ -133,6 +133,7 @@ pub trait LogStore: Send + Sync {
     async fn stats_hourly(&self, hours: i64) -> anyhow::Result<Vec<StatsHourly>>;
     async fn stats_by_model(&self, hours: Option<i64>) -> anyhow::Result<Vec<ModelStats>>;
     async fn stats_by_provider(&self, hours: Option<i64>) -> anyhow::Result<Vec<ProviderStats>>;
+    async fn stats_by_api_key(&self, hours: Option<i64>) -> anyhow::Result<Vec<ApiKeyStats>>;
 }
 
 #[async_trait]

--- a/crates/nyro-core/src/storage/traits.rs
+++ b/crates/nyro-core/src/storage/traits.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::db::models::{
-    ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider, LogPage,
-    LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats, ApiKeyStats,
+    ApiKeyStats, ApiKeyWithBindings, CreateApiKey, CreateModel, CreateModelBackend, CreateProvider,
+    LogPage, LogQuery, Model, ModelBackend, ModelStats, OAuthCredential, Provider, ProviderStats,
     RequestLog, StatsHourly, StatsOverview, UpdateApiKey, UpdateModel, UpdateProvider,
     UpsertOAuthCredential,
 };

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -508,6 +508,7 @@ struct LogQueryParams {
     model: Option<String>,
     status_min: Option<i32>,
     status_max: Option<i32>,
+    api_key: Option<String>,
 }
 
 async fn get_log_handler(
@@ -536,6 +537,7 @@ async fn query_logs_handler(
         model: params.model,
         status_min: params.status_min,
         status_max: params.status_max,
+        api_key: params.api_key,
     };
     match gw.admin().query_logs(q).await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),

--- a/src-server/src/admin_routes.rs
+++ b/src-server/src/admin_routes.rs
@@ -122,6 +122,7 @@ pub fn create_router(gateway: Gateway, admin_token: Option<String>) -> Router {
         .route("/stats/hourly", get(stats_hourly))
         .route("/stats/models", get(stats_by_model))
         .route("/stats/providers", get(stats_by_provider))
+        .route("/stats/api-keys", get(stats_by_api_key))
         .route("/settings/:key", get(get_setting).put(set_setting))
         .route("/status", get(get_status))
         .route("/config/export", get(export_config_handler))
@@ -604,6 +605,16 @@ async fn stats_by_provider(
     Query(params): Query<StatsRangeParams>,
 ) -> impl IntoResponse {
     match gw.admin().get_stats_by_provider(params.hours).await {
+        Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
+        Err(e) => err(e),
+    }
+}
+
+async fn stats_by_api_key(
+    State(gw): State<Gateway>,
+    Query(params): Query<StatsRangeParams>,
+) -> impl IntoResponse {
+    match gw.admin().get_stats_by_api_key(params.hours).await {
         Ok(v) => Json(serde_json::json!({ "data": v })).into_response(),
         Err(e) => err(e),
     }

--- a/webui/src/lib/backend.ts
+++ b/webui/src/lib/backend.ts
@@ -184,6 +184,13 @@ function resolveHTTP(cmd: string, args?: Record<string, unknown>): HTTPMapping {
         url: `${base}/stats/providers${hours != null ? `?hours=${hours}` : ""}`,
       };
     }
+    case "get_stats_by_api_key": {
+      const hours = args?.hours;
+      return {
+        method: "GET",
+        url: `${base}/stats/api-keys${hours != null ? `?hours=${hours}` : ""}`,
+      };
+    }
 
     case "get_setting":
       return { method: "GET", url: `${base}/settings/${args?.key}` };

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -291,6 +291,7 @@ export interface LogQuery {
   model?: string;
   status_min?: number;
   status_max?: number;
+  api_key?: string;
 }
 
 export interface ExportData {

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -149,6 +149,16 @@ export interface ProviderStats {
   avg_duration_ms: number;
 }
 
+export interface ApiKeyStats {
+  api_key_id: string;
+  api_key_name: string;
+  request_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  cache_read_tokens: number;
+  last_used_at: number;
+}
+
 export interface TestResult {
   success: boolean;
   latency_ms: number;

--- a/webui/src/pages/logs.tsx
+++ b/webui/src/pages/logs.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, ScrollText, Trash2 } from "lucide-react";
 
 import { backend } from "@/lib/backend";
-import type { LogPage, LogQuery, ModelStats, Provider, RequestLog } from "@/lib/types";
+import type { ApiKey, LogPage, LogQuery, ModelStats, Provider, RequestLog } from "@/lib/types";
 import { getRouteType } from "@/lib/types";
 import { formatDuration, formatLogTime, formatTokenCount } from "@/lib/format";
 import { prettyName } from "@/lib/protocol";
@@ -58,6 +58,10 @@ export default function LogsPage() {
     queryKey: ["stats", "models", "log-filter"],
     queryFn: () => backend("get_stats_by_model"),
   });
+  const { data: apiKeys = [] } = useQuery<ApiKey[]>({
+    queryKey: ["api-keys", "log-filter"],
+    queryFn: () => backend("list_api_keys"),
+  });
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
@@ -87,8 +91,16 @@ export default function LogsPage() {
     ],
     [isZh],
   );
+  const apiKeyOptions = useMemo(
+    () => [
+      { value: "", label: isZh ? "全部密钥" : "All API Keys" },
+      ...apiKeys.map((k) => ({ value: k.id, label: k.name })),
+    ],
+    [apiKeys, isZh],
+  );
 
   const providerFilterValue = filter.provider ?? ALL_OPTION;
+  const apiKeyFilterValue = filter.api_key ?? ALL_OPTION;
   const modelFilterValue = filter.model ?? ALL_OPTION;
   const statusFilterValue =
     (filter.status_min ?? null) === 200 && (filter.status_max ?? null) === 299
@@ -107,6 +119,24 @@ export default function LogsPage() {
           </p>
         </div>
         <div className="flex gap-2">
+          <Select
+            value={apiKeyFilterValue}
+            onValueChange={(value) => {
+              setFilter({ ...filter, api_key: value === ALL_OPTION ? undefined : value });
+              setPage(0);
+            }}
+          >
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder={isZh ? "密钥过滤" : "API Key Filter"} />
+            </SelectTrigger>
+            <SelectContent>
+              {apiKeyOptions.map((option) => (
+                <SelectItem key={`api-key-${option.value || "all"}`} value={option.value || ALL_OPTION}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Select
             value={providerFilterValue}
             onValueChange={(value) => {
@@ -199,6 +229,9 @@ export default function LogsPage() {
                   <th className="px-3 py-2.5 text-left font-medium">
                     {isZh ? "状态" : "Status"}
                   </th>
+                  <th className="px-3 py-2.5 text-left font-medium whitespace-nowrap">
+                    {isZh ? "密钥" : "API Key"}
+                  </th>
                   <th className="px-3 py-2.5 text-left font-medium">
                     {isZh ? "模型" : "Model"}
                   </th>
@@ -237,6 +270,9 @@ export default function LogsPage() {
                         >
                           {log.client_status_code ?? "–"}
                         </span>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">
+                        {log.api_key_name ?? "–"}
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-col leading-tight">

--- a/webui/src/pages/stats.tsx
+++ b/webui/src/pages/stats.tsx
@@ -243,7 +243,8 @@ export default function StatsPage() {
                 <tr><td className="px-4 py-6 text-center text-slate-400" colSpan={6}>{isZh ? "暂无数据" : "No data"}</td></tr>
               )}
               {apiKeyStats.slice(0, 8).map((k) => {
-                const cacheRate = k.total_input_tokens > 0 ? Math.round((k.cache_read_tokens / k.total_input_tokens) * 100) : 0;
+                const cacheTotal = k.total_input_tokens + k.cache_read_tokens;
+                const cacheRate = cacheTotal > 0 ? Math.round((k.cache_read_tokens / cacheTotal) * 100) : 0;
                 return (
                   <tr key={k.api_key_id} className="border-t border-white/70 text-slate-700">
                     <td className="px-4 py-2.5 font-medium">{k.api_key_name || k.api_key_id}</td>

--- a/webui/src/pages/stats.tsx
+++ b/webui/src/pages/stats.tsx
@@ -2,9 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, PieChart, Pie, Cell } from "recharts";
 import { backend } from "@/lib/backend";
-import type { StatsOverview, StatsHourly, ModelStats, ProviderStats } from "@/lib/types";
+import type { StatsOverview, StatsHourly, ModelStats, ProviderStats, ApiKeyStats } from "@/lib/types";
 import { Zap, Clock, Activity } from "lucide-react";
 import { useLocale } from "@/lib/i18n";
+import { formatLogTime } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -55,6 +56,12 @@ export default function StatsPage() {
   const { data: providerStats = [] } = useQuery<ProviderStats[]>({
     queryKey: ["stats-providers", hours],
     queryFn: () => backend("get_stats_by_provider", { hours }),
+    refetchInterval: 30_000,
+  });
+
+  const { data: apiKeyStats = [] } = useQuery<ApiKeyStats[]>({
+    queryKey: ["stats-apikeys", hours],
+    queryFn: () => backend("get_stats_by_api_key", { hours }),
     refetchInterval: 30_000,
   });
 
@@ -212,6 +219,45 @@ export default function StatsPage() {
                   <td className="px-4 py-2.5 text-right">{fmtLatency(p.avg_duration_ms)}</td>
                 </tr>
               ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="glass rounded-2xl p-6">
+        <h3 className="mb-4 text-sm font-semibold text-slate-800">{isZh ? "秘钥调用统计" : "API Key Usage"}</h3>
+        <div className="overflow-hidden rounded-xl border border-white/70 bg-white/50">
+          <table className="w-full text-sm">
+            <thead className="bg-white/70 text-slate-500">
+              <tr>
+                <th className="px-4 py-2.5 text-left font-medium">{isZh ? "密钥" : "API Key"}</th>
+                <th className="px-4 py-2.5 text-right font-medium">{isZh ? "请求数" : "Requests"}</th>
+                <th className="px-4 py-2.5 text-right font-medium">{isZh ? "输入 Token" : "Input Tokens"}</th>
+                <th className="px-4 py-2.5 text-right font-medium">{isZh ? "输出 Token" : "Output Tokens"}</th>
+                <th className="px-4 py-2.5 text-right font-medium">{isZh ? "缓存命中" : "Cache Hits"}</th>
+                <th className="px-4 py-2.5 text-right font-medium">{isZh ? "最后调用" : "Last Used"}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {apiKeyStats.length === 0 && (
+                <tr><td className="px-4 py-6 text-center text-slate-400" colSpan={6}>{isZh ? "暂无数据" : "No data"}</td></tr>
+              )}
+              {apiKeyStats.slice(0, 8).map((k) => {
+                const cacheRate = k.total_input_tokens > 0 ? Math.round((k.cache_read_tokens / k.total_input_tokens) * 100) : 0;
+                return (
+                  <tr key={k.api_key_id} className="border-t border-white/70 text-slate-700">
+                    <td className="px-4 py-2.5 font-medium">{k.api_key_name || k.api_key_id}</td>
+                    <td className="px-4 py-2.5 text-right">{fmt(k.request_count)}</td>
+                    <td className="px-4 py-2.5 text-right">{fmt(k.total_input_tokens)}</td>
+                    <td className="px-4 py-2.5 text-right">{fmt(k.total_output_tokens)}</td>
+                    <td className="px-4 py-2.5 text-right">
+                      <span>{fmt(k.cache_read_tokens)}</span>
+                      {cacheRate > 0 && <span className="ml-1 text-[11px] text-slate-400">{cacheRate}%</span>}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-xs text-slate-500 whitespace-nowrap">{formatLogTime(k.last_used_at)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
- 在请求日志页面新增 API Key 过滤功能。
    - 管理端日志 API 现在支持 `api_key` 查询参数。
    - SQLite、PostgreSQL 和 MySQL 的日志查询支持按 `api_key_id` 过滤。
    - WebUI 日志表新增 API Key 名称列，并提供 API Key 下拉筛选器。

  - 在统计页面新增 API Key 调用统计。
    - 新增 `ApiKeyStats` 模型和 `LogStore::stats_by_api_key` 接口。
    - SQLite、PostgreSQL、MySQL 和内存存储实现按 API Key 聚合统计。
    - 新增 `GET /stats/api-keys` 接口。
    - WebUI 展示每个 API Key 的请求数、输入 Token、输出 Token、缓存命中 Token 和最后调用时间。

  - 修复缓存命中率计算。
    - 缓存命中率现在按 `cache_read_tokens / (input_tokens + cache_read_tokens)` 计算。
    - 避免在缓存 Token 不计入普通输入 Token 时高估缓存命中率。
 
总儿言之，在统计里添加了对不同API_KEY来源的请求的相关统计信息。是一些我自己在用的功能，不影响任何其他地方逻辑，作者酌情接收。