### PR TITLE
feat(go-webui): run health check before saving edited providers

### DIFF
--- a/go/internal/admin/admin.go
+++ b/go/internal/admin/admin.go
@@ -97,6 +97,14 @@ func Mount(r chi.Router, s storage.Storage, adminToken string, logs LogSource, s
 			}
 			streamDraftUpstreamHealth(w, r, s, in)
 		})
+		g.Post("/upstreams/{id}/test-draft/stream", func(w http.ResponseWriter, r *http.Request) {
+			var in storage.CreateUpstream
+			if err := webutil.Decode(r, &in); err != nil {
+				badRequest(w, err)
+				return
+			}
+			streamEditDraftUpstreamHealth(w, r, s, in, chi.URLParam(r, "id"))
+		})
 		g.Put("/upstreams/{id}", func(w http.ResponseWriter, r *http.Request) {
 			var in storage.UpdateUpstream
 			if err := webutil.Decode(r, &in); err != nil {

--- a/go/internal/admin/admin_test.go
+++ b/go/internal/admin/admin_test.go
@@ -831,6 +831,56 @@ func TestUpstreamHealthStreamRunsModelTestForSavedProvider(t *testing.T) {
 	}
 }
 
+func TestUpstreamEditDraftHealthStreamExcludesOwnName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_edit","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop","index":0}]}`))
+	}))
+	defer ts.Close()
+
+	r, _ := newEngine(t, "")
+	rec := do(r, "POST", "/api/v1/upstreams", "",
+		[]byte(`{"name":"saved","provider":"custom","protocol":"openai-chat","base_url":"`+ts.URL+`","credentials":{"api_key":"k"},"models":["gpt-test"]}`))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create → %d %s", rec.Code, rec.Body.String())
+	}
+	var u storage.Upstream
+	if err := json.Unmarshal(rec.Body.Bytes(), &u); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-submitting the provider's own unchanged name through the edit-draft
+	// endpoint must not be treated as a name conflict with itself.
+	rec = do(r, "POST", "/api/v1/upstreams/"+u.ID+"/test-draft/stream", "",
+		[]byte(`{"name":"saved","provider":"custom","protocol":"openai-chat","base_url":"`+ts.URL+`","credentials":{"api_key":"k"},"models":["gpt-test"]}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("edit draft health stream → %d %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "upstream name already exists") {
+		t.Fatalf("edit draft health stream falsely flagged own name as a conflict:\n%s", body)
+	}
+	if !strings.Contains(body, `"success":true`) {
+		t.Fatalf("edit draft health stream did not succeed:\n%s", body)
+	}
+
+	// A name that collides with a different existing upstream must still fail.
+	rec = do(r, "POST", "/api/v1/upstreams", "",
+		[]byte(`{"name":"other","provider":"custom","protocol":"openai-chat","base_url":"`+ts.URL+`","credentials":{"api_key":"k"},"models":["gpt-test"]}`))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create other → %d %s", rec.Code, rec.Body.String())
+	}
+	rec = do(r, "POST", "/api/v1/upstreams/"+u.ID+"/test-draft/stream", "",
+		[]byte(`{"name":"other","provider":"custom","protocol":"openai-chat","base_url":"`+ts.URL+`","credentials":{"api_key":"k"},"models":["gpt-test"]}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("edit draft health stream → %d %s", rec.Code, rec.Body.String())
+	}
+	body = rec.Body.String()
+	if !strings.Contains(body, "upstream name already exists") {
+		t.Fatalf("edit draft health stream did not flag conflicting name:\n%s", body)
+	}
+}
+
 func TestUpstreamDraftHealthStreamRequiresModelSource(t *testing.T) {
 	r, _ := newEngine(t, "")
 	rec := do(r, "POST", "/api/v1/upstreams/test-draft/stream", "",

--- a/go/internal/admin/upstream_health.go
+++ b/go/internal/admin/upstream_health.go
@@ -40,6 +40,7 @@ type healthEventWriter struct {
 
 type upstreamHealthOptions struct {
 	checkNameConflict bool
+	excludeID         string
 }
 
 func newHealthEventWriter(w http.ResponseWriter) *healthEventWriter {
@@ -60,6 +61,14 @@ func (e *healthEventWriter) send(ev upstreamHealthEvent) {
 
 func streamDraftUpstreamHealth(w http.ResponseWriter, r *http.Request, s storage.Storage, in storage.CreateUpstream) {
 	streamUpstreamHealth(w, r, s, draftUpstream(in), upstreamHealthOptions{checkNameConflict: true})
+}
+
+// streamEditDraftUpstreamHealth runs the same pre-save validation pipeline as
+// streamDraftUpstreamHealth, but excludes excludeID from the name-uniqueness
+// check — an edit form resubmits the provider's own (unchanged) name, which
+// would otherwise always collide with itself.
+func streamEditDraftUpstreamHealth(w http.ResponseWriter, r *http.Request, s storage.Storage, in storage.CreateUpstream, excludeID string) {
+	streamUpstreamHealth(w, r, s, draftUpstream(in), upstreamHealthOptions{checkNameConflict: true, excludeID: excludeID})
 }
 
 func streamSavedUpstreamHealth(w http.ResponseWriter, r *http.Request, s storage.Storage, u storage.Upstream) {
@@ -90,7 +99,7 @@ func streamUpstreamHealth(w http.ResponseWriter, r *http.Request, s storage.Stor
 		return
 	}
 	if opts.checkNameConflict {
-		if exists, _ := s.Upstreams().ExistsByName(u.Name, ""); exists {
+		if exists, _ := s.Upstreams().ExistsByName(u.Name, opts.excludeID); exists {
 			msg := "upstream name already exists"
 			events.send(upstreamHealthEvent{Type: "check", Check: "config", Status: "failed", Error: msg})
 			complete(false, msg)

--- a/go/webui/src/lib/backend.ts
+++ b/go/webui/src/lib/backend.ts
@@ -211,6 +211,23 @@ export async function streamProviderDraftHealth(
   );
 }
 
+export async function streamProviderEditDraftHealth(
+  id: string,
+  input: CreateProvider,
+  onEvent: (event: ProviderHealthEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  await streamProviderHealthEvents(
+    `/api/v1/upstreams/${id}/test-draft/stream`,
+    {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createUpstreamFromProvider(input)),
+    },
+    onEvent,
+    signal,
+  );
+}
+
 export async function streamProviderHealth(
   id: string,
   onEvent: (event: ProviderHealthEvent) => void,

--- a/go/webui/src/pages/providers.tsx
+++ b/go/webui/src/pages/providers.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { backend, streamProviderDraftHealth, streamProviderHealth, streamProviderRouteImport } from "@/lib/backend";
+import { backend, streamProviderDraftHealth, streamProviderEditDraftHealth, streamProviderHealth, streamProviderRouteImport } from "@/lib/backend";
 import { localizeBackendErrorMessage } from "@/lib/backend-error";
 import type {
   Provider,
@@ -484,9 +484,11 @@ export default function ProvidersPage() {
   const [testLogs, setTestLogs] = useState<TestLogEntry[]>([]);
   const [isTestRunning, setIsTestRunning] = useState(false);
   const [testTarget, setTestTarget] = useState<Provider | null>(null);
-  const [testDialogMode, setTestDialogMode] = useState<"provider" | "create" | "route_import">("provider");
+  const [testDialogMode, setTestDialogMode] = useState<"provider" | "create" | "edit" | "route_import">("provider");
   const [pendingCreateInput, setPendingCreateInput] = useState<CreateProvider | null>(null);
   const [createHealthPassed, setCreateHealthPassed] = useState(false);
+  const [pendingUpdateInput, setPendingUpdateInput] = useState<(UpdateProvider & { id: string }) | null>(null);
+  const [editHealthPassed, setEditHealthPassed] = useState(false);
   const [providerToDelete, setProviderToDelete] = useState<Provider | null>(null);
   const [routeImportPreview, setRouteImportPreview] = useState<{ provider: Provider; preview: RouteImportPreview } | null>(null);
   const [selectedPresetId, setSelectedPresetId] = useState("");
@@ -552,6 +554,9 @@ export default function ProvidersPage() {
       setEditError(null);
       qc.invalidateQueries({ queryKey: ["providers"] });
       setEditingId(null);
+      setPendingUpdateInput(null);
+      setEditHealthPassed(false);
+      setTestDialogOpen(false);
     },
     onError: (err: Error) => {
       setEditError(String(err));
@@ -603,6 +608,8 @@ export default function ProvidersPage() {
     setTestDialogOpen(false);
     setPendingCreateInput(null);
     setCreateHealthPassed(false);
+    setPendingUpdateInput(null);
+    setEditHealthPassed(false);
   }
 
   async function handleTest(provider: Provider) {
@@ -701,14 +708,16 @@ export default function ProvidersPage() {
     }
   }
 
-  function appendHealthEvent(event: ProviderHealthEvent, mode: "provider" | "create" = "provider") {
+  function appendHealthEvent(event: ProviderHealthEvent, mode: "provider" | "create" | "edit" = "provider") {
     if (event.type === "complete") {
       appendTestLog(
         event.success ? "success" : "error",
         event.success
           ? (mode === "create"
             ? (isZh ? "✓ 测试全部通过，点击完成创建" : "✓ All checks passed. Click Create Provider to finish.")
-            : (isZh ? "✓ 测试全部通过" : "✓ All checks passed."))
+            : mode === "edit"
+              ? (isZh ? "✓ 测试全部通过，点击完成保存" : "✓ All checks passed. Click Save Provider to finish.")
+              : (isZh ? "✓ 测试全部通过" : "✓ All checks passed."))
           : `${isZh ? "✗ 测试未通过" : "✗ Checks failed"}${event.error ? `: ${event.error}` : ""}`,
       );
       return;
@@ -851,6 +860,47 @@ export default function ProvidersPage() {
       const message = normalizeErrorMessage(error);
       appendTestLog("error", `${isZh ? "✗ 流式测试失败" : "✗ Streaming health check failed"}: ${message}`);
       setCreateHealthPassed(false);
+      setIsTestRunning(false);
+    } finally {
+      if (!isCanceled()) {
+        activeTestAbortRef.current = null;
+      }
+    }
+  }
+
+  async function handleUpdateHealthCheck(draft: CreateProvider, update: UpdateProvider & { id: string }) {
+    const runId = activeTestRunRef.current + 1;
+    activeTestRunRef.current = runId;
+    const abortController = new AbortController();
+    activeTestAbortRef.current = abortController;
+    const isCanceled = () => activeTestRunRef.current !== runId;
+
+    setTestingId(null);
+    setTestTarget(null);
+    setTestDialogMode("edit");
+    setPendingUpdateInput(update);
+    setEditHealthPassed(false);
+    setTestLogs([]);
+    setTestDialogOpen(true);
+    setIsTestRunning(true);
+
+    appendTestLog("info", isZh ? `开始保存前测试 ${draft.name}...` : `Start pre-save checks for ${draft.name}...`);
+    appendTestLog("info", isZh ? "会向上游发送一次最小模型请求用于验证模型可用性" : "A minimal upstream model request will be sent to verify model availability.");
+
+    try {
+      await streamProviderEditDraftHealth(update.id, draft, (event) => {
+        if (isCanceled()) return;
+        appendHealthEvent(event, "edit");
+        if (event.type === "complete") {
+          setEditHealthPassed(event.success === true);
+          setIsTestRunning(false);
+        }
+      }, abortController.signal);
+    } catch (error: unknown) {
+      if (isCanceled() || abortController.signal.aborted) return;
+      const message = normalizeErrorMessage(error);
+      appendTestLog("error", `${isZh ? "✗ 流式测试失败" : "✗ Streaming health check failed"}: ${message}`);
+      setEditHealthPassed(false);
       setIsTestRunning(false);
     } finally {
       if (!isCanceled()) {
@@ -1483,7 +1533,7 @@ export default function ProvidersPage() {
                           setEditError(validation);
                           return;
                         }
-                        const input: UpdateProvider = {
+                        const update: UpdateProvider = {
                           name: editForm.name || undefined,
                           provider: editForm.provider || undefined,
                           protocol,
@@ -1495,15 +1545,29 @@ export default function ProvidersPage() {
                             ? editForm.credentials
                             : undefined,
                         };
-                        updateMut.mutate({ id: editForm.id, ...input });
+                        const draft: CreateProvider = {
+                          name: editForm.name ?? "",
+                          provider: editForm.provider || "custom",
+                          protocol,
+                          base_url: baseUrl,
+                          proxy_url: editForm.proxy_url ?? "",
+                          models_url: editForm.models_url ?? "",
+                          models: editForm.models ?? "",
+                          api_key: editForm.api_key ?? "",
+                          credentials: editForm.credentials ?? {},
+                        };
+                        void handleUpdateHealthCheck(draft, { id: editForm.id, ...update });
                       }}
                       disabled={
                         updateMut.isPending
+                        || isTestRunning
                         || missingRequiredCredentials(editCredentialFields, editForm.credentials ?? {})
                         || editBaseUrlMissing
                       }
                     >
-                      {updateMut.isPending ? (isZh ? "保存中..." : "Saving...") : (isZh ? "保存" : "Save")}
+                      {isTestRunning
+                        ? (isZh ? "测试中..." : "Testing...")
+                        : (isZh ? "测试并保存" : "Test & Save")}
                     </Button>
                     <Button
                       onClick={() => { setEditingId(null); setEditError(null); }}
@@ -1692,16 +1756,20 @@ export default function ProvidersPage() {
             <DialogTitle>
               {testDialogMode === "create"
                 ? (isZh ? `创建前测试 ${pendingCreateInput?.name ?? ""}` : `Pre-create test ${pendingCreateInput?.name ?? ""}`)
-                : testDialogMode === "route_import"
-                  ? (isZh ? `导入模型路由 ${testTarget?.name ?? ""}` : `Import routes for ${testTarget?.name ?? ""}`)
-                  : (isZh ? `测试 ${testTarget?.name ?? ""}` : `Test ${testTarget?.name ?? ""}`)}
+                : testDialogMode === "edit"
+                  ? (isZh ? `保存前测试 ${editForm.name ?? ""}` : `Pre-save test ${editForm.name ?? ""}`)
+                  : testDialogMode === "route_import"
+                    ? (isZh ? `导入模型路由 ${testTarget?.name ?? ""}` : `Import routes for ${testTarget?.name ?? ""}`)
+                    : (isZh ? `测试 ${testTarget?.name ?? ""}` : `Test ${testTarget?.name ?? ""}`)}
             </DialogTitle>
             <DialogDescription>
               {testDialogMode === "create"
                 ? (isZh ? "实时展示创建前验证流水线" : "Real-time pre-create validation pipeline")
-                : testDialogMode === "route_import"
-                  ? (isZh ? "实时展示模型路由导入进度" : "Real-time progress for route import")
-                  : (isZh ? "实时展示 Provider 测试日志" : "Real-time logs for provider testing")}
+                : testDialogMode === "edit"
+                  ? (isZh ? "实时展示保存前验证流水线" : "Real-time pre-save validation pipeline")
+                  : testDialogMode === "route_import"
+                    ? (isZh ? "实时展示模型路由导入进度" : "Real-time progress for route import")
+                    : (isZh ? "实时展示 Provider 测试日志" : "Real-time logs for provider testing")}
             </DialogDescription>
           </DialogHeader>
           <div
@@ -1733,6 +1801,12 @@ export default function ProvidersPage() {
                 {createMut.isPending
                   ? (isZh ? "创建中..." : "Creating...")
                   : (isZh ? "完成创建" : "Create Provider")}
+              </Button>
+            ) : testDialogMode === "edit" && editHealthPassed && pendingUpdateInput ? (
+              <Button onClick={() => updateMut.mutate(pendingUpdateInput)} disabled={updateMut.isPending}>
+                {updateMut.isPending
+                  ? (isZh ? "保存中..." : "Saving...")
+                  : (isZh ? "完成保存" : "Save Provider")}
               </Button>
             ) : (
               <Button variant="secondary" onClick={closeTestDialog}>


### PR DESCRIPTION
Reuse the pre-create health check pipeline for provider edits: the "Save" button becomes "测试并保存"/"Test & Save" and streams the same validation checks before persisting. Adds an id-aware draft health endpoint (/upstreams/{id}/test-draft/stream) so the name-uniqueness check excludes the provider's own record, since editing resubmits its unchanged name.