### PR TITLE
feat(go): add gofumpt+goimports+golangci-lint tooling, wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,33 @@ jobs:
           path: target/debug/nyro-tools
           retention-days: 1
 
+  go-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+
+      - name: Go format check (gofumpt + goimports)
+        run: make go-fmt-check
+
+      - name: Go vet
+        run: make go-vet
+
+      - name: Go lint (golangci-lint)
+        run: make go-lint
+
+      - name: Go test
+        run: make go-test
+
   unit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: dev build server server-slim tools check test test-core test-server fmt fmt-check clean webui smoke smoke-storage release-check go-build go-test go-vet go-fmt go-tidy go-gen-storage go-run help
+.PHONY: dev build server server-slim tools check test test-core test-server fmt fmt-check clean webui smoke smoke-storage release-check go-build go-test go-vet go-fmt go-fmt-check go-lint go-lint-install go-check go-tidy go-gen-storage go-run help
+
+# golangci-lint version pinned for reproducible fmt/lint (installed to go/bin, never touches go.mod)
+GOLANGCI_LINT_VERSION := v2.6.0
+GOLANGCI_LINT := $(CURDIR)/go/bin/golangci-lint
 
 # Development — start Tauri desktop app with hot reload
 dev: webui-build
@@ -77,9 +81,25 @@ go-test:
 go-vet:
 	cd go && go vet ./...
 
-# Format Go code
-go-fmt:
-	cd go && go fmt ./...
+# Install golangci-lint into go/bin at the pinned version (idempotent, no go.mod/go.sum impact)
+go-lint-install:
+	@$(GOLANGCI_LINT) --version 2>/dev/null | grep -q $(GOLANGCI_LINT_VERSION:v%=%) || \
+		GOBIN=$(CURDIR)/go/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+# Format Go code (gofumpt + goimports, in place)
+go-fmt: go-lint-install
+	cd go && $(GOLANGCI_LINT) fmt
+
+# Check Go formatting without modifying files (used in CI)
+go-fmt-check: go-lint-install
+	cd go && $(GOLANGCI_LINT) fmt --diff
+
+# Lint Go code (errcheck, staticcheck, unused, bodyclose, unconvert, ...)
+go-lint: go-lint-install
+	cd go && $(GOLANGCI_LINT) run
+
+# Format, vet, lint, and test the Go module
+go-check: go-fmt-check go-vet go-lint go-test
 
 # Tidy go.mod / go.sum
 go-tidy:
@@ -122,7 +142,10 @@ help:
 	@echo "  make go-build     Build Go nyro CLI → go/bin/nyro"
 	@echo "  make go-test      Run Go tests"
 	@echo "  make go-vet       Vet Go code"
-	@echo "  make go-fmt       Format Go code"
+	@echo "  make go-fmt       Format Go code (gofumpt + goimports)"
+	@echo "  make go-fmt-check Check Go formatting (CI)"
+	@echo "  make go-lint      Lint Go code (golangci-lint)"
+	@echo "  make go-check     go-fmt-check + go-vet + go-lint + go-test"
 	@echo "  make go-tidy      Tidy go.mod/go.sum"
 	@echo "  make go-gen-storage Generate Go storage query code"
 	@echo "  make go-run       Run Go gateway (data plane)"

--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -1,14 +1,26 @@
-# golangci-lint config for the Nyro Go gateway.
-# Baseline linter is `go vet` (always available); this enables the standard
-# default set. Run: golangci-lint run   (or `make -C go vet` for plain vet).
+# golangci-lint (v2) config for the Nyro Go gateway.
+# Run: golangci-lint run          (lint)
+#      golangci-lint fmt          (gofumpt + goimports, in place)
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
+    - bodyclose
+    - unconvert
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/nyroway/nyro/go

--- a/go/internal/admin/admin.go
+++ b/go/internal/admin/admin.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/nyroway/nyro/go/internal/observability"
 	"github.com/nyroway/nyro/go/internal/plugin"
 	"github.com/nyroway/nyro/go/internal/provider"
@@ -132,7 +133,7 @@ func Mount(r chi.Router, s storage.Storage, adminToken string, logs LogSource, s
 				webutil.JSON(w, http.StatusOK, map[string]any{"success": false, "latency_ms": latency, "error": err.Error()})
 				return
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			success := resp.StatusCode < 400
 			webutil.JSON(w, http.StatusOK, map[string]any{"success": success, "latency_ms": latency, "status_code": resp.StatusCode})
 		})
@@ -418,9 +419,7 @@ type Broadcaster interface {
 	Notify()
 }
 
-var (
-	configBroadcasterVal Broadcaster
-)
+var configBroadcasterVal Broadcaster
 
 // SetBroadcaster wires the xDS push target. Call once at admin startup (after
 // Mount) if the gRPC ConfigServer is enabled. Safe to pass nil to disable.

--- a/go/internal/admin/admin_test.go
+++ b/go/internal/admin/admin_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/nyroway/nyro/go/internal/storage"
 	"github.com/nyroway/nyro/go/internal/storage/memory"
 )

--- a/go/internal/admin/obs_source_test.go
+++ b/go/internal/admin/obs_source_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/nyroway/nyro/go/internal/observability"
 	"github.com/nyroway/nyro/go/internal/observability/parquet"
 	"github.com/nyroway/nyro/go/internal/storage/memory"

--- a/go/internal/admin/stats_source_test.go
+++ b/go/internal/admin/stats_source_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/nyroway/nyro/go/internal/observability"
 	"github.com/nyroway/nyro/go/internal/observability/parquet"
 	"github.com/nyroway/nyro/go/internal/storage/memory"

--- a/go/internal/observability/hooks.go
+++ b/go/internal/observability/hooks.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/nyroway/nyro/go/internal/plugin"
-	"github.com/nyroway/nyro/go/internal/protocol/ir"
-	"github.com/nyroway/nyro/go/internal/storage"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/nyroway/nyro/go/internal/plugin"
+	"github.com/nyroway/nyro/go/internal/protocol/ir"
+	"github.com/nyroway/nyro/go/internal/storage"
 )
 
 // Bag key contract. Exported (plain strings) so the proxy dispatcher can set

--- a/go/internal/observability/hooks_test.go
+++ b/go/internal/observability/hooks_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nyroway/nyro/go/internal/plugin"
-	"github.com/nyroway/nyro/go/internal/protocol/ir"
-	"github.com/nyroway/nyro/go/internal/storage"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/log"
@@ -17,6 +14,10 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/nyroway/nyro/go/internal/plugin"
+	"github.com/nyroway/nyro/go/internal/protocol/ir"
+	"github.com/nyroway/nyro/go/internal/storage"
 )
 
 // captureLogger is a minimal log.Logger wrapper that records every emitted

--- a/go/internal/observability/janitor_test.go
+++ b/go/internal/observability/janitor_test.go
@@ -53,7 +53,9 @@ func TestCleanSignalSkipsZeroDays(t *testing.T) {
 		t.Fatal(err)
 	}
 	old := time.Now().UTC().AddDate(0, 0, -365)
-	os.Chtimes(p, old, old)
+	if err := os.Chtimes(p, old, old); err != nil {
+		t.Fatal(err)
+	}
 
 	cleanSignal(dir, "logs", 0, time.Now().UTC())
 

--- a/go/internal/observability/parquet/reader.go
+++ b/go/internal/observability/parquet/reader.go
@@ -77,7 +77,7 @@ func readParquetFile[Row any](name string) ([]Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	pr := parquet.NewGenericReader[Row](f)
 	rows := make([]Row, pr.NumRows())
 	// parquet-go's Read returns io.EOF when it has drained the file, even on a

--- a/go/internal/observability/parquet/reader_test.go
+++ b/go/internal/observability/parquet/reader_test.go
@@ -11,9 +11,15 @@ func TestReadSinceRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	s, _ := parquet.NewSink[observability.LogRecord](dir, "logs", 100)
 	rows := []observability.LogRecord{{ID: "a"}, {ID: "b"}, {ID: "c"}}
-	s.Write(rows)
-	s.Flush()
-	s.Close()
+	if err := s.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := parquet.ReadSince[observability.LogRecord](dir, "logs", 0)
 	if err != nil {

--- a/go/internal/observability/parquet/sink.go
+++ b/go/internal/observability/parquet/sink.go
@@ -83,17 +83,17 @@ func (s *Sink[Row]) flushLocked(now time.Time) error {
 	}
 	pw := parquet.NewGenericWriter[Row](f)
 	if _, err := pw.Write(s.buf); err != nil {
-		f.Close()
-		os.Remove(tmp)
+		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := pw.Close(); err != nil {
-		f.Close()
-		os.Remove(tmp)
+		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmp)
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := os.Rename(tmp, name); err != nil {

--- a/go/internal/observability/parquet/sink_test.go
+++ b/go/internal/observability/parquet/sink_test.go
@@ -14,7 +14,7 @@ func TestSinkWriteRotateReadBack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	// maxRows=2 → writing 3 rows forces a rotation (2 files).
 	if err := s.Write([]observability.LogRecord{

--- a/go/internal/observability/receiver.go
+++ b/go/internal/observability/receiver.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/nyroway/nyro/go/internal/observability/parquet"
 	collectlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectmetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collecttrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -16,6 +15,8 @@ import (
 	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/nyroway/nyro/go/internal/observability/parquet"
 )
 
 // Receiver is the admin-side OTLP/HTTP receiver. It decodes the official OTLP
@@ -140,18 +141,24 @@ func (rcv *Receiver) handleMetrics(w http.ResponseWriter, r *http.Request) {
 				switch d := m.Data.(type) {
 				case *metricsv1.Metric_Gauge:
 					for _, p := range d.Gauge.GetDataPoints() {
-						rows = append(rows, MetricSample{Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "gauge",
-							Value: dataPointValue(p), LabelsJSON: attrsToJSON(p.GetAttributes())})
+						rows = append(rows, MetricSample{
+							Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "gauge",
+							Value: dataPointValue(p), LabelsJSON: attrsToJSON(p.GetAttributes()),
+						})
 					}
 				case *metricsv1.Metric_Sum:
 					for _, p := range d.Sum.GetDataPoints() {
-						rows = append(rows, MetricSample{Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "counter",
-							Value: dataPointValue(p), LabelsJSON: attrsToJSON(p.GetAttributes())})
+						rows = append(rows, MetricSample{
+							Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "counter",
+							Value: dataPointValue(p), LabelsJSON: attrsToJSON(p.GetAttributes()),
+						})
 					}
 				case *metricsv1.Metric_Histogram:
 					for _, p := range d.Histogram.GetDataPoints() {
-						rows = append(rows, MetricSample{Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "histogram",
-							HistSum: p.GetSum(), HistCount: int64(p.GetCount()), LabelsJSON: attrsToJSON(p.GetAttributes())})
+						rows = append(rows, MetricSample{
+							Ts: int64(p.GetTimeUnixNano()), Name: name, Kind: "histogram",
+							HistSum: p.GetSum(), HistCount: int64(p.GetCount()), LabelsJSON: attrsToJSON(p.GetAttributes()),
+						})
 					}
 				}
 			}

--- a/go/internal/observability/receiver_test.go
+++ b/go/internal/observability/receiver_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/nyroway/nyro/go/internal/observability"
-	"github.com/nyroway/nyro/go/internal/observability/parquet"
 	collectlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectmetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collecttrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -21,6 +19,9 @@ import (
 	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/nyroway/nyro/go/internal/observability"
+	"github.com/nyroway/nyro/go/internal/observability/parquet"
 )
 
 func TestReceiverLogs(t *testing.T) {
@@ -49,7 +50,7 @@ func TestReceiverLogs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -121,7 +122,7 @@ func TestReceiverMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -202,7 +203,7 @@ func TestReceiverTraces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -289,7 +290,7 @@ func TestReceiverBadBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status=%d want 400", resp.StatusCode)
 	}

--- a/go/internal/observability/stats_aggregate.go
+++ b/go/internal/observability/stats_aggregate.go
@@ -165,8 +165,10 @@ func AggregateStats(samples []MetricSample, _ int64) (StatsOverview, []ModelStat
 		if a.name != "" {
 			name = a.name
 		}
-		keys = append(keys, ApiKeyStats{APIKeyID: id, APIKeyName: name, RequestCount: a.req,
-			TotalInputTokens: a.in, TotalOutputTokens: a.out, CacheReadTokens: a.cache, LastUsedAt: a.lastTs})
+		keys = append(keys, ApiKeyStats{
+			APIKeyID: id, APIKeyName: name, RequestCount: a.req,
+			TotalInputTokens: a.in, TotalOutputTokens: a.out, CacheReadTokens: a.cache, LastUsedAt: a.lastTs,
+		})
 	}
 	sort.Slice(keys, func(i, j int) bool { return keys[i].RequestCount > keys[j].RequestCount })
 
@@ -196,9 +198,10 @@ func AggregateHourly(samples []MetricSample, _ int64) ([]StatsHourly, error) {
 				bb.err += int64(s.Value)
 			}
 		case "nyro_tokens_total":
-			if l.Direction == "in" {
+			switch l.Direction {
+			case "in":
 				bb.in += int64(s.Value)
-			} else if l.Direction == "out" {
+			case "out":
 				bb.out += int64(s.Value)
 			}
 		case "nyro_request_latency_ms":
@@ -212,8 +215,10 @@ func AggregateHourly(samples []MetricSample, _ int64) ([]StatsHourly, error) {
 		if bb.latCnt > 0 {
 			avg = bb.latSum / float64(bb.latCnt)
 		}
-		out = append(out, StatsHourly{Hour: hour, RequestCount: bb.req, ErrorCount: bb.err,
-			TotalInputTokens: bb.in, TotalOutputTokens: bb.out, AvgDurationMs: avg})
+		out = append(out, StatsHourly{
+			Hour: hour, RequestCount: bb.req, ErrorCount: bb.err,
+			TotalInputTokens: bb.in, TotalOutputTokens: bb.out, AvgDurationMs: avg,
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Hour < out[j].Hour })
 	return out, nil

--- a/go/internal/protocol/codec/openai/encode.go
+++ b/go/internal/protocol/codec/openai/encode.go
@@ -274,7 +274,7 @@ func encodeResponseFormat(rf ir.ResponseFormat) json.RawMessage {
 	case *ir.JsonSchemaResponse:
 		js := map[string]any{"name": v.Name}
 		if len(v.Schema) > 0 {
-			js["schema"] = json.RawMessage(v.Schema)
+			js["schema"] = v.Schema
 		}
 		if v.Strict != nil {
 			js["strict"] = *v.Strict

--- a/go/internal/protocol/codec/responses/decode_stream.go
+++ b/go/internal/protocol/codec/responses/decode_stream.go
@@ -22,23 +22,23 @@ func (d *streamResponseDecoder) ParseChunk(payload string) ([]ir.StreamDelta, er
 		return []ir.StreamDelta{&ir.UnknownDelta{Raw: payload}}, nil
 	}
 	var out []ir.StreamDelta
-	switch {
-	case ev.Type == "response.created" || ev.Type == "response.in_progress":
+	switch ev.Type {
+	case "response.created", "response.in_progress":
 		if ev.Response != nil {
 			d.id, d.model = ev.Response.ID, ev.Response.Model
 			out = append(out, &ir.MessageStartDelta{ID: ev.Response.ID, Model: ev.Response.Model})
 		}
-	case ev.Type == "response.output_text.delta":
+	case "response.output_text.delta":
 		if ev.Delta != "" {
 			out = append(out, &ir.TextDelta{Text: ev.Delta})
 		}
-	case ev.Type == "response.function_call_arguments.delta":
+	case "response.function_call_arguments.delta":
 		out = append(out, &ir.ToolCallDeltaDelta{Index: 0, Arguments: ev.Delta})
-	case ev.Type == "response.output_item.added":
+	case "response.output_item.added":
 		if ev.Item != nil && ev.Item.Type == "function_call" {
 			out = append(out, &ir.ToolCallStartDelta{Index: 0, ID: ev.Item.CallID, Name: ev.Item.Name})
 		}
-	case ev.Type == "response.completed":
+	case "response.completed":
 		if ev.Response != nil {
 			if ev.Response.Usage != nil {
 				out = append(out, &ir.UsageDelta{Usage: ir.Usage{
@@ -53,7 +53,7 @@ func (d *streamResponseDecoder) ParseChunk(payload string) ([]ir.StreamDelta, er
 			d.done = true
 			out = append(out, &ir.DoneDelta{StopReason: nvl(d.stop, "completed")})
 		}
-	case ev.Type == "response.failed" || ev.Type == "response.incomplete":
+	case "response.failed", "response.incomplete":
 		if !d.done {
 			d.done = true
 			out = append(out, &ir.DoneDelta{StopReason: ev.Type})

--- a/go/internal/proxy/anthropic_e2e_test.go
+++ b/go/internal/proxy/anthropic_e2e_test.go
@@ -32,7 +32,7 @@ func anthropicStreamUpstream(t *testing.T) *httptest.Server {
 			{"message_stop", `{"type":"message_stop"}`},
 		}
 		for _, e := range events {
-			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.event, e.data)
+			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.event, e.data)
 			f.Flush()
 		}
 	}))

--- a/go/internal/proxy/dispatcher.go
+++ b/go/internal/proxy/dispatcher.go
@@ -178,7 +178,7 @@ func (g *Gateway) Dispatch(w http.ResponseWriter, r *http.Request, req *ir.AiReq
 				break
 			}
 			if ps.RetryOnStatus[resp.StatusCode] {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				resp = nil
 				if attempt < attempts {
 					continue
@@ -213,7 +213,7 @@ func (g *Gateway) Dispatch(w http.ResponseWriter, r *http.Request, req *ir.AiReq
 		default:
 			g.serveNonStream(r.Context(), rec, resp.Body, egressHandler, ingress, req, &usage, bag)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		served = true
 		break
 	}

--- a/go/internal/proxy/dispatcher_test.go
+++ b/go/internal/proxy/dispatcher_test.go
@@ -92,10 +92,10 @@ func streamUpstream(t *testing.T) *httptest.Server {
 			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
 		}
 		for _, c := range chunks {
-			fmt.Fprintf(w, "data: %s\n\n", c)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", c)
 			f.Flush()
 		}
-		fmt.Fprint(w, "data: [DONE]\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 		f.Flush()
 	}))
 }

--- a/go/internal/proxy/gateway_test.go
+++ b/go/internal/proxy/gateway_test.go
@@ -31,15 +31,21 @@ func TestGatewayHTTPClientForProxy(t *testing.T) {
 	}
 
 	// use_proxy=true but proxy disabled → direct client.
-	st.Storage().Settings().Set("proxy_enabled", "false")
+	if err := st.Storage().Settings().Set("proxy_enabled", "false"); err != nil {
+		t.Fatal(err)
+	}
 	_ = gw.Cache.LoadAndSwap(st.Storage()) // reflect the settings change in the in-memory cache
 	if c, err := gw.httpClientFor(true); err != nil || c != direct {
 		t.Errorf("proxy disabled: want direct client, got %v err=%v", c, err)
 	}
 
 	// use_proxy=true + enabled + proxy_url → distinct proxied client.
-	st.Storage().Settings().Set("proxy_enabled", "true")
-	st.Storage().Settings().Set("proxy_url", "http://proxy.example:8080")
+	if err := st.Storage().Settings().Set("proxy_enabled", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Storage().Settings().Set("proxy_url", "http://proxy.example:8080"); err != nil {
+		t.Fatal(err)
+	}
 	_ = gw.Cache.LoadAndSwap(st.Storage())
 	c, err := gw.httpClientFor(true)
 	if err != nil {
@@ -63,7 +69,9 @@ func TestGatewayHTTPClientForProxy(t *testing.T) {
 	}
 
 	// empty proxy_url → error.
-	st.Storage().Settings().Set("proxy_url", "")
+	if err := st.Storage().Settings().Set("proxy_url", ""); err != nil {
+		t.Fatal(err)
+	}
 	_ = gw.Cache.LoadAndSwap(st.Storage())
 	if _, err := gw.httpClientFor(true); err == nil {
 		t.Error("empty proxy_url: want error, got nil")
@@ -97,11 +105,17 @@ func TestResolveProxySettings_Defaults(t *testing.T) {
 func TestResolveProxySettings_Overrides(t *testing.T) {
 	st := memory.New()
 	core := st.Storage()
-	core.Settings().Set("proxy.request_timeout", "45s")
-	core.Settings().Set("proxy.connect_timeout", "5s")
-	core.Settings().Set("proxy.max_retries", "4")
+	mustSet := func(key, value string) {
+		t.Helper()
+		if err := core.Settings().Set(key, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustSet("proxy.request_timeout", "45s")
+	mustSet("proxy.connect_timeout", "5s")
+	mustSet("proxy.max_retries", "4")
 	codes, _ := json.Marshal([]int{408, 429})
-	core.Settings().Set("proxy.retry_on_status", string(codes))
+	mustSet("proxy.retry_on_status", string(codes))
 
 	c := &xds.ConfigCache{}
 	if err := c.LoadAndSwap(core); err != nil {

--- a/go/internal/proxy/gemini_e2e_test.go
+++ b/go/internal/proxy/gemini_e2e_test.go
@@ -24,7 +24,7 @@ func geminiStreamUpstream(t *testing.T) *httptest.Server {
 			`{"candidates":[{"content":{"parts":[{"text":"there"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}`,
 		}
 		for _, c := range chunks {
-			fmt.Fprintf(w, "data: %s\n\n", c)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", c)
 			f.Flush()
 		}
 	}))

--- a/go/internal/proxy/responses_e2e_test.go
+++ b/go/internal/proxy/responses_e2e_test.go
@@ -25,7 +25,7 @@ func responsesStreamUpstream(t *testing.T) *httptest.Server {
 			`{"type":"response.completed","response":{"id":"r1","status":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}`,
 		}
 		for _, e := range events {
-			fmt.Fprintf(w, "data: %s\n\n", e)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", e)
 			f.Flush()
 		}
 	}))

--- a/go/internal/proxy/retry_test.go
+++ b/go/internal/proxy/retry_test.go
@@ -26,7 +26,9 @@ func TestDispatchMaxRetries(t *testing.T) {
 
 	st := memory.New()
 	core := st.Storage()
-	core.Settings().Set("proxy.max_retries", "3")
+	if err := core.Settings().Set("proxy.max_retries", "3"); err != nil {
+		t.Fatal(err)
+	}
 	p, _ := core.Upstreams().Create(storage.CreateUpstream{
 		Name: "p", Provider: "p", Protocol: "openai-compatible", BaseURL: up.URL,
 		CredentialsJSON: []byte(`{"api_key":"k"}`),
@@ -65,7 +67,9 @@ func TestDispatchRetryOnStatusCustom(t *testing.T) {
 	st := memory.New()
 	core := st.Storage()
 	codes, _ := json.Marshal([]int{429})
-	core.Settings().Set("proxy.retry_on_status", string(codes))
+	if err := core.Settings().Set("proxy.retry_on_status", string(codes)); err != nil {
+		t.Fatal(err)
+	}
 	p, _ := core.Upstreams().Create(storage.CreateUpstream{
 		Name: "p", Provider: "p", Protocol: "openai-compatible", BaseURL: up.URL,
 		CredentialsJSON: []byte(`{"api_key":"k"}`),
@@ -98,8 +102,12 @@ func TestDispatchRetryOnStatusCustom(t *testing.T) {
 func TestDispatchConnectTimeout(t *testing.T) {
 	st := memory.New()
 	core := st.Storage()
-	core.Settings().Set("proxy.connect_timeout", "200ms")
-	core.Settings().Set("proxy.max_retries", "1")
+	if err := core.Settings().Set("proxy.connect_timeout", "200ms"); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.Settings().Set("proxy.max_retries", "1"); err != nil {
+		t.Fatal(err)
+	}
 	p, _ := core.Upstreams().Create(storage.CreateUpstream{
 		Name: "p", Provider: "p", Protocol: "openai-compatible",
 		BaseURL:         "http://192.0.2.1:81", // TEST-NET-1: reserved, non-routable

--- a/go/internal/proxy/server.go
+++ b/go/internal/proxy/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
 	"github.com/nyroway/nyro/go/internal/protocol/codec"
 	"github.com/nyroway/nyro/go/internal/protocol/codec/anthropic"  // register Anthropic codec
 	"github.com/nyroway/nyro/go/internal/protocol/codec/embeddings" // register Embeddings codec

--- a/go/internal/proxy/webui.go
+++ b/go/internal/proxy/webui.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/nyroway/nyro/go/internal/webutil"
 )
 

--- a/go/internal/storage/memory/memory.go
+++ b/go/internal/storage/memory/memory.go
@@ -65,11 +65,11 @@ func (b *Backend) Storage() storage.Storage { return storageView{b} }
 
 type storageView struct{ b *Backend }
 
-func (v storageView) Upstreams() storage.UpstreamStore { return upstreamStore{v.b} }
-func (v storageView) Routes() storage.RouteStore       { return routeStore{v.b} }
-func (v storageView) Consumers() storage.ConsumerStore { return consumerStore{v.b} }
-func (v storageView) Auth() storage.KeyAuthStore       { return keyAuthStore{v.b} }
-func (v storageView) Settings() storage.SettingsStore  { return coreSettingsStore{v.b} }
+func (v storageView) Upstreams() storage.UpstreamStore { return upstreamStore(v) }
+func (v storageView) Routes() storage.RouteStore       { return routeStore(v) }
+func (v storageView) Consumers() storage.ConsumerStore { return consumerStore(v) }
+func (v storageView) Auth() storage.KeyAuthStore       { return keyAuthStore(v) }
+func (v storageView) Settings() storage.SettingsStore  { return coreSettingsStore(v) }
 func (v storageView) Migrator() storage.Migrator       { return v.b }
 
 var _ storage.Storage = storageView{}

--- a/go/internal/xds/client.go
+++ b/go/internal/xds/client.go
@@ -84,11 +84,11 @@ func (c *ConfigClient) runOnce(ctx context.Context) (connected bool, err error) 
 	dialCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	conn, err := grpc.DialContext(dialCtx, c.target, c.dialOpts...)
+	conn, err := grpc.NewClient(c.target, c.dialOpts...)
 	if err != nil {
 		return false, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := pb.NewConfigServiceClient(conn)
 	stream, err := client.StreamConfig(dialCtx, &pb.Subscribe{Version: 0})

--- a/go/internal/xds/client_test.go
+++ b/go/internal/xds/client_test.go
@@ -13,7 +13,7 @@ import (
 
 // newClient builds a ConfigClient pointed at the bufconn env via dialOpts.
 func newClient(cache *ConfigCache, dialOpt grpc.DialOption) *ConfigClient {
-	c := NewConfigClient("bufnet", cache)
+	c := NewConfigClient("passthrough:///bufnet", cache)
 	c.initialBackoff = 20 * time.Millisecond
 	c.maxBackoff = 100 * time.Millisecond
 	c.dialOpts = []grpc.DialOption{

--- a/go/internal/xds/server_test.go
+++ b/go/internal/xds/server_test.go
@@ -23,7 +23,7 @@ func bufconnEnv(t *testing.T, store *memory.Backend) (srv *ConfigServer, dialOpt
 	srv = NewConfigServer(store.Storage())
 	gs := grpc.NewServer()
 	pb.RegisterConfigServiceServer(gs, srv)
-	go gs.Serve(lis)
+	go func() { _ = gs.Serve(lis) }()
 	dialOpt = grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 		return lis.DialContext(ctx)
 	})
@@ -40,10 +40,10 @@ func dialClient(t *testing.T, dialOpt grpc.DialOption) (pb.ConfigService_StreamC
 	}
 	stream, err := pb.NewConfigServiceClient(conn).StreamConfig(context.Background(), &pb.Subscribe{Version: 0})
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		t.Fatalf("StreamConfig: %v", err)
 	}
-	return stream, func() { conn.Close() }
+	return stream, func() { _ = conn.Close() }
 }
 
 func TestStreamConfig_SendsInitialSnapshot(t *testing.T) {
@@ -133,7 +133,7 @@ func TestStreamConfig_DisconnectOnClientCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	stream, err := pb.NewConfigServiceClient(conn).StreamConfig(ctx, &pb.Subscribe{Version: 0})
 	if err != nil {
 		t.Fatalf("StreamConfig: %v", err)


### PR DESCRIPTION
go/fmt was a bare `go fmt` and go/.golangci.yaml existed but was never invoked by Makefile or CI, so Go code had no enforced style/lint gate.

- go/.golangci.yaml: migrate to v2 schema, add formatters (gofumpt + goimports w/ local-prefix grouping), enable bodyclose + unconvert.
- Makefile: go-fmt now runs `golangci-lint fmt` in place; add go-fmt-check (non-destructive), go-lint, go-lint-install (pinned v2.6.0, installed to go/bin via `go install`, never touches go.mod/go.sum), and go-check (fmt-check+vet+lint+test).
- ci.yml: add a go-check job — Go had no CI coverage at all before.
- Fix the ~34 pre-existing lint findings surfaced by first enabling the linters: unchecked errors (mostly best-effort Close/cleanup, a few promoted to t.Fatal where the test's premise depends on them), deprecated grpc.DialContext -> grpc.NewClient (with passthrough:// target fix for the bufconn tests), and a handful of staticcheck/ unconvert simplifications.