### PR TITLE
feat(go): consumer schema redesign — access/quotas/limits, multi-key management

### DIFF
--- a/go/docs/schema/config.md
+++ b/go/docs/schema/config.md
@@ -88,7 +88,8 @@ consumers:
       protocols: ["openai-chat"]     # empty/omitted = allow all protocols
       ip_allowlist: ["10.0.0.0/8"]   # empty/omitted = allow all source IPs
     quotas:
-      inflight: 10                   # max concurrently in-flight requests
+      concurrency:
+        limit: 10                    # max concurrently in-flight requests
       requests:
         - limit: 60
           window: "1m"
@@ -99,7 +100,7 @@ consumers:
           window: "1m"
       budgets:                       # persisted only; not enforced yet
         - limit: 100
-          window: "mo"                # s | m | h | d | mo (natural month)
+          window: "1mo"               # s | m | h | d | Nmo (N natural months)
           currency: "USD"
     limits:
       max_input_tokens: 4000
@@ -157,11 +158,12 @@ uses `routes[].upstreams[].model`.
     its sub-fields, being empty/omitted means default-allow for that
     dimension — `models`, `protocols`, and `ip_allowlist` are each judged
     independently.
-  - `quotas`: `inflight` (max concurrently in-flight requests, no window),
-    `requests[]` / `tokens[]` (`limit` + `window`), and `budgets[]` (`limit` +
-    `window` + `currency`). Window units are `s`/`m`/`h`/`d`, plus `mo`
-    (natural calendar month) for budgets. Budgets are validated and persisted
-    but not enforced by the proxy in this version (enforcement requires a
-    pricing table, planned for a later version).
+  - `quotas`: `concurrency.limit` (max concurrently in-flight requests, no
+    window), `requests[]` / `tokens[]` (`limit` + `window`), and `budgets[]`
+    (`limit` + `window` + `currency`). Window units are `s`/`m`/`h`/`d`, plus
+    `Nmo` (N natural calendar months, e.g. `1mo`, `3mo`) for budgets. Budgets
+    are validated and persisted but not enforced by the proxy in this version
+    (enforcement requires a pricing table, planned for a later version).
+    `concurrency` maps internally to `consumer_quotas.quota_type = "concurrency"`.
   - `limits`: `max_input_tokens`, `max_output_tokens`,
     `max_request_body_bytes` — per-request caps; omitted/zero means no limit.

--- a/go/docs/schema/config.md
+++ b/go/docs/schema/config.md
@@ -76,14 +76,19 @@ routes:
 consumers:
   - name: "default-app"
     enabled: true
+    metadata:
+      team: "growth"
     keys:
       - name: "primary"
         api_key: "${NYRO_API_KEY}"   # empty = auto-generate
         enabled: true
         expires_at: null
-    routes:
-      - "gpt-4o"
+    access:
+      models: ["gpt-4o"]             # empty/omitted = allow all models
+      protocols: ["openai-chat"]     # empty/omitted = allow all protocols
+      ip_allowlist: ["10.0.0.0/8"]   # empty/omitted = allow all source IPs
     quotas:
+      inflight: 10                   # max concurrently in-flight requests
       requests:
         - limit: 60
           window: "1m"
@@ -92,8 +97,14 @@ consumers:
       tokens:
         - limit: 100000
           window: "1m"
-      concurrency:
-        max_requests: 10
+      budgets:                       # persisted only; not enforced yet
+        - limit: 100
+          window: "mo"                # s | m | h | d | mo (natural month)
+          currency: "USD"
+    limits:
+      max_input_tokens: 4000
+      max_output_tokens: 2000
+      max_request_body_bytes: 1048576
 ```
 
 ## Upstream Model Declaration
@@ -138,7 +149,19 @@ uses `routes[].upstreams[].model`.
     `weight`, `priority`, `enabled`.
 - `consumers[]`
   - `name`, `enabled`.
+  - `metadata`: free-form string map, informational only (not used for access
+    decisions).
   - `keys[]`: `name`, `api_key` (empty = auto-generate), `enabled`, `expires_at`.
-  - `routes[]`: granted client-visible route model names.
-  - `quotas`: `requests[]` / `tokens[]` (`limit` + `window`) and
-    `concurrency.max_requests`.
+  - `access`: `models[]` (granted client-visible route model names),
+    `protocols[]`, `ip_allowlist[]`. The whole `access` block, or any one of
+    its sub-fields, being empty/omitted means default-allow for that
+    dimension — `models`, `protocols`, and `ip_allowlist` are each judged
+    independently.
+  - `quotas`: `inflight` (max concurrently in-flight requests, no window),
+    `requests[]` / `tokens[]` (`limit` + `window`), and `budgets[]` (`limit` +
+    `window` + `currency`). Window units are `s`/`m`/`h`/`d`, plus `mo`
+    (natural calendar month) for budgets. Budgets are validated and persisted
+    but not enforced by the proxy in this version (enforcement requires a
+    pricing table, planned for a later version).
+  - `limits`: `max_input_tokens`, `max_output_tokens`,
+    `max_request_body_bytes` — per-request caps; omitted/zero means no limit.

--- a/go/docs/schema/database.md
+++ b/go/docs/schema/database.md
@@ -60,7 +60,7 @@ CREATE TABLE consumer_keys (
   id TEXT PRIMARY KEY,
   consumer_id TEXT NOT NULL,
   name TEXT NOT NULL,
-  key_prefix TEXT NOT NULL,
+  key_preview TEXT NOT NULL,
   key_hash TEXT NOT NULL,
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   expires_at TEXT,

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -140,22 +140,46 @@ type QuotaLimitSpec struct {
 	Window string `yaml:"window"`
 }
 
-type ConsumerConcurrencySpec struct {
-	MaxRequests int64 `yaml:"max_requests"`
+// BudgetLimitSpec is one spend-budget rule. It is validated and persisted
+// only; budgets are not enforced by the proxy in this version.
+type BudgetLimitSpec struct {
+	Limit    int64  `yaml:"limit"`
+	Window   string `yaml:"window"` // s/m/h/d, or "mo" for a natural calendar month
+	Currency string `yaml:"currency"`
 }
 
 type ConsumerQuotasSpec struct {
-	Requests    []QuotaLimitSpec         `yaml:"requests,omitempty"`
-	Tokens      []QuotaLimitSpec         `yaml:"tokens,omitempty"`
-	Concurrency *ConsumerConcurrencySpec `yaml:"concurrency,omitempty"`
+	// Inflight caps concurrently in-flight requests; zero/omitted = unlimited.
+	Inflight int64             `yaml:"inflight,omitempty"`
+	Requests []QuotaLimitSpec  `yaml:"requests,omitempty"`
+	Tokens   []QuotaLimitSpec  `yaml:"tokens,omitempty"`
+	Budgets  []BudgetLimitSpec `yaml:"budgets,omitempty"`
+}
+
+// ConsumerAccessSpec grants a consumer access to models/protocols/source IPs.
+// Any empty/omitted field means default-allow for that dimension.
+type ConsumerAccessSpec struct {
+	Models      []string `yaml:"models,omitempty"`
+	Protocols   []string `yaml:"protocols,omitempty"`
+	IPAllowlist []string `yaml:"ip_allowlist,omitempty"`
+}
+
+// ConsumerLimitsSpec caps per-request resource usage; zero/omitted means no
+// limit for that dimension.
+type ConsumerLimitsSpec struct {
+	MaxInputTokens      int64 `yaml:"max_input_tokens,omitempty"`
+	MaxOutputTokens     int64 `yaml:"max_output_tokens,omitempty"`
+	MaxRequestBodyBytes int64 `yaml:"max_request_body_bytes,omitempty"`
 }
 
 type ConsumerSpec struct {
-	Name    string             `yaml:"name"`
-	Enabled *bool              `yaml:"enabled,omitempty"`
-	Keys    []ConsumerKeySpec  `yaml:"keys"`
-	Routes  []string           `yaml:"routes"`
-	Quotas  ConsumerQuotasSpec `yaml:"quotas,omitempty"`
+	Name     string             `yaml:"name"`
+	Enabled  *bool              `yaml:"enabled,omitempty"`
+	Metadata map[string]string  `yaml:"metadata,omitempty"`
+	Keys     []ConsumerKeySpec  `yaml:"keys"`
+	Access   ConsumerAccessSpec `yaml:"access,omitempty"`
+	Quotas   ConsumerQuotasSpec `yaml:"quotas,omitempty"`
+	Limits   ConsumerLimitsSpec `yaml:"limits,omitempty"`
 }
 
 // Config is the standalone YAML configuration.
@@ -273,7 +297,7 @@ func (c *Config) ApplyTo(st storage.Storage) error {
 	}
 
 	for _, cs := range c.Consumers {
-		for _, name := range cs.Routes {
+		for _, name := range cs.Access.Models {
 			if !routeModels[name] {
 				return fmt.Errorf("consumer %q references unknown route %q", cs.Name, name)
 			}
@@ -285,8 +309,18 @@ func (c *Config) ApplyTo(st storage.Storage) error {
 			})
 		}
 		quotas := consumerQuotas(cs.Quotas)
+		var limits *storage.ConsumerLimits
+		if cs.Limits != (ConsumerLimitsSpec{}) {
+			limits = &storage.ConsumerLimits{
+				MaxInputTokens:      cs.Limits.MaxInputTokens,
+				MaxOutputTokens:     cs.Limits.MaxOutputTokens,
+				MaxRequestBodyBytes: cs.Limits.MaxRequestBodyBytes,
+			}
+		}
 		if _, err := st.Consumers().Create(storage.CreateConsumer{
-			Name: cs.Name, Enabled: cs.Enabled, Keys: keys, Routes: cs.Routes, Quotas: quotas,
+			Name: cs.Name, Enabled: cs.Enabled, Keys: keys, Routes: cs.Access.Models, Quotas: quotas,
+			Metadata: cs.Metadata, Protocols: cs.Access.Protocols, IPAllowlist: cs.Access.IPAllowlist,
+			Limits: limits,
 		}); err != nil {
 			return fmt.Errorf("create consumer %q: %w", cs.Name, err)
 		}
@@ -301,9 +335,9 @@ func (c *Config) ApplyTo(st storage.Storage) error {
 	return nil
 }
 
-// consumerQuotas expands the requests/tokens/concurrency quota shape into the
-// flat []CreateConsumerQuota rows the storage layer persists (one row per
-// (quota_type, window) pair; concurrency has no window).
+// consumerQuotas expands the requests/tokens/inflight/budgets quota shape
+// into the flat []CreateConsumerQuota rows the storage layer persists (one
+// row per (quota_type, window) pair; concurrency has no window).
 func consumerQuotas(q ConsumerQuotasSpec) []storage.CreateConsumerQuota {
 	var out []storage.CreateConsumerQuota
 	for _, r := range q.Requests {
@@ -312,8 +346,13 @@ func consumerQuotas(q ConsumerQuotasSpec) []storage.CreateConsumerQuota {
 	for _, t := range q.Tokens {
 		out = append(out, storage.CreateConsumerQuota{QuotaType: "tokens", QuotaLimit: t.Limit, Window: t.Window})
 	}
-	if q.Concurrency != nil {
-		out = append(out, storage.CreateConsumerQuota{QuotaType: "concurrency", QuotaLimit: q.Concurrency.MaxRequests})
+	if q.Inflight != 0 {
+		out = append(out, storage.CreateConsumerQuota{QuotaType: "concurrency", QuotaLimit: q.Inflight})
+	}
+	for _, b := range q.Budgets {
+		out = append(out, storage.CreateConsumerQuota{
+			QuotaType: "budget", QuotaLimit: b.Limit, Window: b.Window, Currency: b.Currency,
+		})
 	}
 	return out
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -144,16 +144,21 @@ type QuotaLimitSpec struct {
 // only; budgets are not enforced by the proxy in this version.
 type BudgetLimitSpec struct {
 	Limit    int64  `yaml:"limit"`
-	Window   string `yaml:"window"` // s/m/h/d, or "mo" for a natural calendar month
+	Window   string `yaml:"window"` // s/m/h/d, or "Nmo" for N natural calendar months (e.g. "1mo", "3mo")
 	Currency string `yaml:"currency"`
 }
 
+// ConsumerConcurrencySpec caps concurrently in-flight requests.
+type ConsumerConcurrencySpec struct {
+	Limit int64 `yaml:"limit"`
+}
+
 type ConsumerQuotasSpec struct {
-	// Inflight caps concurrently in-flight requests; zero/omitted = unlimited.
-	Inflight int64             `yaml:"inflight,omitempty"`
-	Requests []QuotaLimitSpec  `yaml:"requests,omitempty"`
-	Tokens   []QuotaLimitSpec  `yaml:"tokens,omitempty"`
-	Budgets  []BudgetLimitSpec `yaml:"budgets,omitempty"`
+	// Concurrency caps concurrently in-flight requests; nil/omitted = unlimited.
+	Concurrency *ConsumerConcurrencySpec `yaml:"concurrency,omitempty"`
+	Requests    []QuotaLimitSpec         `yaml:"requests,omitempty"`
+	Tokens      []QuotaLimitSpec         `yaml:"tokens,omitempty"`
+	Budgets     []BudgetLimitSpec        `yaml:"budgets,omitempty"`
 }
 
 // ConsumerAccessSpec grants a consumer access to models/protocols/source IPs.
@@ -335,7 +340,7 @@ func (c *Config) ApplyTo(st storage.Storage) error {
 	return nil
 }
 
-// consumerQuotas expands the requests/tokens/inflight/budgets quota shape
+// consumerQuotas expands the requests/tokens/concurrency/budgets quota shape
 // into the flat []CreateConsumerQuota rows the storage layer persists (one
 // row per (quota_type, window) pair; concurrency has no window).
 func consumerQuotas(q ConsumerQuotasSpec) []storage.CreateConsumerQuota {
@@ -346,8 +351,8 @@ func consumerQuotas(q ConsumerQuotasSpec) []storage.CreateConsumerQuota {
 	for _, t := range q.Tokens {
 		out = append(out, storage.CreateConsumerQuota{QuotaType: "tokens", QuotaLimit: t.Limit, Window: t.Window})
 	}
-	if q.Inflight != 0 {
-		out = append(out, storage.CreateConsumerQuota{QuotaType: "concurrency", QuotaLimit: q.Inflight})
+	if q.Concurrency != nil {
+		out = append(out, storage.CreateConsumerQuota{QuotaType: "concurrency", QuotaLimit: q.Concurrency.Limit})
 	}
 	for _, b := range q.Budgets {
 		out = append(out, storage.CreateConsumerQuota{

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -35,12 +35,12 @@ consumers:
   - name: local
     keys:
       - {name: primary, api_key: nyro-secret}
-    routes: [gpt-4o]
+    access:
+      models: [gpt-4o]
     quotas:
       requests:
         - {limit: 60, window: "1m"}
-      concurrency:
-        max_requests: 10
+      inflight: 10
 `
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
@@ -288,7 +288,7 @@ func TestApplyToUnknownUpstream(t *testing.T) {
 
 func TestApplyToUnknownRoute(t *testing.T) {
 	cfg := &Config{
-		Consumers: []ConsumerSpec{{Name: "c", Routes: []string{"nope"}}},
+		Consumers: []ConsumerSpec{{Name: "c", Access: ConsumerAccessSpec{Models: []string{"nope"}}}},
 	}
 	if err := cfg.ApplyTo(memory.New().Storage()); err == nil {
 		t.Error("expected error for unknown route reference")
@@ -305,7 +305,8 @@ func TestBuildSnapshot_BuildsReadableSnapshot(t *testing.T) {
 			Model: "gpt-4o", Upstreams: []RouteUpstreamSpec{{Name: "openai", Model: "gpt-4o"}},
 		}},
 		Consumers: []ConsumerSpec{{
-			Name: "local", Keys: []ConsumerKeySpec{{Name: "primary", APIKey: "nyro-secret"}}, Routes: []string{"gpt-4o"},
+			Name: "local", Keys: []ConsumerKeySpec{{Name: "primary", APIKey: "nyro-secret"}},
+			Access: ConsumerAccessSpec{Models: []string{"gpt-4o"}},
 		}},
 	}
 	snap, err := cfg.BuildSnapshot()
@@ -342,17 +343,18 @@ func TestBuildSnapshot_UnknownRefs(t *testing.T) {
 	}
 }
 
-func TestConsumerQuotas_ExpandsThreeCategories(t *testing.T) {
+func TestConsumerQuotas_ExpandsAllCategories(t *testing.T) {
 	q := ConsumerQuotasSpec{
-		Requests:    []QuotaLimitSpec{{Limit: 60, Window: "1m"}, {Limit: 10000, Window: "1d"}},
-		Tokens:      []QuotaLimitSpec{{Limit: 100000, Window: "1m"}},
-		Concurrency: &ConsumerConcurrencySpec{MaxRequests: 10},
+		Requests: []QuotaLimitSpec{{Limit: 60, Window: "1m"}, {Limit: 10000, Window: "1d"}},
+		Tokens:   []QuotaLimitSpec{{Limit: 100000, Window: "1m"}},
+		Inflight: 10,
+		Budgets:  []BudgetLimitSpec{{Limit: 100, Window: "mo", Currency: "USD"}},
 	}
 	got := consumerQuotas(q)
-	if len(got) != 4 {
-		t.Fatalf("consumerQuotas() = %d rows, want 4: %+v", len(got), got)
+	if len(got) != 5 {
+		t.Fatalf("consumerQuotas() = %d rows, want 5: %+v", len(got), got)
 	}
-	var requestsCount, tokensCount, concurrencyCount int
+	var requestsCount, tokensCount, concurrencyCount, budgetCount int
 	for _, row := range got {
 		switch row.QuotaType {
 		case "requests":
@@ -367,6 +369,11 @@ func TestConsumerQuotas_ExpandsThreeCategories(t *testing.T) {
 			if row.QuotaLimit != 10 || row.Window != "" {
 				t.Errorf("concurrency row wrong (window must be empty): %+v", row)
 			}
+		case "budget":
+			budgetCount++
+			if row.QuotaLimit != 100 || row.Window != "mo" || row.Currency != "USD" {
+				t.Errorf("budget row wrong: %+v", row)
+			}
 		}
 	}
 	if requestsCount != 2 {
@@ -377,6 +384,9 @@ func TestConsumerQuotas_ExpandsThreeCategories(t *testing.T) {
 	}
 	if concurrencyCount != 1 {
 		t.Errorf("concurrency rows = %d, want 1", concurrencyCount)
+	}
+	if budgetCount != 1 {
+		t.Errorf("budget rows = %d, want 1", budgetCount)
 	}
 }
 

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -40,7 +40,7 @@ consumers:
     quotas:
       requests:
         - {limit: 60, window: "1m"}
-      inflight: 10
+      concurrency: {limit: 10}
 `
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
@@ -345,10 +345,10 @@ func TestBuildSnapshot_UnknownRefs(t *testing.T) {
 
 func TestConsumerQuotas_ExpandsAllCategories(t *testing.T) {
 	q := ConsumerQuotasSpec{
-		Requests: []QuotaLimitSpec{{Limit: 60, Window: "1m"}, {Limit: 10000, Window: "1d"}},
-		Tokens:   []QuotaLimitSpec{{Limit: 100000, Window: "1m"}},
-		Inflight: 10,
-		Budgets:  []BudgetLimitSpec{{Limit: 100, Window: "mo", Currency: "USD"}},
+		Requests:    []QuotaLimitSpec{{Limit: 60, Window: "1m"}, {Limit: 10000, Window: "1d"}},
+		Tokens:      []QuotaLimitSpec{{Limit: 100000, Window: "1m"}},
+		Concurrency: &ConsumerConcurrencySpec{Limit: 10},
+		Budgets:     []BudgetLimitSpec{{Limit: 100, Window: "1mo", Currency: "USD"}},
 	}
 	got := consumerQuotas(q)
 	if len(got) != 5 {
@@ -371,7 +371,7 @@ func TestConsumerQuotas_ExpandsAllCategories(t *testing.T) {
 			}
 		case "budget":
 			budgetCount++
-			if row.QuotaLimit != 100 || row.Window != "mo" || row.Currency != "USD" {
+			if row.QuotaLimit != 100 || row.Window != "1mo" || row.Currency != "USD" {
 				t.Errorf("budget row wrong: %+v", row)
 			}
 		}

--- a/go/internal/proxy/inbound.go
+++ b/go/internal/proxy/inbound.go
@@ -32,7 +32,7 @@ func checkAccess(snap *xds.ConfigSnapshot, qc *quota.Counter, route storage.Rout
 		return http.StatusUnauthorized, "invalid API key", nil
 	}
 	*consumerID = rec.ConsumerID
-	*keyName = rec.KeyPrefix
+	*keyName = rec.KeyPreview
 	if !rec.Enabled {
 		return http.StatusForbidden, "API key is disabled", nil
 	}

--- a/go/internal/storage/consumer.go
+++ b/go/internal/storage/consumer.go
@@ -11,14 +11,29 @@ import (
 // replaces the legacy ApiKey: a single consumer can hold multiple keys and
 // grants routes (model names) that apply to all of its keys.
 type Consumer struct {
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Enabled   bool            `json:"enabled"`
-	Keys      []ConsumerKey   `json:"keys,omitempty"`
-	Routes    []string        `json:"routes,omitempty"` // route model names granted
-	Quotas    []ConsumerQuota `json:"quotas,omitempty"`
-	CreatedAt string          `json:"created_at,omitempty"`
-	UpdatedAt string          `json:"updated_at,omitempty"`
+	ID      string        `json:"id"`
+	Name    string        `json:"name"`
+	Enabled bool          `json:"enabled"`
+	Keys    []ConsumerKey `json:"keys,omitempty"`
+	// Routes are the granted route model names. An empty/nil slice means
+	// access to all routes is allowed (default-allow), matching Protocols
+	// and IPAllowlist.
+	Routes      []string          `json:"routes,omitempty"`
+	Quotas      []ConsumerQuota   `json:"quotas,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Protocols   []string          `json:"protocols,omitempty"`
+	IPAllowlist []string          `json:"ip_allowlist,omitempty"`
+	Limits      *ConsumerLimits   `json:"limits,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	UpdatedAt   string            `json:"updated_at,omitempty"`
+}
+
+// ConsumerLimits caps per-request resource usage for a consumer. A zero value
+// on any field means "no limit" for that dimension.
+type ConsumerLimits struct {
+	MaxInputTokens      int64 `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens     int64 `json:"max_output_tokens,omitempty"`
+	MaxRequestBodyBytes int64 `json:"max_request_body_bytes,omitempty"`
 }
 
 // ConsumerKey is one credential owned by a consumer (table: consumer_keys).
@@ -45,19 +60,26 @@ type ConsumerKey struct {
 type ConsumerQuota struct {
 	ID         string `json:"id"`
 	ConsumerID string `json:"consumer_id"`
-	QuotaType  string `json:"quota_type"` // requests | tokens | concurrency
+	QuotaType  string `json:"quota_type"` // requests | tokens | concurrency | budget
 	QuotaLimit int64  `json:"quota_limit"`
 	Window     string `json:"window,omitempty"`
+	// Currency is set only for budget quotas (ISO 4217 code, e.g. "USD").
+	// Budgets are validated and persisted but not enforced by the proxy yet.
+	Currency string `json:"currency,omitempty"`
 }
 
 // CreateConsumer is the write DTO for creating a consumer with its keys, route
 // grants, and quotas in one call.
 type CreateConsumer struct {
-	Name    string                `json:"name"`
-	Enabled *bool                 `json:"enabled,omitempty"`
-	Keys    []CreateConsumerKey   `json:"keys,omitempty"`
-	Routes  []string              `json:"routes,omitempty"`
-	Quotas  []CreateConsumerQuota `json:"quotas,omitempty"`
+	Name        string                `json:"name"`
+	Enabled     *bool                 `json:"enabled,omitempty"`
+	Keys        []CreateConsumerKey   `json:"keys,omitempty"`
+	Routes      []string              `json:"routes,omitempty"`
+	Quotas      []CreateConsumerQuota `json:"quotas,omitempty"`
+	Metadata    map[string]string     `json:"metadata,omitempty"`
+	Protocols   []string              `json:"protocols,omitempty"`
+	IPAllowlist []string              `json:"ip_allowlist,omitempty"`
+	Limits      *ConsumerLimits       `json:"limits,omitempty"`
 }
 
 // CreateConsumerKey carries the raw token at creation time; the store derives
@@ -74,6 +96,8 @@ type CreateConsumerQuota struct {
 	QuotaType  string `json:"quota_type"`
 	QuotaLimit int64  `json:"quota_limit"`
 	Window     string `json:"window,omitempty"`
+	// Currency is required when QuotaType is "budget".
+	Currency string `json:"currency,omitempty"`
 }
 
 // UpdateConsumerKey is the partial-update DTO for a single consumer key;
@@ -85,28 +109,38 @@ type UpdateConsumerKey struct {
 }
 
 // UpdateConsumer is the partial-update DTO; nil fields mean "unchanged". A
-// non-nil Quotas or Routes slice replaces that dimension wholesale (matching
-// UpdateRoute.Upstreams semantics). Key mutations go through a dedicated
-// sub-store in a later step.
+// non-nil Quotas, Routes, Protocols, or IPAllowlist slice replaces that
+// dimension wholesale (matching UpdateRoute.Upstreams semantics). Key
+// mutations go through a dedicated sub-store in a later step.
 type UpdateConsumer struct {
-	Name    *string                `json:"name,omitempty"`
-	Enabled *bool                  `json:"enabled,omitempty"`
-	Quotas  *[]CreateConsumerQuota `json:"quotas,omitempty"`
-	Routes  *[]string              `json:"routes,omitempty"`
+	Name        *string                `json:"name,omitempty"`
+	Enabled     *bool                  `json:"enabled,omitempty"`
+	Quotas      *[]CreateConsumerQuota `json:"quotas,omitempty"`
+	Routes      *[]string              `json:"routes,omitempty"`
+	Metadata    *map[string]string     `json:"metadata,omitempty"`
+	Protocols   *[]string              `json:"protocols,omitempty"`
+	IPAllowlist *[]string              `json:"ip_allowlist,omitempty"`
+	Limits      *ConsumerLimits        `json:"limits,omitempty"`
 }
 
 // validQuotaTypes enumerates the allowed ConsumerQuota.QuotaType values.
-var validQuotaTypes = map[string]bool{"requests": true, "tokens": true, "concurrency": true}
+var validQuotaTypes = map[string]bool{"requests": true, "tokens": true, "concurrency": true, "budget": true}
 
 // ValidateConsumerQuota checks a single quota DTO's invariants:
-//   - QuotaType must be one of requests, tokens, concurrency.
+//   - QuotaType must be one of requests, tokens, concurrency, budget.
 //   - QuotaLimit must be positive.
 //   - concurrency quotas must not set a window (they aren't time-windowed).
-//   - any window must parse via quota.ParseWindow (the same parser the proxy's
-//     quota counter uses at enforcement time).
+//   - budget quotas must set Currency, and their window may additionally be
+//     "mo" (natural calendar month) on top of the s/m/h/d units accepted
+//     elsewhere; "mo" has no fixed time.Duration, so it is accepted as a
+//     literal here and left for the (not-yet-built) budget-enforcement path
+//     to interpret against calendar boundaries. Budgets are validated and
+//     persisted only; they are not enforced by the proxy in this version.
+//   - any other window must parse via quota.ParseWindow (the same parser the
+//     proxy's quota counter uses at enforcement time).
 func ValidateConsumerQuota(q CreateConsumerQuota) error {
 	if !validQuotaTypes[q.QuotaType] {
-		return fmt.Errorf("invalid quota_type %q: must be one of requests, tokens, concurrency", q.QuotaType)
+		return fmt.Errorf("invalid quota_type %q: must be one of requests, tokens, concurrency, budget", q.QuotaType)
 	}
 	if q.QuotaLimit <= 0 {
 		return fmt.Errorf("quota_limit must be > 0, got %d", q.QuotaLimit)
@@ -114,6 +148,17 @@ func ValidateConsumerQuota(q CreateConsumerQuota) error {
 	if q.QuotaType == "concurrency" {
 		if q.Window != "" {
 			return fmt.Errorf("concurrency quotas must not set a window")
+		}
+		return nil
+	}
+	if q.QuotaType == "budget" {
+		if q.Currency == "" {
+			return fmt.Errorf("budget quotas require a currency")
+		}
+		if q.Window != "" && q.Window != "mo" {
+			if _, err := quota.ParseWindow(q.Window); err != nil {
+				return fmt.Errorf("invalid window %q: %w", q.Window, err)
+			}
 		}
 		return nil
 	}

--- a/go/internal/storage/consumer.go
+++ b/go/internal/storage/consumer.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/nyroway/nyro/go/internal/proxy/quota"
 )
@@ -37,13 +38,13 @@ type ConsumerLimits struct {
 }
 
 // ConsumerKey is one credential owned by a consumer (table: consumer_keys).
-// Only KeyPrefix + KeyHash are persisted; the raw token is held only at
+// Only KeyPreview + KeyHash are persisted; the raw token is held only at
 // creation/import time and never stored.
 type ConsumerKey struct {
 	ID         string `json:"id"`
 	ConsumerID string `json:"consumer_id"`
 	Name       string `json:"name"`
-	KeyPrefix  string `json:"key_prefix"`
+	KeyPreview string `json:"key_preview"`
 	KeyHash    string `json:"-"` // never serialized
 	// Token carries the raw key exactly once, in the response to the create
 	// call that generated it. It is never populated on read paths (List/Get)
@@ -83,7 +84,7 @@ type CreateConsumer struct {
 }
 
 // CreateConsumerKey carries the raw token at creation time; the store derives
-// KeyPrefix + KeyHash from it and discards the plaintext.
+// KeyPreview + KeyHash from it and discards the plaintext.
 type CreateConsumerKey struct {
 	Name      string `json:"name"`
 	Token     string `json:"token,omitempty"` // raw; empty = auto-generate
@@ -126,16 +127,22 @@ type UpdateConsumer struct {
 // validQuotaTypes enumerates the allowed ConsumerQuota.QuotaType values.
 var validQuotaTypes = map[string]bool{"requests": true, "tokens": true, "concurrency": true, "budget": true}
 
+// naturalMonthWindow matches an "Nmo" budget window (e.g. "1mo", "3mo"): N
+// natural calendar months, which have no fixed time.Duration.
+var naturalMonthWindow = regexp.MustCompile(`^[0-9]+mo$`)
+
 // ValidateConsumerQuota checks a single quota DTO's invariants:
 //   - QuotaType must be one of requests, tokens, concurrency, budget.
 //   - QuotaLimit must be positive.
-//   - concurrency quotas must not set a window (they aren't time-windowed).
+//   - concurrency quotas must not set a window (they aren't time-windowed;
+//     they cap concurrently in-flight requests).
 //   - budget quotas must set Currency, and their window may additionally be
-//     "mo" (natural calendar month) on top of the s/m/h/d units accepted
-//     elsewhere; "mo" has no fixed time.Duration, so it is accepted as a
-//     literal here and left for the (not-yet-built) budget-enforcement path
-//     to interpret against calendar boundaries. Budgets are validated and
-//     persisted only; they are not enforced by the proxy in this version.
+//     "Nmo" (N natural calendar months, e.g. "1mo", "3mo") on top of the
+//     s/m/h/d units accepted elsewhere; "Nmo" has no fixed time.Duration, so
+//     it is accepted as a literal here and left for the (not-yet-built)
+//     budget-enforcement path to interpret against calendar boundaries.
+//     Budgets are validated and persisted only; they are not enforced by the
+//     proxy in this version.
 //   - any other window must parse via quota.ParseWindow (the same parser the
 //     proxy's quota counter uses at enforcement time).
 func ValidateConsumerQuota(q CreateConsumerQuota) error {
@@ -155,7 +162,7 @@ func ValidateConsumerQuota(q CreateConsumerQuota) error {
 		if q.Currency == "" {
 			return fmt.Errorf("budget quotas require a currency")
 		}
-		if q.Window != "" && q.Window != "mo" {
+		if q.Window != "" && !naturalMonthWindow.MatchString(q.Window) {
 			if _, err := quota.ParseWindow(q.Window); err != nil {
 				return fmt.Errorf("invalid window %q: %w", q.Window, err)
 			}
@@ -176,7 +183,7 @@ func ValidateConsumerQuota(q CreateConsumerQuota) error {
 type ConsumerKeyAccessRecord struct {
 	KeyID      string          `json:"key_id"`
 	ConsumerID string          `json:"consumer_id"`
-	KeyPrefix  string          `json:"key_prefix"`
+	KeyPreview string          `json:"key_preview"`
 	Enabled    bool            `json:"enabled"`
 	ExpiresAt  string          `json:"expires_at,omitempty"`
 	Routes     []string        `json:"routes,omitempty"`
@@ -205,7 +212,7 @@ type ConsumerStore interface {
 }
 
 // KeyAuthStore is the inbound-auth read path used by the proxy: resolve a raw
-// token to its consumer key + grants. Implementations use KeyPrefix filtering
+// token to its consumer key + grants. Implementations use KeyPreview filtering
 // plus a hash compare (raw tokens are not persisted); the contract is defined
 // here, the implementation is added in a later step.
 type KeyAuthStore interface {

--- a/go/internal/storage/database/consumers.go
+++ b/go/internal/storage/database/consumers.go
@@ -108,11 +108,19 @@ func (s consumerStore) Create(in storage.CreateConsumer) (storage.Consumer, erro
 		enabled = *in.Enabled
 	}
 	c := &model.Consumer{
-		ID:        newID(),
-		Name:      in.Name,
-		Enabled:   enabled,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:              newID(),
+		Name:            in.Name,
+		Enabled:         enabled,
+		MetadataJSON:    stringMapToJSON(in.Metadata),
+		ProtocolsJSON:   stringSliceToJSON(in.Protocols),
+		IPAllowlistJSON: stringSliceToJSON(in.IPAllowlist),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if in.Limits != nil {
+		c.MaxInputTokens = in.Limits.MaxInputTokens
+		c.MaxOutputTokens = in.Limits.MaxOutputTokens
+		c.MaxRequestBodyBytes = in.Limits.MaxRequestBodyBytes
 	}
 	var out storage.Consumer
 	err := s.q.Transaction(func(tx *query.Query) error {
@@ -238,6 +246,7 @@ func insertConsumerQuotas(ctx context.Context, tx *query.Query, consumerID strin
 			QuotaType:  qin.QuotaType,
 			QuotaLimit: qin.QuotaLimit,
 			Window:     qin.Window,
+			Currency:   qin.Currency,
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}
@@ -302,6 +311,22 @@ func (s consumerStore) Update(id string, in storage.UpdateConsumer) (storage.Con
 		}
 		if in.Enabled != nil {
 			assigns = append(assigns, tx.Consumer.Enabled.Value(*in.Enabled))
+		}
+		if in.Metadata != nil {
+			assigns = append(assigns, tx.Consumer.MetadataJSON.Value(stringMapToJSON(*in.Metadata)))
+		}
+		if in.Protocols != nil {
+			assigns = append(assigns, tx.Consumer.ProtocolsJSON.Value(stringSliceToJSON(*in.Protocols)))
+		}
+		if in.IPAllowlist != nil {
+			assigns = append(assigns, tx.Consumer.IPAllowlistJSON.Value(stringSliceToJSON(*in.IPAllowlist)))
+		}
+		if in.Limits != nil {
+			assigns = append(assigns,
+				tx.Consumer.MaxInputTokens.Value(in.Limits.MaxInputTokens),
+				tx.Consumer.MaxOutputTokens.Value(in.Limits.MaxOutputTokens),
+				tx.Consumer.MaxRequestBodyBytes.Value(in.Limits.MaxRequestBodyBytes),
+			)
 		}
 		if _, err := tx.Consumer.WithContext(ctx).Where(tx.Consumer.ID.Eq(id)).UpdateSimple(assigns...); err != nil {
 			return err

--- a/go/internal/storage/database/consumers.go
+++ b/go/internal/storage/database/consumers.go
@@ -176,15 +176,15 @@ func (s consumerStore) Create(in storage.CreateConsumer) (storage.Consumer, erro
 func createConsumerKey(ctx context.Context, tx *query.Query, consumerID string, in storage.CreateConsumerKey) (storage.ConsumerKey, error) {
 	now := nowISO()
 	raw := in.Token
-	var prefix, hash string
+	var preview, hash string
 	if raw == "" {
 		var err error
-		raw, prefix, hash, err = storage.GenerateKey()
+		raw, preview, hash, err = storage.GenerateKey()
 		if err != nil {
 			return storage.ConsumerKey{}, err
 		}
 	} else {
-		prefix = storage.PrefixOf(raw)
+		preview = storage.PreviewOf(raw)
 		hash = storage.HashKey(raw)
 	}
 	enabled := true
@@ -195,7 +195,7 @@ func createConsumerKey(ctx context.Context, tx *query.Query, consumerID string, 
 		ID:         newID(),
 		ConsumerID: consumerID,
 		Name:       in.Name,
-		KeyPrefix:  prefix,
+		KeyPreview: preview,
 		KeyHash:    hash,
 		Enabled:    enabled,
 		ExpiresAt:  in.ExpiresAt,

--- a/go/internal/storage/database/convert.go
+++ b/go/internal/storage/database/convert.go
@@ -162,7 +162,7 @@ func consumerKeyFromModel(m *model.ConsumerKey) storage.ConsumerKey {
 		ID:         m.ID,
 		ConsumerID: m.ConsumerID,
 		Name:       m.Name,
-		KeyPrefix:  m.KeyPrefix,
+		KeyPreview: m.KeyPreview,
 		KeyHash:    m.KeyHash,
 		Enabled:    m.Enabled,
 		ExpiresAt:  m.ExpiresAt,

--- a/go/internal/storage/database/convert.go
+++ b/go/internal/storage/database/convert.go
@@ -85,13 +85,76 @@ func routeUpstreamFromModel(m *model.RouteUpstream) storage.RouteUpstream {
 }
 
 func consumerFromModel(m *model.Consumer) storage.Consumer {
-	return storage.Consumer{
-		ID:        m.ID,
-		Name:      m.Name,
-		Enabled:   m.Enabled,
-		CreatedAt: m.CreatedAt,
-		UpdatedAt: m.UpdatedAt,
+	out := storage.Consumer{
+		ID:          m.ID,
+		Name:        m.Name,
+		Enabled:     m.Enabled,
+		Metadata:    stringMapFromJSON(m.MetadataJSON),
+		Protocols:   stringSliceFromJSON(m.ProtocolsJSON),
+		IPAllowlist: stringSliceFromJSON(m.IPAllowlistJSON),
+		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
 	}
+	if m.MaxInputTokens != 0 || m.MaxOutputTokens != 0 || m.MaxRequestBodyBytes != 0 {
+		out.Limits = &storage.ConsumerLimits{
+			MaxInputTokens:      m.MaxInputTokens,
+			MaxOutputTokens:     m.MaxOutputTokens,
+			MaxRequestBodyBytes: m.MaxRequestBodyBytes,
+		}
+	}
+	return out
+}
+
+// stringMapFromJSON decodes a DB-stored JSON object column into a
+// map[string]string (empty string means "not set").
+func stringMapFromJSON(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// stringMapToJSON encodes a map[string]string DTO field to the DB-stored JSON
+// string column.
+func stringMapToJSON(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// stringSliceFromJSON decodes a DB-stored JSON array column into a []string
+// (empty string means "not set").
+func stringSliceFromJSON(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// stringSliceToJSON encodes a []string DTO field to the DB-stored JSON string
+// column.
+func stringSliceToJSON(v []string) string {
+	if len(v) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func consumerKeyFromModel(m *model.ConsumerKey) storage.ConsumerKey {
@@ -116,5 +179,6 @@ func consumerQuotaFromModel(m *model.ConsumerQuota) storage.ConsumerQuota {
 		QuotaType:  m.QuotaType,
 		QuotaLimit: m.QuotaLimit,
 		Window:     m.Window,
+		Currency:   m.Currency,
 	}
 }

--- a/go/internal/storage/database/keyauth.go
+++ b/go/internal/storage/database/keyauth.go
@@ -9,14 +9,14 @@ import (
 
 type keyAuthStore struct{ q *query.Query }
 
-// FindKey narrows candidates by KeyPrefix (indexed), then compares SHA-256
+// FindKey narrows candidates by KeyPreview (indexed), then compares SHA-256
 // hashes to find the exact match — raw tokens are never persisted.
 func (s keyAuthStore) FindKey(rawKey string) (*storage.ConsumerKeyAccessRecord, error) {
 	ctx := context.Background()
-	prefix := storage.PrefixOf(rawKey)
+	preview := storage.PreviewOf(rawKey)
 	hash := storage.HashKey(rawKey)
 
-	candidates, err := s.q.ConsumerKey.WithContext(ctx).Where(s.q.ConsumerKey.KeyPrefix.Eq(prefix)).Find()
+	candidates, err := s.q.ConsumerKey.WithContext(ctx).Where(s.q.ConsumerKey.KeyPreview.Eq(preview)).Find()
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s keyAuthStore) FindKey(rawKey string) (*storage.ConsumerKeyAccessRecord, 
 	rec := &storage.ConsumerKeyAccessRecord{
 		KeyID:      matched.ID,
 		ConsumerID: matched.ConsumerID,
-		KeyPrefix:  matched.KeyPrefix,
+		KeyPreview: matched.KeyPreview,
 		Enabled:    matched.Enabled && consumerEnabled,
 		ExpiresAt:  matched.ExpiresAt,
 	}

--- a/go/internal/storage/key.go
+++ b/go/internal/storage/key.go
@@ -7,29 +7,41 @@ import (
 	"fmt"
 )
 
-// keyPrefixLen is the number of raw-key characters persisted as KeyPrefix, used
-// to narrow candidates before a hash compare in KeyAuthStore.FindKey.
-const keyPrefixLen = 12
+// keyPreviewLeadLen and keyPreviewTrailLen are the number of raw-key
+// characters persisted as KeyPreview (leading+trailing, concatenated). The
+// leading slice alone is also what KeyAuthStore.FindKey uses to narrow
+// candidates before a hash compare — auth time always has the full raw key,
+// so it derives the identical leading+trailing slice and does an exact-match
+// lookup against the stored value, preserving the same indexed-equality
+// lookup behavior as before this field also carried a trailing slice.
+const (
+	keyPreviewLeadLen  = 12
+	keyPreviewTrailLen = 6
+)
 
 // GenerateKey creates a new random API key. raw is returned to the caller
-// exactly once (at creation time) and must never be persisted; prefix and hash
-// are the values a ConsumerKey store persists.
-func GenerateKey() (raw, prefix, hash string, err error) {
+// exactly once (at creation time) and must never be persisted; preview and
+// hash are the values a ConsumerKey store persists.
+func GenerateKey() (raw, preview, hash string, err error) {
 	var buf [24]byte
 	if _, err := rand.Read(buf[:]); err != nil {
 		return "", "", "", fmt.Errorf("storage: generate key: %w", err)
 	}
-	raw = "nyro_" + hex.EncodeToString(buf[:])
-	return raw, PrefixOf(raw), HashKey(raw), nil
+	raw = "sk-" + hex.EncodeToString(buf[:])
+	return raw, PreviewOf(raw), HashKey(raw), nil
 }
 
-// PrefixOf returns the persisted prefix of a raw key (the whole key if shorter
-// than the prefix length).
-func PrefixOf(raw string) string {
-	if len(raw) <= keyPrefixLen {
+// PreviewOf returns the persisted preview of a raw key: its leading
+// keyPreviewLeadLen characters concatenated with its trailing
+// keyPreviewTrailLen characters (the whole key if it's shorter than that
+// combined length). This is never enough to reconstruct the key — it exists
+// so a masked "sk-abc123...xyz789" can be rendered without ever persisting
+// (or re-exposing) the full plaintext.
+func PreviewOf(raw string) string {
+	if len(raw) <= keyPreviewLeadLen+keyPreviewTrailLen {
 		return raw
 	}
-	return raw[:keyPrefixLen]
+	return raw[:keyPreviewLeadLen] + raw[len(raw)-keyPreviewTrailLen:]
 }
 
 // HashKey returns the persisted hash of a raw key (hex-encoded SHA-256). API

--- a/go/internal/storage/memory/consumers.go
+++ b/go/internal/storage/memory/consumers.go
@@ -111,7 +111,11 @@ func (s consumerStore) Create(in storage.CreateConsumer) (storage.Consumer, erro
 	if in.Enabled != nil {
 		enabled = *in.Enabled
 	}
-	c := storage.Consumer{ID: newID(), Name: in.Name, Enabled: enabled, CreatedAt: now, UpdatedAt: now}
+	c := storage.Consumer{
+		ID: newID(), Name: in.Name, Enabled: enabled,
+		Metadata: in.Metadata, Protocols: in.Protocols, IPAllowlist: in.IPAllowlist, Limits: in.Limits,
+		CreatedAt: now, UpdatedAt: now,
+	}
 	s.b.consumers[c.ID] = c
 
 	// Collect the created keys directly (with their one-time raw Token);
@@ -177,7 +181,7 @@ func (b *Backend) insertConsumerQuotas(consumerID string, quotas []storage.Creat
 	for _, qin := range quotas {
 		cq := storage.ConsumerQuota{
 			ID: newID(), ConsumerID: consumerID, QuotaType: qin.QuotaType,
-			QuotaLimit: qin.QuotaLimit, Window: qin.Window,
+			QuotaLimit: qin.QuotaLimit, Window: qin.Window, Currency: qin.Currency,
 		}
 		b.consumerQuotas[cq.ID] = cq
 	}
@@ -250,6 +254,18 @@ func (s consumerStore) Update(id string, in storage.UpdateConsumer) (storage.Con
 	}
 	if in.Enabled != nil {
 		c.Enabled = *in.Enabled
+	}
+	if in.Metadata != nil {
+		c.Metadata = *in.Metadata
+	}
+	if in.Protocols != nil {
+		c.Protocols = *in.Protocols
+	}
+	if in.IPAllowlist != nil {
+		c.IPAllowlist = *in.IPAllowlist
+	}
+	if in.Limits != nil {
+		c.Limits = in.Limits
 	}
 	c.UpdatedAt = nowISO()
 	s.b.consumers[id] = c

--- a/go/internal/storage/memory/consumers.go
+++ b/go/internal/storage/memory/consumers.go
@@ -45,15 +45,15 @@ func (b *Backend) consumerWithDetails(c storage.Consumer) storage.Consumer {
 func (b *Backend) createConsumerKey(consumerID string, in storage.CreateConsumerKey) (storage.ConsumerKey, error) {
 	now := nowISO()
 	raw := in.Token
-	var prefix, hash string
+	var preview, hash string
 	if raw == "" {
 		var err error
-		raw, prefix, hash, err = storage.GenerateKey()
+		raw, preview, hash, err = storage.GenerateKey()
 		if err != nil {
 			return storage.ConsumerKey{}, err
 		}
 	} else {
-		prefix = storage.PrefixOf(raw)
+		preview = storage.PreviewOf(raw)
 		hash = storage.HashKey(raw)
 	}
 	enabled := true
@@ -61,7 +61,7 @@ func (b *Backend) createConsumerKey(consumerID string, in storage.CreateConsumer
 		enabled = *in.Enabled
 	}
 	k := storage.ConsumerKey{
-		ID: newID(), ConsumerID: consumerID, Name: in.Name, KeyPrefix: prefix, KeyHash: hash,
+		ID: newID(), ConsumerID: consumerID, Name: in.Name, KeyPreview: preview, KeyHash: hash,
 		Enabled: enabled, ExpiresAt: in.ExpiresAt, CreatedAt: now, UpdatedAt: now,
 	}
 	b.consumerKeys[k.ID] = k

--- a/go/internal/storage/memory/keyauth.go
+++ b/go/internal/storage/memory/keyauth.go
@@ -4,18 +4,18 @@ import "github.com/nyroway/nyro/go/internal/storage"
 
 type keyAuthStore struct{ b *Backend }
 
-// FindKey narrows candidates by KeyPrefix, then compares SHA-256 hashes — raw
+// FindKey narrows candidates by KeyPreview, then compares SHA-256 hashes — raw
 // tokens are never persisted.
 func (s keyAuthStore) FindKey(rawKey string) (*storage.ConsumerKeyAccessRecord, error) {
 	s.b.mu.RLock()
 	defer s.b.mu.RUnlock()
 
-	prefix := storage.PrefixOf(rawKey)
+	preview := storage.PreviewOf(rawKey)
 	hash := storage.HashKey(rawKey)
 
 	var matched *storage.ConsumerKey
 	for _, k := range s.b.consumerKeys {
-		if k.KeyPrefix == prefix && k.KeyHash == hash {
+		if k.KeyPreview == preview && k.KeyHash == hash {
 			m := k
 			matched = &m
 			break
@@ -36,7 +36,7 @@ func (s keyAuthStore) FindKey(rawKey string) (*storage.ConsumerKeyAccessRecord, 
 	rec := &storage.ConsumerKeyAccessRecord{
 		KeyID:      matched.ID,
 		ConsumerID: matched.ConsumerID,
-		KeyPrefix:  matched.KeyPrefix,
+		KeyPreview: matched.KeyPreview,
 		Enabled:    matched.Enabled && consumerEnabled,
 		ExpiresAt:  matched.ExpiresAt,
 	}

--- a/go/internal/storage/model/models.go
+++ b/go/internal/storage/model/models.go
@@ -51,11 +51,17 @@ func (RouteUpstream) TableName() string { return "route_upstreams" }
 
 // Consumer is a downstream caller identity.
 type Consumer struct {
-	ID        string `gorm:"column:id;primaryKey"`
-	Name      string `gorm:"column:name;uniqueIndex;not null"`
-	Enabled   bool   `gorm:"column:enabled;not null;default:true"`
-	CreatedAt string `gorm:"column:created_at;not null"`
-	UpdatedAt string `gorm:"column:updated_at;not null"`
+	ID                  string `gorm:"column:id;primaryKey"`
+	Name                string `gorm:"column:name;uniqueIndex;not null"`
+	Enabled             bool   `gorm:"column:enabled;not null;default:true"`
+	MetadataJSON        string `gorm:"column:metadata_json"`
+	ProtocolsJSON       string `gorm:"column:protocols_json"`
+	IPAllowlistJSON     string `gorm:"column:ip_allowlist_json"`
+	MaxInputTokens      int64  `gorm:"column:max_input_tokens"`
+	MaxOutputTokens     int64  `gorm:"column:max_output_tokens"`
+	MaxRequestBodyBytes int64  `gorm:"column:max_request_body_bytes"`
+	CreatedAt           string `gorm:"column:created_at;not null"`
+	UpdatedAt           string `gorm:"column:updated_at;not null"`
 }
 
 func (Consumer) TableName() string { return "consumers" }
@@ -91,6 +97,7 @@ type ConsumerQuota struct {
 	QuotaType  string `gorm:"column:quota_type;not null"`
 	QuotaLimit int64  `gorm:"column:quota_limit;not null"`
 	Window     string `gorm:"column:window"`
+	Currency   string `gorm:"column:currency"`
 	CreatedAt  string `gorm:"column:created_at;not null"`
 	UpdatedAt  string `gorm:"column:updated_at;not null"`
 }

--- a/go/internal/storage/model/models.go
+++ b/go/internal/storage/model/models.go
@@ -71,7 +71,7 @@ type ConsumerKey struct {
 	ID         string `gorm:"column:id;primaryKey"`
 	ConsumerID string `gorm:"column:consumer_id;not null;uniqueIndex:idx_consumer_key_name"`
 	Name       string `gorm:"column:name;not null;uniqueIndex:idx_consumer_key_name"`
-	KeyPrefix  string `gorm:"column:key_prefix;not null;index"`
+	KeyPreview string `gorm:"column:key_preview;not null;index"`
 	KeyHash    string `gorm:"column:key_hash;not null"`
 	Enabled    bool   `gorm:"column:enabled;not null;default:true"`
 	ExpiresAt  string `gorm:"column:expires_at"`

--- a/go/internal/storage/model/schema_test.go
+++ b/go/internal/storage/model/schema_test.go
@@ -35,7 +35,7 @@ func TestAutoMigrateCreatesConfigSchemaTables(t *testing.T) {
 		"upstreams":       {"provider", "credentials_json", "models_json", "models_url", "proxy_url"},
 		"routes":          {"model", "balance", "enable_auth", "enable_payload"},
 		"route_upstreams": {"route_id", "upstream_id", "model", "weight", "priority"},
-		"consumer_keys":   {"consumer_id", "key_prefix", "key_hash", "last_used_at"},
+		"consumer_keys":   {"consumer_id", "key_preview", "key_hash", "last_used_at"},
 		"consumer_quotas": {"consumer_id", "quota_type", "quota_limit", "window"},
 		"settings":        {"key", "value", "updated_at"},
 	} {

--- a/go/internal/storage/query/consumer_keys.gen.go
+++ b/go/internal/storage/query/consumer_keys.gen.go
@@ -30,7 +30,7 @@ func newConsumerKey(db *gorm.DB, opts ...gen.DOOption) consumerKey {
 	_consumerKey.ID = field.NewString(tableName, "id")
 	_consumerKey.ConsumerID = field.NewString(tableName, "consumer_id")
 	_consumerKey.Name = field.NewString(tableName, "name")
-	_consumerKey.KeyPrefix = field.NewString(tableName, "key_prefix")
+	_consumerKey.KeyPreview = field.NewString(tableName, "key_preview")
 	_consumerKey.KeyHash = field.NewString(tableName, "key_hash")
 	_consumerKey.Enabled = field.NewBool(tableName, "enabled")
 	_consumerKey.ExpiresAt = field.NewString(tableName, "expires_at")
@@ -50,7 +50,7 @@ type consumerKey struct {
 	ID         field.String
 	ConsumerID field.String
 	Name       field.String
-	KeyPrefix  field.String
+	KeyPreview field.String
 	KeyHash    field.String
 	Enabled    field.Bool
 	ExpiresAt  field.String
@@ -76,7 +76,7 @@ func (c *consumerKey) updateTableName(table string) *consumerKey {
 	c.ID = field.NewString(table, "id")
 	c.ConsumerID = field.NewString(table, "consumer_id")
 	c.Name = field.NewString(table, "name")
-	c.KeyPrefix = field.NewString(table, "key_prefix")
+	c.KeyPreview = field.NewString(table, "key_preview")
 	c.KeyHash = field.NewString(table, "key_hash")
 	c.Enabled = field.NewBool(table, "enabled")
 	c.ExpiresAt = field.NewString(table, "expires_at")
@@ -113,7 +113,7 @@ func (c *consumerKey) fillFieldMap() {
 	c.fieldMap["id"] = c.ID
 	c.fieldMap["consumer_id"] = c.ConsumerID
 	c.fieldMap["name"] = c.Name
-	c.fieldMap["key_prefix"] = c.KeyPrefix
+	c.fieldMap["key_preview"] = c.KeyPreview
 	c.fieldMap["key_hash"] = c.KeyHash
 	c.fieldMap["enabled"] = c.Enabled
 	c.fieldMap["expires_at"] = c.ExpiresAt

--- a/go/internal/storage/query/consumer_quotas.gen.go
+++ b/go/internal/storage/query/consumer_quotas.gen.go
@@ -32,6 +32,7 @@ func newConsumerQuota(db *gorm.DB, opts ...gen.DOOption) consumerQuota {
 	_consumerQuota.QuotaType = field.NewString(tableName, "quota_type")
 	_consumerQuota.QuotaLimit = field.NewInt64(tableName, "quota_limit")
 	_consumerQuota.Window = field.NewString(tableName, "window")
+	_consumerQuota.Currency = field.NewString(tableName, "currency")
 	_consumerQuota.CreatedAt = field.NewString(tableName, "created_at")
 	_consumerQuota.UpdatedAt = field.NewString(tableName, "updated_at")
 
@@ -49,6 +50,7 @@ type consumerQuota struct {
 	QuotaType  field.String
 	QuotaLimit field.Int64
 	Window     field.String
+	Currency   field.String
 	CreatedAt  field.String
 	UpdatedAt  field.String
 
@@ -72,6 +74,7 @@ func (c *consumerQuota) updateTableName(table string) *consumerQuota {
 	c.QuotaType = field.NewString(table, "quota_type")
 	c.QuotaLimit = field.NewInt64(table, "quota_limit")
 	c.Window = field.NewString(table, "window")
+	c.Currency = field.NewString(table, "currency")
 	c.CreatedAt = field.NewString(table, "created_at")
 	c.UpdatedAt = field.NewString(table, "updated_at")
 
@@ -102,12 +105,13 @@ func (c *consumerQuota) GetFieldByName(fieldName string) (field.OrderExpr, bool)
 }
 
 func (c *consumerQuota) fillFieldMap() {
-	c.fieldMap = make(map[string]field.Expr, 7)
+	c.fieldMap = make(map[string]field.Expr, 8)
 	c.fieldMap["id"] = c.ID
 	c.fieldMap["consumer_id"] = c.ConsumerID
 	c.fieldMap["quota_type"] = c.QuotaType
 	c.fieldMap["quota_limit"] = c.QuotaLimit
 	c.fieldMap["window"] = c.Window
+	c.fieldMap["currency"] = c.Currency
 	c.fieldMap["created_at"] = c.CreatedAt
 	c.fieldMap["updated_at"] = c.UpdatedAt
 }

--- a/go/internal/storage/query/consumers.gen.go
+++ b/go/internal/storage/query/consumers.gen.go
@@ -30,6 +30,12 @@ func newConsumer(db *gorm.DB, opts ...gen.DOOption) consumer {
 	_consumer.ID = field.NewString(tableName, "id")
 	_consumer.Name = field.NewString(tableName, "name")
 	_consumer.Enabled = field.NewBool(tableName, "enabled")
+	_consumer.MetadataJSON = field.NewString(tableName, "metadata_json")
+	_consumer.ProtocolsJSON = field.NewString(tableName, "protocols_json")
+	_consumer.IPAllowlistJSON = field.NewString(tableName, "ip_allowlist_json")
+	_consumer.MaxInputTokens = field.NewInt64(tableName, "max_input_tokens")
+	_consumer.MaxOutputTokens = field.NewInt64(tableName, "max_output_tokens")
+	_consumer.MaxRequestBodyBytes = field.NewInt64(tableName, "max_request_body_bytes")
 	_consumer.CreatedAt = field.NewString(tableName, "created_at")
 	_consumer.UpdatedAt = field.NewString(tableName, "updated_at")
 
@@ -41,12 +47,18 @@ func newConsumer(db *gorm.DB, opts ...gen.DOOption) consumer {
 type consumer struct {
 	consumerDo consumerDo
 
-	ALL       field.Asterisk
-	ID        field.String
-	Name      field.String
-	Enabled   field.Bool
-	CreatedAt field.String
-	UpdatedAt field.String
+	ALL                 field.Asterisk
+	ID                  field.String
+	Name                field.String
+	Enabled             field.Bool
+	MetadataJSON        field.String
+	ProtocolsJSON       field.String
+	IPAllowlistJSON     field.String
+	MaxInputTokens      field.Int64
+	MaxOutputTokens     field.Int64
+	MaxRequestBodyBytes field.Int64
+	CreatedAt           field.String
+	UpdatedAt           field.String
 
 	fieldMap map[string]field.Expr
 }
@@ -66,6 +78,12 @@ func (c *consumer) updateTableName(table string) *consumer {
 	c.ID = field.NewString(table, "id")
 	c.Name = field.NewString(table, "name")
 	c.Enabled = field.NewBool(table, "enabled")
+	c.MetadataJSON = field.NewString(table, "metadata_json")
+	c.ProtocolsJSON = field.NewString(table, "protocols_json")
+	c.IPAllowlistJSON = field.NewString(table, "ip_allowlist_json")
+	c.MaxInputTokens = field.NewInt64(table, "max_input_tokens")
+	c.MaxOutputTokens = field.NewInt64(table, "max_output_tokens")
+	c.MaxRequestBodyBytes = field.NewInt64(table, "max_request_body_bytes")
 	c.CreatedAt = field.NewString(table, "created_at")
 	c.UpdatedAt = field.NewString(table, "updated_at")
 
@@ -92,10 +110,16 @@ func (c *consumer) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (c *consumer) fillFieldMap() {
-	c.fieldMap = make(map[string]field.Expr, 5)
+	c.fieldMap = make(map[string]field.Expr, 11)
 	c.fieldMap["id"] = c.ID
 	c.fieldMap["name"] = c.Name
 	c.fieldMap["enabled"] = c.Enabled
+	c.fieldMap["metadata_json"] = c.MetadataJSON
+	c.fieldMap["protocols_json"] = c.ProtocolsJSON
+	c.fieldMap["ip_allowlist_json"] = c.IPAllowlistJSON
+	c.fieldMap["max_input_tokens"] = c.MaxInputTokens
+	c.fieldMap["max_output_tokens"] = c.MaxOutputTokens
+	c.fieldMap["max_request_body_bytes"] = c.MaxRequestBodyBytes
 	c.fieldMap["created_at"] = c.CreatedAt
 	c.fieldMap["updated_at"] = c.UpdatedAt
 }

--- a/go/internal/xds/configcache.go
+++ b/go/internal/xds/configcache.go
@@ -54,7 +54,7 @@ func LoadFromStorage(s storage.Storage) (*ConfigSnapshot, error) {
 		for _, k := range c.Keys {
 			// A key is only usable when both it and its owning consumer are
 			// enabled — disabling a consumer must revoke every key it owns.
-			b.AddConsumerKey(k.ID, c.ID, k.KeyPrefix, k.KeyHash, k.Enabled && c.Enabled, k.ExpiresAt, c.Routes, c.Quotas)
+			b.AddConsumerKey(k.ID, c.ID, k.KeyPreview, k.KeyHash, k.Enabled && c.Enabled, k.ExpiresAt, c.Routes, c.Quotas)
 		}
 	}
 

--- a/go/internal/xds/convert.go
+++ b/go/internal/xds/convert.go
@@ -75,10 +75,10 @@ func SnapshotFromProto(in *pb.ConfigSnapshot) *ConfigSnapshot {
 		}
 		routes := append([]string(nil), c.GetRoutes()...)
 		for _, k := range c.GetKeys() {
-			if k == nil || k.GetKeyPrefix() == "" {
+			if k == nil || k.GetKeyPreview() == "" {
 				continue
 			}
-			b.AddConsumerKey(k.GetId(), k.GetConsumerId(), k.GetKeyPrefix(), k.GetKeyHash(), k.GetEnabled(), k.GetExpiresAt(), routes, quotas)
+			b.AddConsumerKey(k.GetId(), k.GetConsumerId(), k.GetKeyPreview(), k.GetKeyHash(), k.GetEnabled(), k.GetExpiresAt(), routes, quotas)
 		}
 	}
 
@@ -138,7 +138,7 @@ func SnapshotFromStorage(s storage.Storage, version int64) (*pb.ConfigSnapshot, 
 			// A key is only usable when both it and its owning consumer are
 			// enabled — disabling a consumer must revoke every key it owns.
 			pc.Keys = append(pc.Keys, &pb.ConsumerKeyRef{
-				Id: k.ID, ConsumerId: k.ConsumerID, KeyPrefix: k.KeyPrefix, KeyHash: k.KeyHash,
+				Id: k.ID, ConsumerId: k.ConsumerID, KeyPreview: k.KeyPreview, KeyHash: k.KeyHash,
 				Enabled: k.Enabled && c.Enabled, ExpiresAt: k.ExpiresAt,
 			})
 		}

--- a/go/internal/xds/convert_test.go
+++ b/go/internal/xds/convert_test.go
@@ -67,9 +67,9 @@ func TestSnapshotFromProto_ConsumerKeysAndGrants(t *testing.T) {
 		Consumers: []*pb.Consumer{{
 			Id: "c-1", Name: "alice", Enabled: true,
 			Keys: []*pb.ConsumerKeyRef{{
-				Id: "k-1", ConsumerId: "c-1", KeyPrefix: "nyro_abcd", KeyHash: "deadbeef", Enabled: true,
+				Id: "k-1", ConsumerId: "c-1", KeyPreview: "sk-abcd", KeyHash: "deadbeef", Enabled: true,
 			}, {
-				Id: "k-2", ConsumerId: "c-1", KeyPrefix: "", KeyHash: "x", // empty prefix dropped
+				Id: "k-2", ConsumerId: "c-1", KeyPreview: "", KeyHash: "x", // empty preview dropped
 			}},
 			Routes: []string{"m-1", "m-2"},
 			Quotas: []*pb.ConsumerQuota{{
@@ -79,7 +79,7 @@ func TestSnapshotFromProto_ConsumerKeysAndGrants(t *testing.T) {
 	}
 	snap := protoRoundtrip(t, in)
 
-	entries := snap.keysByPrefix["nyro_abcd"]
+	entries := snap.keysByPreview["sk-abcd"]
 	if len(entries) != 1 || entries[0].ConsumerID != "c-1" || entries[0].KeyHash != "deadbeef" {
 		t.Errorf("consumer key not carried: %+v", entries)
 	}
@@ -89,8 +89,8 @@ func TestSnapshotFromProto_ConsumerKeysAndGrants(t *testing.T) {
 	if len(entries[0].Quotas) != 1 || entries[0].Quotas[0].QuotaLimit != 60 {
 		t.Errorf("quotas not carried: %+v", entries[0].Quotas)
 	}
-	if _, ok := snap.keysByPrefix[""]; ok {
-		t.Error("empty key_prefix should not be stored")
+	if _, ok := snap.keysByPreview[""]; ok {
+		t.Error("empty key_preview should not be stored")
 	}
 }
 

--- a/go/internal/xds/pb/xds/v1/xds.pb.go
+++ b/go/internal/xds/pb/xds/v1/xds.pb.go
@@ -431,13 +431,13 @@ func (x *Route) GetTargets() []*RouteUpstream {
 }
 
 // ConsumerKeyRef is the gateway-facing view of a consumer key: enough to
-// authenticate a raw token locally (prefix filter + hash compare) without ever
+// authenticate a raw token locally (preview filter + hash compare) without ever
 // carrying the plaintext token or DB-only bookkeeping fields (name, last_used_at).
 type ConsumerKeyRef struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	ConsumerId    string                 `protobuf:"bytes,2,opt,name=consumer_id,json=consumerId,proto3" json:"consumer_id,omitempty"`
-	KeyPrefix     string                 `protobuf:"bytes,3,opt,name=key_prefix,json=keyPrefix,proto3" json:"key_prefix,omitempty"`
+	KeyPreview    string                 `protobuf:"bytes,3,opt,name=key_preview,json=keyPreview,proto3" json:"key_preview,omitempty"`
 	KeyHash       string                 `protobuf:"bytes,4,opt,name=key_hash,json=keyHash,proto3" json:"key_hash,omitempty"`
 	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	ExpiresAt     string                 `protobuf:"bytes,6,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
@@ -489,9 +489,9 @@ func (x *ConsumerKeyRef) GetConsumerId() string {
 	return ""
 }
 
-func (x *ConsumerKeyRef) GetKeyPrefix() string {
+func (x *ConsumerKeyRef) GetKeyPreview() string {
 	if x != nil {
-		return x.KeyPrefix
+		return x.KeyPreview
 	}
 	return ""
 }
@@ -720,13 +720,13 @@ const file_xds_v1_xds_proto_rawDesc = "" +
 	"enableAuth\x12%\n" +
 	"\x0eenable_payload\x18\x05 \x01(\bR\renablePayload\x12\x18\n" +
 	"\aenabled\x18\x06 \x01(\bR\aenabled\x124\n" +
-	"\atargets\x18\a \x03(\v2\x1a.nyro.xds.v1.RouteUpstreamR\atargets\"\xb4\x01\n" +
+	"\atargets\x18\a \x03(\v2\x1a.nyro.xds.v1.RouteUpstreamR\atargets\"\xb6\x01\n" +
 	"\x0eConsumerKeyRef\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vconsumer_id\x18\x02 \x01(\tR\n" +
-	"consumerId\x12\x1d\n" +
-	"\n" +
-	"key_prefix\x18\x03 \x01(\tR\tkeyPrefix\x12\x19\n" +
+	"consumerId\x12\x1f\n" +
+	"\vkey_preview\x18\x03 \x01(\tR\n" +
+	"keyPreview\x12\x19\n" +
 	"\bkey_hash\x18\x04 \x01(\tR\akeyHash\x12\x18\n" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x1d\n" +
 	"\n" +

--- a/go/internal/xds/snapshot.go
+++ b/go/internal/xds/snapshot.go
@@ -3,13 +3,13 @@ package xds
 import "github.com/nyroway/nyro/go/internal/storage"
 
 // consumerKeyEntry is the gateway-facing view of a consumer key: enough to
-// authenticate a raw token locally (prefix filter + hash compare) plus the
+// authenticate a raw token locally (preview filter + hash compare) plus the
 // grants needed to answer FindKey in one shot. It never carries the plaintext
 // token.
 type consumerKeyEntry struct {
 	KeyID      string
 	ConsumerID string
-	KeyPrefix  string
+	KeyPreview string
 	KeyHash    string
 	Enabled    bool
 	ExpiresAt  string
@@ -25,10 +25,10 @@ type ConfigSnapshot struct {
 	upstreams map[string]storage.Upstream
 	// routes maps client-facing Route.Model → Route (Upstreams targets attached).
 	routes map[string]storage.Route
-	// keysByPrefix indexes consumer keys by KeyPrefix for FindKey's candidate
+	// keysByPreview indexes consumer keys by KeyPreview for FindKey's candidate
 	// narrowing (raw tokens are never persisted, so this is the closest to an
 	// O(1) lookup available without a per-request DB round trip).
-	keysByPrefix map[string][]consumerKeyEntry
+	keysByPreview map[string][]consumerKeyEntry
 	// settings holds the gateway-relevant key/value settings (proxy_*).
 	settings map[string]string
 }
@@ -70,19 +70,19 @@ func (s *ConfigSnapshot) RoutesList() []storage.Route {
 }
 
 // FindKey resolves a raw consumer-key token to its access record: filter
-// candidates by prefix, then compare hashes (raw tokens are never persisted,
+// candidates by preview, then compare hashes (raw tokens are never persisted,
 // so an exact-match map lookup like the legacy FindAPIKey isn't possible).
 func (s *ConfigSnapshot) FindKey(rawKey string) *storage.ConsumerKeyAccessRecord {
-	prefix := storage.PrefixOf(rawKey)
+	preview := storage.PreviewOf(rawKey)
 	hash := storage.HashKey(rawKey)
-	for _, entry := range s.keysByPrefix[prefix] {
+	for _, entry := range s.keysByPreview[preview] {
 		if entry.KeyHash != hash {
 			continue
 		}
 		return &storage.ConsumerKeyAccessRecord{
 			KeyID:      entry.KeyID,
 			ConsumerID: entry.ConsumerID,
-			KeyPrefix:  entry.KeyPrefix,
+			KeyPreview: entry.KeyPreview,
 			Enabled:    entry.Enabled,
 			ExpiresAt:  entry.ExpiresAt,
 			Routes:     entry.Routes,
@@ -124,11 +124,11 @@ func (b *Snapshot) SetRoute(r storage.Route) {
 	b.routes[r.Model] = r
 }
 
-// AddConsumerKey registers one consumer key's gateway-facing view (prefix,
+// AddConsumerKey registers one consumer key's gateway-facing view (preview,
 // hash, grants). Called once per key across all consumers.
-func (b *Snapshot) AddConsumerKey(keyID, consumerID, keyPrefix, keyHash string, enabled bool, expiresAt string, routes []string, quotas []storage.ConsumerQuota) {
+func (b *Snapshot) AddConsumerKey(keyID, consumerID, keyPreview, keyHash string, enabled bool, expiresAt string, routes []string, quotas []storage.ConsumerQuota) {
 	b.keys = append(b.keys, consumerKeyEntry{
-		KeyID: keyID, ConsumerID: consumerID, KeyPrefix: keyPrefix, KeyHash: keyHash,
+		KeyID: keyID, ConsumerID: consumerID, KeyPreview: keyPreview, KeyHash: keyHash,
 		Enabled: enabled, ExpiresAt: expiresAt, Routes: routes, Quotas: quotas,
 	})
 }
@@ -152,14 +152,14 @@ func (b *Snapshot) Done() *ConfigSnapshot {
 	if b.settings == nil {
 		b.settings = map[string]string{}
 	}
-	byPrefix := make(map[string][]consumerKeyEntry, len(b.keys))
+	byPreview := make(map[string][]consumerKeyEntry, len(b.keys))
 	for _, k := range b.keys {
-		byPrefix[k.KeyPrefix] = append(byPrefix[k.KeyPrefix], k)
+		byPreview[k.KeyPreview] = append(byPreview[k.KeyPreview], k)
 	}
 	return &ConfigSnapshot{
-		upstreams:    b.upstreams,
-		routes:       b.routes,
-		keysByPrefix: byPrefix,
-		settings:     b.settings,
+		upstreams:     b.upstreams,
+		routes:        b.routes,
+		keysByPreview: byPreview,
+		settings:      b.settings,
 	}
 }

--- a/go/proto/xds/v1/xds.proto
+++ b/go/proto/xds/v1/xds.proto
@@ -63,12 +63,12 @@ message Route {
 }
 
 // ConsumerKeyRef is the gateway-facing view of a consumer key: enough to
-// authenticate a raw token locally (prefix filter + hash compare) without ever
+// authenticate a raw token locally (preview filter + hash compare) without ever
 // carrying the plaintext token or DB-only bookkeeping fields (name, last_used_at).
 message ConsumerKeyRef {
   string id = 1;
   string consumer_id = 2;
-  string key_prefix = 3;
+  string key_preview = 3;
   string key_hash = 4;
   bool enabled = 5;
   string expires_at = 6;

--- a/go/webui/src/lib/types.ts
+++ b/go/webui/src/lib/types.ts
@@ -91,7 +91,7 @@ export interface ConsumerKey {
   id: string;
   consumer_id: string;
   name: string;
-  key_prefix: string;
+  key_preview: string;
   token?: string;
   enabled: boolean;
   expires_at?: string;
@@ -103,9 +103,18 @@ export interface ConsumerKey {
 export interface ConsumerQuota {
   id?: string;
   consumer_id?: string;
-  quota_type: "requests" | "tokens" | "concurrency" | string;
+  quota_type: "requests" | "tokens" | "concurrency" | "budget" | string;
   quota_limit: number;
   window?: string;
+  /** Set only for "budget" quotas (ISO 4217 code, e.g. "USD"). */
+  currency?: string;
+}
+
+/** Per-request resource caps; omitted/zero means no limit for that dimension. */
+export interface ConsumerLimits {
+  max_input_tokens?: number;
+  max_output_tokens?: number;
+  max_request_body_bytes?: number;
 }
 
 export interface Consumer {
@@ -115,6 +124,10 @@ export interface Consumer {
   keys?: ConsumerKey[];
   routes?: string[];
   quotas?: ConsumerQuota[];
+  metadata?: Record<string, string>;
+  protocols?: string[];
+  ip_allowlist?: string[];
+  limits?: ConsumerLimits;
   created_at?: string;
   updated_at?: string;
 }
@@ -134,9 +147,10 @@ export interface UpdateConsumerKey {
 }
 
 export interface CreateConsumerQuota {
-  quota_type: "requests" | "tokens" | "concurrency" | string;
+  quota_type: "requests" | "tokens" | "concurrency" | "budget" | string;
   quota_limit: number;
   window?: string;
+  currency?: string;
 }
 
 export interface CreateConsumer {
@@ -145,6 +159,10 @@ export interface CreateConsumer {
   keys?: CreateConsumerKey[];
   routes?: string[];
   quotas?: CreateConsumerQuota[];
+  metadata?: Record<string, string>;
+  protocols?: string[];
+  ip_allowlist?: string[];
+  limits?: ConsumerLimits;
 }
 
 export interface UpdateConsumer {
@@ -152,6 +170,10 @@ export interface UpdateConsumer {
   enabled?: boolean;
   quotas?: CreateConsumerQuota[];
   routes?: string[];
+  metadata?: Record<string, string>;
+  protocols?: string[];
+  ip_allowlist?: string[];
+  limits?: ConsumerLimits;
 }
 
 /** Raw Go backend response shape for a provider preset (`GET /api/v1/provider-presets`), snake_case fields. */

--- a/go/webui/src/pages/api-keys.test.ts
+++ b/go/webui/src/pages/api-keys.test.ts
@@ -49,32 +49,32 @@ describe("dynamic quota editor", () => {
   });
 });
 
-describe("multi-key management", () => {
-  it("adds a key via add_consumer_key and reveals the one-time token", () => {
-    const start = source.indexOf("const addKeyMut = useMutation({");
+describe("single-key management", () => {
+  it("generates a key for a keyless consumer via add_consumer_key with a fixed default name", () => {
+    const start = source.indexOf("const generateKeyMut = useMutation({");
     const end = source.indexOf("\n\n  const updateKeyMut", start);
     if (start < 0 || end < 0) {
-      throw new Error("Could not locate addKeyMut");
+      throw new Error("Could not locate generateKeyMut");
     }
     const body = source.slice(start, end);
 
-    expect(body).toContain('backend<ConsumerKey>("add_consumer_key", { id: consumerId, input })');
+    expect(body).toContain('backend<ConsumerKey>("add_consumer_key", { id: consumerId, input: { name: "default" }');
     expect(body).toContain("openRevealDialog({ name: created.name, token: created.token })");
   });
 
-  it("updates a key via update_consumer_key with the {id, keyId, input} shape", () => {
+  it("updates the primary key via update_consumer_key with the {id, keyId, input} shape", () => {
     expect(source).toContain('backend<ConsumerKey>("update_consumer_key", { id: consumerId, keyId, input })');
   });
 
-  it("deletes a key via delete_consumer_key with the {id, keyId} shape", () => {
-    expect(source).toContain('backend("delete_consumer_key", { id: consumerId, keyId })');
+  it("has no standalone per-key deletion mutation (delete_consumer_key is only used internally by regenerate)", () => {
+    expect(source).not.toContain("deleteKeyMut");
   });
 
-  it("rotates a key by adding a new one and deleting the old one, then reveals the new token", () => {
-    const start = source.indexOf("const rotateKeyMut = useMutation({");
+  it("regenerates the primary key by adding a new one and deleting the old one, then reveals the new token", () => {
+    const start = source.indexOf("const regenerateKeyMut = useMutation({");
     const end = source.indexOf("\n\n  const totalPages", start);
     if (start < 0 || end < 0) {
-      throw new Error("Could not locate rotateKeyMut");
+      throw new Error("Could not locate regenerateKeyMut");
     }
     const body = source.slice(start, end);
 
@@ -83,7 +83,7 @@ describe("multi-key management", () => {
     expect(body).toContain("openRevealDialog({ name: created.name, token: created.token })");
   });
 
-  it("only ever copies the key_prefix for existing keys, never a full plaintext key", () => {
+  it("only ever copies the key_prefix for the existing key, never a full plaintext key", () => {
     const start = source.indexOf("async function copyKeyPrefix");
     const end = source.indexOf("\n  function renderQuotaBadges", start);
     if (start < 0 || end < 0) {
@@ -92,5 +92,16 @@ describe("multi-key management", () => {
     const body = source.slice(start, end);
 
     expect(body).toContain("navigator.clipboard.writeText(key.key_prefix)");
+  });
+
+  it("operates on consumer.keys[0] as the primary key, with no per-key add/delete UI", () => {
+    expect(source).toContain("const key = consumer.keys?.[0];");
+    expect(source).not.toContain("addKeyOpenFor");
+    expect(source).not.toContain("addKeyForm");
+  });
+
+  it("creates a consumer with a single fixed-name key, no key-name field", () => {
+    expect(source).toContain('name: "default"');
+    expect(source).not.toContain("createForm.keyName");
   });
 });

--- a/go/webui/src/pages/api-keys.test.ts
+++ b/go/webui/src/pages/api-keys.test.ts
@@ -25,6 +25,51 @@ describe("consumer route binding (P0 regression)", () => {
   });
 });
 
+describe("access.protocols and access.ip_allowlist", () => {
+  it("submits protocols from a fixed protocol option set, both on create and edit", () => {
+    expect(source).toContain("import { PROTOCOL_TABLE } from \"@/lib/protocol\";");
+    expect(source).toContain("protocols: createForm.protocols");
+    expect(source).toContain("protocols: editForm.protocols");
+  });
+
+  it("edits ip_allowlist as one input row per entry, dropping blank rows on submit", () => {
+    expect(source).toContain("function IPAllowlistEditor({");
+    expect(source).toContain("ip_allowlist: buildAccessListPayload(createForm.ipAllowlist)");
+    expect(source).toContain("ip_allowlist: buildAccessListPayload(editForm.ipAllowlist)");
+
+    const start = source.indexOf("function buildAccessListPayload");
+    const end = source.indexOf("\n}", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate buildAccessListPayload");
+    }
+    expect(source.slice(start, end)).toContain(".filter(Boolean)");
+  });
+
+  it("validates each ip_allowlist row as a bare IP or a CIDR block, and blocks submit when invalid", () => {
+    expect(source).toContain("function isValidIPOrCIDR(value: string)");
+    expect(source).toContain("createForm.ipAllowlist.some((ip) => !isValidIPOrCIDR(ip))");
+    expect(source).toContain("editForm.ipAllowlist.some((ip) => !isValidIPOrCIDR(ip))");
+  });
+});
+
+describe("consumer limits", () => {
+  it("omits the limits payload entirely when every field is empty", () => {
+    const start = source.indexOf("function buildLimitsPayload");
+    const end = source.indexOf("\n}", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate buildLimitsPayload");
+    }
+    const body = source.slice(start, end);
+
+    expect(body).toContain("if (!form.maxInputTokens && !form.maxOutputTokens && !form.maxRequestBodyBytes) return undefined;");
+  });
+
+  it("submits limits built from the form, both on create and edit", () => {
+    expect(source).toContain("limits: buildLimitsPayload(createForm.limits)");
+    expect(source).toContain("limits: buildLimitsPayload(editForm.limits)");
+  });
+});
+
 describe("dynamic quota editor", () => {
   it("supports adding/removing arbitrary requests and tokens quota rows", () => {
     expect(source).toContain('function renderGroup(kind: "requests" | "tokens", title: string)');
@@ -32,9 +77,21 @@ describe("dynamic quota editor", () => {
     expect(source).toContain("updateRows(kind, rows.filter((_, i) => i !== idx))");
   });
 
+  it("only shows a delete button once there are 2+ rows; a lone row gets a clear button instead", () => {
+    const start = source.indexOf("function renderGroup(kind:");
+    const end = source.indexOf("\n  return (\n    <div className=\"grid grid-cols-2", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate renderGroup");
+    }
+    const body = source.slice(start, end);
+
+    expect(body).toContain("rows.length > 1 ? (");
+    expect(body).toContain('updateRows(kind, [{ limit: "", window: "" }])');
+  });
+
   it("treats concurrency as a single value with no window", () => {
     const start = source.indexOf("function buildQuotasPayload");
-    const end = source.indexOf("\nfunction quotaBadgeLabel", start);
+    const end = source.indexOf("\nconst quotaBadgeColors", start);
     if (start < 0 || end < 0) {
       throw new Error("Could not locate buildQuotasPayload");
     }
@@ -43,65 +100,117 @@ describe("dynamic quota editor", () => {
     expect(body).toContain('quotas.push({ quota_type: "concurrency", quota_limit: Number.parseInt(form.concurrency, 10) });');
   });
 
-  it("renders one quota badge per entry in consumer.quotas, not a fixed set", () => {
-    expect(source).toContain("function renderQuotaBadges(quotas: ConsumerQuota[] | undefined)");
-    expect(source).toContain("return (quotas ?? []).map((q, idx) => {");
-  });
-});
-
-describe("single-key management", () => {
-  it("generates a key for a keyless consumer via add_consumer_key with a fixed default name", () => {
-    const start = source.indexOf("const generateKeyMut = useMutation({");
-    const end = source.indexOf("\n\n  const updateKeyMut", start);
+  it("renders exactly one badge per quota type, folding extra rules into a +N suffix instead of adding badges", () => {
+    const start = source.indexOf("function renderQuotaBadges(quotas: ConsumerQuota[] | undefined)");
+    const end = source.indexOf("\n  }", start);
     if (start < 0 || end < 0) {
-      throw new Error("Could not locate generateKeyMut");
+      throw new Error("Could not locate renderQuotaBadges");
     }
     const body = source.slice(start, end);
 
-    expect(body).toContain('backend<ConsumerKey>("add_consumer_key", { id: consumerId, input: { name: "default" }');
+    expect(body).toContain("quotaSummaryOrder.flatMap(({ type, zh, en }, idx) => {");
+    expect(body).toContain('const suffix = rows.length > 1 ? ` +${rows.length - 1}` : "";');
+  });
+});
+
+describe("access permission summary badges", () => {
+  it("shows one count badge per access dimension instead of one badge per bound item", () => {
+    const start = source.indexOf("function renderAccessBadges(consumer: Consumer)");
+    const end = source.indexOf("\n  }", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate renderAccessBadges");
+    }
+    const body = source.slice(start, end);
+
+    expect(body).toContain("consumer.routes?.length ?? 0");
+    expect(body).toContain("consumer.protocols?.length ?? 0");
+    expect(body).toContain("consumer.ip_allowlist?.length ?? 0");
+    expect(body).toContain(".filter((d) => d.count > 0)");
+  });
+});
+
+describe("multi-key management", () => {
+  it("adds a key via a dialog carrying name + validity, reveals the one-time token", () => {
+    const start = source.indexOf("const addKeyMut = useMutation({");
+    const end = source.indexOf("\n\n  const updateKeyMut", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate addKeyMut");
+    }
+    const body = source.slice(start, end);
+
+    expect(body).toContain('backend<ConsumerKey>("add_consumer_key", { id: consumerId, input })');
     expect(body).toContain("openRevealDialog({ name: created.name, token: created.token })");
+    expect(source).toContain("function openAddKeyDialog(consumer: Consumer)");
   });
 
-  it("updates the primary key via update_consumer_key with the {id, keyId, input} shape", () => {
+  it("updates a key's name/expiry via update_consumer_key with the {id, keyId, input} shape", () => {
     expect(source).toContain('backend<ConsumerKey>("update_consumer_key", { id: consumerId, keyId, input })');
   });
 
-  it("has no standalone per-key deletion mutation (delete_consumer_key is only used internally by regenerate)", () => {
-    expect(source).not.toContain("deleteKeyMut");
+  it("only submits expires_at from the edit dialog when the user actually touched the validity preset", () => {
+    expect(source).toContain("expiresTouched: boolean");
+    expect(source).toContain("if (editKeyForm.expiresTouched) {");
+    expect(source).toContain("input.expires_at = resolveExpiresAtForUpdate(editKeyForm.expiresPreset);");
   });
 
-  it("regenerates the primary key by adding a new one and deleting the old one, then reveals the new token", () => {
+  it("deletes a key via delete_consumer_key with the {id, keyId} shape", () => {
+    expect(source).toContain('backend("delete_consumer_key", { id: consumerId, keyId })');
+  });
+
+  it("warns when deleting a consumer's only key", () => {
+    const start = source.indexOf("title={isZh ? \"确认删除 Key\"");
+    const end = source.indexOf("\n      />", start);
+    if (start < 0 || end < 0) {
+      throw new Error("Could not locate the delete-key ConfirmDialog");
+    }
+    expect(source.slice(start, end)).toContain("keyToDelete.consumer.keys?.length ?? 0) <= 1");
+  });
+
+  it("regenerates a key under a throwaway temp name, then renames it back after the old key is deleted (consumer_keys has a UNIQUE(consumer_id, name) constraint, so adding under the same name while the old row still exists would violate it)", () => {
     const start = source.indexOf("const regenerateKeyMut = useMutation({");
-    const end = source.indexOf("\n\n  const totalPages", start);
+    const end = source.indexOf("\n\n  const deleteKeyMut", start);
     if (start < 0 || end < 0) {
       throw new Error("Could not locate regenerateKeyMut");
     }
     const body = source.slice(start, end);
 
-    expect(body).toContain('backend<ConsumerKey>("add_consumer_key"');
+    expect(body).toContain("const tempName = `${key.name}~regen~${crypto.randomUUID()}`;");
+    expect(body).toContain('input: { name: tempName, expires_at: key.expires_at },');
     expect(body).toContain('await backend("delete_consumer_key", { id: consumerId, keyId: key.id });');
+    expect(body).toContain('backend<ConsumerKey>("update_consumer_key", {');
+    expect(body).toContain("input: { name: key.name },");
     expect(body).toContain("openRevealDialog({ name: created.name, token: created.token })");
   });
 
-  it("only ever copies the key_prefix for the existing key, never a full plaintext key", () => {
-    const start = source.indexOf("async function copyKeyPrefix");
-    const end = source.indexOf("\n  function renderQuotaBadges", start);
+  it("displays the key_preview as plain text with no copy affordance (copying a masked preview has no real use)", () => {
+    expect(source).not.toContain("copyKeyPreview");
+    expect(source).not.toContain("copiedKeyId");
+    expect(source).toContain("{formatKeyPreview(key.key_preview)}");
+  });
+
+  it("renders every key in consumer.keys, not just the first", () => {
+    expect(source).toContain("keys.map((key) => renderKeyRow(consumer, key))");
+  });
+
+  it("has a + button in the list row to add a key, before the edit button", () => {
+    const start = source.indexOf("onClick={() => toggleConsumerEnabledMut.mutate({ id: item.id");
+    const editIdx = source.indexOf("onClick={() => startEdit(item)}", start);
+    const addIdx = source.indexOf("onClick={() => openAddKeyDialog(item)}", start);
+    if (start < 0 || editIdx < 0 || addIdx < 0) {
+      throw new Error("Could not locate the list row action buttons");
+    }
+    expect(addIdx).toBeGreaterThan(start);
+    expect(addIdx).toBeLessThan(editIdx);
+  });
+
+  it("masks the key preview to a fixed length regardless of the real key's length", () => {
+    const start = source.indexOf("function formatKeyPreview(");
+    const end = source.indexOf("\nfunction formatExpiresText", start);
     if (start < 0 || end < 0) {
-      throw new Error("Could not locate copyKeyPrefix");
+      throw new Error("Could not locate formatKeyPreview");
     }
     const body = source.slice(start, end);
 
-    expect(body).toContain("navigator.clipboard.writeText(key.key_prefix)");
-  });
-
-  it("operates on consumer.keys[0] as the primary key, with no per-key add/delete UI", () => {
-    expect(source).toContain("const key = consumer.keys?.[0];");
-    expect(source).not.toContain("addKeyOpenFor");
-    expect(source).not.toContain("addKeyForm");
-  });
-
-  it("creates a consumer with a single fixed-name key, no key-name field", () => {
-    expect(source).toContain('name: "default"');
-    expect(source).not.toContain("createForm.keyName");
+    expect(body).toContain('"*".repeat(KEY_PREVIEW_MASK_LEN)');
   });
 });

--- a/go/webui/src/pages/api-keys.tsx
+++ b/go/webui/src/pages/api-keys.tsx
@@ -290,7 +290,6 @@ type CreateForm = {
   name: string;
   routes: string[];
   quotas: QuotaFormState;
-  keyName: string;
   keyExpiresPreset: ExpirePreset;
 };
 
@@ -298,7 +297,6 @@ const emptyCreate: CreateForm = {
   name: "",
   routes: [],
   quotas: emptyQuotaForm,
-  keyName: "",
   keyExpiresPreset: "never",
 };
 
@@ -343,12 +341,6 @@ export default function ApiKeysPage() {
 
   const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null);
 
-  const [addKeyOpenFor, setAddKeyOpenFor] = useState<string | null>(null);
-  const [addKeyForm, setAddKeyForm] = useState<{ name: string; expiresPreset: ExpirePreset }>({
-    name: "",
-    expiresPreset: "never",
-  });
-
   const [keyExpiryEdit, setKeyExpiryEdit] = useState<{
     consumerId: string;
     keyId: string;
@@ -356,8 +348,7 @@ export default function ApiKeysPage() {
   } | null>(null);
 
   const [consumerToDelete, setConsumerToDelete] = useState<Consumer | null>(null);
-  const [keyToDelete, setKeyToDelete] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
-  const [keyToRotate, setKeyToRotate] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
+  const [keyToRegenerate, setKeyToRegenerate] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
   const [errorDialog, setErrorDialog] = useState<{ title: string; description?: string } | null>(null);
 
   function formatErrorMessage(error: unknown) {
@@ -436,19 +427,17 @@ export default function ApiKeysPage() {
     },
   });
 
-  const addKeyMut = useMutation({
-    mutationFn: ({ consumerId, input }: { consumerId: string; input: CreateConsumerKey }) =>
-      backend<ConsumerKey>("add_consumer_key", { id: consumerId, input }),
+  const generateKeyMut = useMutation({
+    mutationFn: ({ consumerId }: { consumerId: string }) =>
+      backend<ConsumerKey>("add_consumer_key", { id: consumerId, input: { name: "default" } as CreateConsumerKey }),
     onSuccess: (created) => {
       invalidateConsumers();
-      setAddKeyOpenFor(null);
-      setAddKeyForm({ name: "", expiresPreset: "never" });
       if (created.token) {
         openRevealDialog({ name: created.name, token: created.token });
       }
     },
     onError: (error: unknown) => {
-      showErrorDialog("新增 Key 失败", "Failed to add key", error);
+      showErrorDialog("生成 Key 失败", "Failed to generate key", error);
     },
   });
 
@@ -468,16 +457,7 @@ export default function ApiKeysPage() {
     },
   });
 
-  const deleteKeyMut = useMutation({
-    mutationFn: ({ consumerId, keyId }: { consumerId: string; keyId: string }) =>
-      backend("delete_consumer_key", { id: consumerId, keyId }),
-    onSuccess: () => invalidateConsumers(),
-    onError: (error: unknown) => {
-      showErrorDialog("删除 Key 失败", "Failed to delete key", error);
-    },
-  });
-
-  const rotateKeyMut = useMutation({
+  const regenerateKeyMut = useMutation({
     mutationFn: async ({ consumerId, key }: { consumerId: string; key: ConsumerKey }) => {
       const created = await backend<ConsumerKey>("add_consumer_key", {
         id: consumerId,
@@ -493,7 +473,7 @@ export default function ApiKeysPage() {
       }
     },
     onError: (error: unknown) => {
-      showErrorDialog("轮换 Key 失败", "Failed to rotate key", error);
+      showErrorDialog("重新生成 Key 失败", "Failed to regenerate key", error);
     },
   });
 
@@ -550,21 +530,40 @@ export default function ApiKeysPage() {
     });
   }
 
-  function renderKeyRow(consumer: Consumer, key: ConsumerKey) {
+  // Single-key simplification: the backend keeps keys[] as 1:N, but the UI
+  // always operates on the consumer's primary key (keys[0]) and never exposes
+  // per-key add/delete.
+  function renderPrimaryKeySection(consumer: Consumer) {
+    const key = consumer.keys?.[0];
+    if (!key) {
+      return (
+        <div className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
+          <p className="text-xs text-slate-400">
+            {isZh ? "该 consumer 暂无可用密钥，无法鉴权。" : "No key yet — this consumer cannot authenticate."}
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={generateKeyMut.isPending}
+            onClick={() => generateKeyMut.mutate({ consumerId: consumer.id })}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {generateKeyMut.isPending ? (isZh ? "生成中..." : "Generating...") : (isZh ? "生成 Key" : "Generate key")}
+          </Button>
+        </div>
+      );
+    }
+
     const keyExpired = isApiKeyExpired(key.expires_at);
     const isEditingExpiry = keyExpiryEdit?.consumerId === consumer.id && keyExpiryEdit.keyId === key.id;
     return (
-      <div key={key.id} className="flex items-center justify-between rounded-xl border border-slate-200/70 bg-white/60 px-3 py-2">
+      <div className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="inline-flex h-5 items-center font-medium text-slate-800">{key.name}</span>
+          <span className="text-xs font-semibold text-slate-600">{isZh ? "API Key" : "API Key"}</span>
           <code className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600">
             {formatKeyPrefix(key.key_prefix)}
           </code>
-          {!key.enabled && (
-            <Badge variant="danger" className="connect-label-badge">
-              {isZh ? "已禁用" : "Disabled"}
-            </Badge>
-          )}
           <Badge variant={keyExpired ? "danger" : "success"} className="connect-label-badge">
             {formatValidityLabel(keyExpired, isZh)}
           </Badge>
@@ -619,24 +618,13 @@ export default function ApiKeysPage() {
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
           <button
-            onClick={() => updateKeyMut.mutate({ consumerId: consumer.id, keyId: key.id, input: { enabled: !key.enabled } })}
-            title={key.enabled ? (isZh ? "禁用" : "Disable") : (isZh ? "启用" : "Enable")}
-            className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
-          >
-            {key.enabled ? (
-              <ToggleRight className="h-4 w-4 text-green-500" />
-            ) : (
-              <ToggleLeft className="h-4 w-4 text-slate-400" />
-            )}
-          </button>
-          <button
             onClick={() => copyKeyPrefix(key)}
             title={
               copiedKeyId === key.id
                 ? (isZh ? "已复制前缀" : "Prefix copied")
                 : (isZh
-                  ? "复制前缀（完整 Key 仅在创建/轮换时展示一次，此处无法复制完整 Key）"
-                  : "Copy prefix only (full key is shown once on create/rotate, not copyable here)")
+                  ? "复制前缀（完整 Key 仅在创建/重新生成时展示一次，此处无法复制完整 Key）"
+                  : "Copy prefix only (full key is shown once on create/regenerate, not copyable here)")
             }
             className={`cursor-pointer rounded-lg p-1.5 transition-colors ${
               copiedKeyId === key.id
@@ -647,97 +635,13 @@ export default function ApiKeysPage() {
             {copiedKeyId === key.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
           </button>
           <button
-            onClick={() => setKeyToRotate({ consumer, key })}
-            title={isZh ? "轮换 Key（旧 Key 将立即失效）" : "Rotate key (old key is invalidated immediately)"}
+            onClick={() => setKeyToRegenerate({ consumer, key })}
+            title={isZh ? "重新生成 Key（旧 Key 将立即失效）" : "Regenerate key (old key is invalidated immediately)"}
             className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-500"
           >
             <RotateCw className="h-4 w-4" />
           </button>
-          <button
-            onClick={() => setKeyToDelete({ consumer, key })}
-            className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
         </div>
-      </div>
-    );
-  }
-
-  function renderKeysSection(consumer: Consumer) {
-    const keys = consumer.keys ?? [];
-    const isAddingKey = addKeyOpenFor === consumer.id;
-    return (
-      <div className="space-y-2 rounded-xl bg-slate-50/60 p-3">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-semibold text-slate-600">
-            {isZh ? `密钥（共 ${keys.length} 把）` : `Keys (${keys.length})`}
-          </span>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            onClick={() => {
-              setAddKeyOpenFor(isAddingKey ? null : consumer.id);
-              setAddKeyForm({ name: "", expiresPreset: "never" });
-            }}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {isZh ? "新增 Key" : "Add key"}
-          </Button>
-        </div>
-
-        {keys.length === 0 && !isAddingKey && (
-          <p className="text-xs text-slate-400">
-            {isZh ? "该 consumer 暂无可用密钥，无法鉴权。" : "No keys yet — this consumer cannot authenticate."}
-          </p>
-        )}
-
-        <div className="space-y-1.5">{keys.map((key) => renderKeyRow(consumer, key))}</div>
-
-        {isAddingKey && (
-          <div className="flex flex-wrap items-center gap-2 rounded-xl border border-dashed border-slate-300 p-2">
-            <Input
-              value={addKeyForm.name}
-              onChange={(e) => setAddKeyForm((prev) => ({ ...prev, name: e.target.value }))}
-              placeholder={isZh ? "Key 名称" : "Key name"}
-              className="h-8 w-40 text-xs"
-            />
-            <Select
-              value={addKeyForm.expiresPreset}
-              onValueChange={(value: ExpirePreset) => setAddKeyForm((prev) => ({ ...prev, expiresPreset: value }))}
-            >
-              <SelectTrigger className="h-8 w-28 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {expirePresetOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {isZh ? option.zh : option.en}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              size="sm"
-              disabled={addKeyMut.isPending || !addKeyForm.name.trim()}
-              onClick={() =>
-                addKeyMut.mutate({
-                  consumerId: consumer.id,
-                  input: {
-                    name: addKeyForm.name.trim(),
-                    expires_at: resolveExpiresAt(addKeyForm.expiresPreset),
-                  },
-                })
-              }
-            >
-              {addKeyMut.isPending ? (isZh ? "添加中..." : "Adding...") : (isZh ? "添加" : "Add")}
-            </Button>
-            <Button size="sm" variant="secondary" onClick={() => setAddKeyOpenFor(null)}>
-              {isZh ? "取消" : "Cancel"}
-            </Button>
-          </div>
-        )}
       </div>
     );
   }
@@ -780,15 +684,7 @@ export default function ApiKeysPage() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <FieldLabel>{isZh ? "首个 Key 名称" : "First key name"}</FieldLabel>
-                  <Input
-                    value={createForm.keyName}
-                    onChange={(e) => setCreateForm((prev) => ({ ...prev, keyName: e.target.value }))}
-                    placeholder={isZh ? "例如 default" : "e.g. default"}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <FieldLabel>{isZh ? "首个 Key 有效期" : "First key validity"}</FieldLabel>
+                  <FieldLabel>{isZh ? "Key 有效期" : "Key validity"}</FieldLabel>
                   <Select
                     value={createForm.keyExpiresPreset}
                     onValueChange={(value: ExpirePreset) =>
@@ -859,7 +755,7 @@ export default function ApiKeysPage() {
                   quotas: buildQuotasPayload(createForm.quotas),
                   keys: [
                     {
-                      name: createForm.keyName.trim() || (isZh ? "默认 Key" : "Default key"),
+                      name: "default",
                       expires_at: resolveExpiresAt(createForm.keyExpiresPreset),
                     },
                   ],
@@ -1002,7 +898,7 @@ export default function ApiKeysPage() {
                   </div>
 
                   <div className="h-px bg-slate-200/70" />
-                  {renderKeysSection(item)}
+                  {renderPrimaryKeySection(item)}
                 </div>
               );
             }
@@ -1060,7 +956,7 @@ export default function ApiKeysPage() {
                   </div>
                 </div>
 
-                {renderKeysSection(item)}
+                {renderPrimaryKeySection(item)}
               </div>
             );
           })}
@@ -1144,8 +1040,8 @@ export default function ApiKeysPage() {
         description={
           consumerToDelete
             ? (isZh
-              ? `此操作不可撤销，将同时删除其名下所有 Key。确认删除「${consumerToDelete.name}」吗？`
-              : `This action cannot be undone and will delete all of its keys. Delete "${consumerToDelete.name}"?`)
+              ? `此操作不可撤销，将同时删除其 Key。确认删除「${consumerToDelete.name}」吗？`
+              : `This action cannot be undone and will delete its key. Delete "${consumerToDelete.name}"?`)
             : undefined
         }
         cancelText={isZh ? "取消" : "Cancel"}
@@ -1158,50 +1054,24 @@ export default function ApiKeysPage() {
       />
 
       <ConfirmDialog
-        open={Boolean(keyToRotate)}
+        open={Boolean(keyToRegenerate)}
         onOpenChange={(open) => {
-          if (!open) setKeyToRotate(null);
+          if (!open) setKeyToRegenerate(null);
         }}
-        title={isZh ? "确认轮换 Key" : "Confirm key rotation"}
+        title={isZh ? "确认重新生成 Key" : "Confirm key regeneration"}
         description={
-          keyToRotate
+          keyToRegenerate
             ? (isZh
-              ? `轮换后旧 Key「${keyToRotate.key.name}」将立即失效，新 Key 会以相同名称生成，完整值仅显示一次。确认继续吗？`
-              : `Rotating will immediately invalidate the old key "${keyToRotate.key.name}". A new key with the same name will be generated and its full value shown once. Continue?`)
+              ? `重新生成后旧 Key 将立即失效，新 Key 会以相同名称生成，完整值仅显示一次。确认继续吗？`
+              : `Regenerating will immediately invalidate the old key. A new key with the same name will be generated and its full value shown once. Continue?`)
             : undefined
         }
         cancelText={isZh ? "取消" : "Cancel"}
-        confirmText={isZh ? "轮换" : "Rotate"}
+        confirmText={isZh ? "重新生成" : "Regenerate"}
         onConfirm={() => {
-          if (!keyToRotate) return;
-          rotateKeyMut.mutate({ consumerId: keyToRotate.consumer.id, key: keyToRotate.key });
-          setKeyToRotate(null);
-        }}
-      />
-
-      <ConfirmDialog
-        open={Boolean(keyToDelete)}
-        onOpenChange={(open) => {
-          if (!open) setKeyToDelete(null);
-        }}
-        title={isZh ? "确认删除 Key" : "Confirm key deletion"}
-        description={
-          keyToDelete
-            ? ((keyToDelete.consumer.keys?.length ?? 0) <= 1
-              ? (isZh
-                ? `「${keyToDelete.key.name}」是「${keyToDelete.consumer.name}」目前唯一的 Key，删除后该 consumer 将没有可用凭证，无法鉴权。确认删除吗？`
-                : `"${keyToDelete.key.name}" is the only key for "${keyToDelete.consumer.name}". Deleting it leaves this consumer with no usable credential. Delete anyway?`)
-              : (isZh
-                ? `此操作不可撤销。确认删除「${keyToDelete.key.name}」吗？`
-                : `This action cannot be undone. Delete "${keyToDelete.key.name}"?`))
-            : undefined
-        }
-        cancelText={isZh ? "取消" : "Cancel"}
-        confirmText={isZh ? "删除" : "Delete"}
-        onConfirm={() => {
-          if (!keyToDelete) return;
-          deleteKeyMut.mutate({ consumerId: keyToDelete.consumer.id, keyId: keyToDelete.key.id });
-          setKeyToDelete(null);
+          if (!keyToRegenerate) return;
+          regenerateKeyMut.mutate({ consumerId: keyToRegenerate.consumer.id, key: keyToRegenerate.key });
+          setKeyToRegenerate(null);
         }}
       />
 

--- a/go/webui/src/pages/api-keys.tsx
+++ b/go/webui/src/pages/api-keys.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Check,
   ChevronLeft,
   ChevronRight,
-  Copy,
+  Info,
   KeyRound,
   Pencil,
   Plus,
@@ -22,6 +21,7 @@ import { localizeBackendErrorMessage } from "@/lib/backend-error";
 import type {
   Consumer,
   ConsumerKey,
+  ConsumerLimits,
   ConsumerQuota,
   CreateConsumer,
   CreateConsumerKey,
@@ -30,6 +30,7 @@ import type {
   UpdateConsumer,
   UpdateConsumerKey,
 } from "@/lib/types";
+import { PROTOCOL_TABLE } from "@/lib/protocol";
 import { useLocale } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -52,6 +53,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const PAGE_SIZE = 7;
 
@@ -67,17 +69,82 @@ const expirePresetOptions: { value: ExpirePreset; zh: string; en: string }[] = [
   { value: "1y", zh: "1 年", en: "1 year" },
 ];
 
-function FieldLabel({ children }: { children: string }) {
-  return <label className="ml-1 text-xs leading-none font-normal text-slate-900">{children}</label>;
+function FieldLabel({
+  children,
+  info,
+  required,
+}: {
+  children: string;
+  info?: string;
+  required?: boolean;
+}) {
+  return (
+    <label className="ml-1 inline-flex items-center gap-1 text-xs leading-none font-normal text-slate-900">
+      <span>{children}</span>
+      {required ? (
+        <span className="text-red-500">
+          <span aria-hidden="true">*</span>
+          <span className="sr-only">required</span>
+        </span>
+      ) : null}
+      {info ? (
+        <TooltipProvider delayDuration={120}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="inline-flex cursor-help text-slate-400 hover:text-slate-600"
+                aria-label={info}
+              >
+                <Info className="h-3.5 w-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{info}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </label>
+  );
 }
 
-/** Backend only ever returns a fixed-length key prefix (never the full plaintext key,
- *  except the one-time reveal right after create/rotate), so there's nothing left to
- *  truncate here — just render it with a trailing ellipsis to signal "there's more". */
-function formatKeyPrefix(prefix: string | undefined | null) {
-  const trimmed = (prefix ?? "").trim();
+function SectionTitle({ children, info }: { children: string; info?: string }) {
+  return (
+    <div className="flex items-center gap-1">
+      <p className="text-sm font-semibold text-slate-700">{children}</p>
+      {info ? (
+        <TooltipProvider delayDuration={120}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="inline-flex cursor-help text-slate-400 hover:text-slate-600"
+                aria-label={info}
+              >
+                <Info className="h-3.5 w-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{info}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </div>
+  );
+}
+
+/** Backend only ever returns a masked key_preview (leading 12 + trailing 6
+ *  characters of the raw key, concatenated — never the full plaintext, except
+ *  the one-time reveal right after create/add/regenerate). This renders it as
+ *  "sk-abc123************************abc123": a fixed-length mask so the
+ *  asterisk run never hints at the real key's length. */
+const KEY_PREVIEW_LEAD_VISIBLE = 9;
+const KEY_PREVIEW_TRAIL_VISIBLE = 6;
+const KEY_PREVIEW_MASK_LEN = 28;
+
+function formatKeyPreview(preview: string | undefined | null) {
+  const trimmed = (preview ?? "").trim();
   if (!trimmed) return "sk-";
-  return `${trimmed}...`;
+  if (trimmed.length <= KEY_PREVIEW_LEAD_VISIBLE + KEY_PREVIEW_TRAIL_VISIBLE) return trimmed;
+  const lead = trimmed.slice(0, KEY_PREVIEW_LEAD_VISIBLE);
+  const trail = trimmed.slice(-KEY_PREVIEW_TRAIL_VISIBLE);
+  return `${lead}${"*".repeat(KEY_PREVIEW_MASK_LEN)}${trail}`;
 }
 
 function formatExpiresText(value: string | null | undefined, isZh: boolean) {
@@ -136,7 +203,12 @@ type QuotaFormState = {
   concurrency: string;
 };
 
-const emptyQuotaForm: QuotaFormState = { requests: [], tokens: [], concurrency: "" };
+const emptyQuotaRow: QuotaRuleForm = { limit: "", window: "" };
+
+/** buildQuotasPayload drops any row with an empty limit, so a default blank
+ *  row is purely a UI convenience — it never reaches the submitted payload
+ *  unless the user actually fills in a limit. */
+const emptyQuotaForm: QuotaFormState = { requests: [{ ...emptyQuotaRow }], tokens: [{ ...emptyQuotaRow }], concurrency: "" };
 
 function quotasToForm(quotas: ConsumerQuota[] | undefined): QuotaFormState {
   const form: QuotaFormState = { requests: [], tokens: [], concurrency: "" };
@@ -149,6 +221,8 @@ function quotasToForm(quotas: ConsumerQuota[] | undefined): QuotaFormState {
       form.concurrency = String(q.quota_limit);
     }
   }
+  if (form.requests.length === 0) form.requests.push({ ...emptyQuotaRow });
+  if (form.tokens.length === 0) form.tokens.push({ ...emptyQuotaRow });
   return form;
 }
 
@@ -176,12 +250,74 @@ function buildQuotasPayload(form: QuotaFormState): CreateConsumerQuota[] {
   return quotas;
 }
 
-function quotaBadgeLabel(quotaType: string, isZh: boolean) {
-  if (quotaType === "requests") return isZh ? "请求" : "req";
-  if (quotaType === "tokens") return isZh ? "Token" : "tok";
-  if (quotaType === "concurrency") return isZh ? "并发" : "conc";
-  return quotaType;
+type LimitsFormState = { maxInputTokens: string; maxOutputTokens: string; maxRequestBodyBytes: string };
+
+const emptyLimitsForm: LimitsFormState = { maxInputTokens: "", maxOutputTokens: "", maxRequestBodyBytes: "" };
+
+function limitsToForm(limits: ConsumerLimits | undefined): LimitsFormState {
+  return {
+    maxInputTokens: limits?.max_input_tokens ? String(limits.max_input_tokens) : "",
+    maxOutputTokens: limits?.max_output_tokens ? String(limits.max_output_tokens) : "",
+    maxRequestBodyBytes: limits?.max_request_body_bytes ? String(limits.max_request_body_bytes) : "",
+  };
 }
+
+/** Returns undefined (omit `limits` entirely) when every field is empty, rather
+ *  than sending an all-zero object — zero on a single field already means "no
+ *  limit" for that dimension, so an empty form should not touch the others. */
+function buildLimitsPayload(form: LimitsFormState): ConsumerLimits | undefined {
+  if (!form.maxInputTokens && !form.maxOutputTokens && !form.maxRequestBodyBytes) return undefined;
+  return {
+    max_input_tokens: form.maxInputTokens ? Number.parseInt(form.maxInputTokens, 10) : undefined,
+    max_output_tokens: form.maxOutputTokens ? Number.parseInt(form.maxOutputTokens, 10) : undefined,
+    max_request_body_bytes: form.maxRequestBodyBytes ? Number.parseInt(form.maxRequestBodyBytes, 10) : undefined,
+  };
+}
+
+/** access.ip_allowlist is edited as one input row per entry (like the
+ *  requests/tokens quota rows), each holding a single IP or CIDR block. */
+function ipAllowlistToForm(list: string[] | undefined): string[] {
+  return list && list.length > 0 ? [...list] : [""];
+}
+
+/** buildAccessListPayload drops blank rows, mirroring buildQuotasPayload's
+ *  skip-empty-limit behavior — an untouched blank row never reaches the
+ *  submitted payload. */
+function buildAccessListPayload(rows: string[]): string[] {
+  return rows.map((r) => r.trim()).filter(Boolean);
+}
+
+function isValidIPv4(addr: string): boolean {
+  const parts = addr.split(".");
+  if (parts.length !== 4) return false;
+  return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+}
+
+function isValidIPv6(addr: string): boolean {
+  if (!/^[0-9a-fA-F:]+$/.test(addr)) return false;
+  if ((addr.match(/::/g) ?? []).length > 1) return false;
+  const groups = addr.split(":").filter((g, i, arr) => !(g === "" && (i === 0 || i === arr.length - 1)));
+  return groups.length > 0 && groups.length <= 8 && groups.every((g) => /^[0-9a-fA-F]{1,4}$/.test(g));
+}
+
+/** Accepts a bare IP (v4 or v6) or a CIDR block (IP + "/" + prefix length).
+ *  An empty string is treated as valid — blank rows are filtered out at
+ *  submit time by buildAccessListPayload, not flagged as errors while typing. */
+function isValidIPOrCIDR(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  const [addr, prefix, ...rest] = trimmed.split("/");
+  if (rest.length > 0) return false;
+  if (isValidIPv4(addr)) {
+    return prefix === undefined || (/^\d{1,2}$/.test(prefix) && Number(prefix) <= 32);
+  }
+  if (isValidIPv6(addr)) {
+    return prefix === undefined || (/^\d{1,3}$/.test(prefix) && Number(prefix) <= 128);
+  }
+  return false;
+}
+
+const protocolOptions: ComboboxOption[] = PROTOCOL_TABLE.map((p) => ({ value: p.id, label: p.displayName }));
 
 const quotaBadgeColors = [
   "bg-indigo-50 text-indigo-700",
@@ -190,6 +326,18 @@ const quotaBadgeColors = [
   "bg-amber-50 text-amber-700",
   "bg-fuchsia-50 text-fuchsia-700",
 ];
+
+/** Quota types surfaced as list-card summary badges, in display order. Budget
+ *  quotas are intentionally excluded — there's no WebUI editor for them yet. */
+const quotaSummaryOrder: { type: string; zh: string; en: string }[] = [
+  { type: "requests", zh: "限频", en: "Rate" },
+  { type: "tokens", zh: "限量", en: "Tokens" },
+  { type: "concurrency", zh: "并发", en: "Concurrency" },
+];
+
+function formatQuotaRule(q: ConsumerQuota) {
+  return q.window ? `${q.quota_limit}/${q.window}` : `${q.quota_limit}`;
+}
 
 function QuotaEditor({
   value,
@@ -210,18 +358,7 @@ function QuotaEditor({
     const rows = value[kind];
     return (
       <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <FieldLabel>{title}</FieldLabel>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => updateRows(kind, [...rows, { limit: "", window: "" }])}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {isZh ? "添加一条" : "Add rule"}
-          </Button>
-        </div>
+        <FieldLabel>{title}</FieldLabel>
         {rows.length === 0 && (
           <p className="text-xs text-slate-400">{isZh ? "未设置，不限" : "Not set, unlimited"}</p>
         )}
@@ -253,35 +390,170 @@ function QuotaEditor({
                 placeholder={isZh ? "窗口" : "window"}
               />
             </div>
-            <button
-              type="button"
-              onClick={() => updateRows(kind, rows.filter((_, i) => i !== idx))}
-              className="cursor-pointer p-1 text-slate-400 hover:text-red-500"
-              title={isZh ? "删除该条限额" : "Remove rule"}
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
+            {rows.length > 1 ? (
+              <button
+                type="button"
+                onClick={() => updateRows(kind, rows.filter((_, i) => i !== idx))}
+                className="cursor-pointer p-1 text-slate-400 hover:text-red-500"
+                title={isZh ? "删除该条限额" : "Remove rule"}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => updateRows(kind, [{ limit: "", window: "" }])}
+                className="cursor-pointer p-1 text-slate-400 hover:text-slate-600"
+                title={isZh ? "清空" : "Clear"}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
           </div>
         ))}
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => updateRows(kind, [...rows, { limit: "", window: "" }])}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {isZh ? "添加一条" : "Add rule"}
+        </Button>
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
-      {renderGroup("requests", isZh ? "请求次数限额 (requests)" : "Request quota (requests)")}
-      {renderGroup("tokens", isZh ? "Token 用量限额 (tokens)" : "Token quota (tokens)")}
+    <div className="grid grid-cols-2 items-start gap-4">
+      {renderGroup("requests", isZh ? "请求频率限额" : "Rate limit")}
+      {renderGroup("tokens", isZh ? "Token 用量限额" : "Token quota")}
       <div className="space-y-2">
-        <FieldLabel>{isZh ? "并发上限 (concurrency)" : "Concurrency limit"}</FieldLabel>
+        <FieldLabel
+          info={
+            isZh
+              ? "限制同时处理中的最大请求数，留空不做限制"
+              : "Caps the number of requests processed at the same time; leave empty for no limit"
+          }
+        >
+          {isZh ? "并发上限" : "Concurrency limit"}
+        </FieldLabel>
         <Input
           type="text"
           inputMode="numeric"
           pattern="[0-9]*"
           value={value.concurrency}
           onChange={(e) => onChange({ ...value, concurrency: digitsOnly(e.target.value) })}
-          placeholder={isZh ? "留空=不限，同时处理的最大请求数" : "Empty = unlimited, max in-flight requests"}
+          placeholder={isZh ? "如：10" : "e.g. 10"}
         />
       </div>
+    </div>
+  );
+}
+
+function LimitsEditor({
+  value,
+  onChange,
+  isZh,
+}: {
+  value: LimitsFormState;
+  onChange: (next: LimitsFormState) => void;
+  isZh: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div className="space-y-2">
+        <FieldLabel>{isZh ? "最大输入 Token" : "Max input tokens"}</FieldLabel>
+        <Input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={value.maxInputTokens}
+          onChange={(e) => onChange({ ...value, maxInputTokens: digitsOnly(e.target.value) })}
+          placeholder={isZh ? "如：4000" : "e.g. 4000"}
+        />
+      </div>
+      <div className="space-y-2">
+        <FieldLabel>{isZh ? "最大输出 Token" : "Max output tokens"}</FieldLabel>
+        <Input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={value.maxOutputTokens}
+          onChange={(e) => onChange({ ...value, maxOutputTokens: digitsOnly(e.target.value) })}
+          placeholder={isZh ? "如：2000" : "e.g. 2000"}
+        />
+      </div>
+      <div className="space-y-2">
+        <FieldLabel>{isZh ? "最大请求体积（字节）" : "Max request body (bytes)"}</FieldLabel>
+        <Input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={value.maxRequestBodyBytes}
+          onChange={(e) => onChange({ ...value, maxRequestBodyBytes: digitsOnly(e.target.value) })}
+          placeholder={isZh ? "如：1048576" : "e.g. 1048576"}
+        />
+      </div>
+    </div>
+  );
+}
+
+function IPAllowlistEditor({
+  value,
+  onChange,
+  isZh,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  isZh: boolean;
+}) {
+  function updateRows(rows: string[]) {
+    onChange(rows);
+  }
+
+  return (
+    <div className="space-y-2">
+      {value.map((ip, idx) => {
+        const invalid = ip.trim() !== "" && !isValidIPOrCIDR(ip);
+        return (
+          <div key={idx} className="flex items-center gap-2">
+            <Input
+              value={ip}
+              onChange={(e) => {
+                const next = value.slice();
+                next[idx] = e.target.value;
+                updateRows(next);
+              }}
+              placeholder={isZh ? "例如 10.0.0.0/8 或 192.168.1.1" : "e.g. 10.0.0.0/8 or 192.168.1.1"}
+              className={invalid ? "border-red-400 focus-visible:ring-red-400" : ""}
+            />
+            {value.length > 1 ? (
+              <button
+                type="button"
+                onClick={() => updateRows(value.filter((_, i) => i !== idx))}
+                className="cursor-pointer p-1 text-slate-400 hover:text-red-500"
+                title={isZh ? "删除该条" : "Remove"}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => updateRows([""])}
+                className="cursor-pointer p-1 text-slate-400 hover:text-slate-600"
+                title={isZh ? "清空" : "Clear"}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+      <Button type="button" variant="secondary" size="sm" onClick={() => updateRows([...value, ""])}>
+        <Plus className="h-3.5 w-3.5" />
+        {isZh ? "添加一条" : "Add rule"}
+      </Button>
     </div>
   );
 }
@@ -289,14 +561,20 @@ function QuotaEditor({
 type CreateForm = {
   name: string;
   routes: string[];
+  protocols: string[];
+  ipAllowlist: string[];
   quotas: QuotaFormState;
+  limits: LimitsFormState;
   keyExpiresPreset: ExpirePreset;
 };
 
 const emptyCreate: CreateForm = {
   name: "",
   routes: [],
+  protocols: [],
+  ipAllowlist: [""],
   quotas: emptyQuotaForm,
+  limits: emptyLimitsForm,
   keyExpiresPreset: "never",
 };
 
@@ -305,7 +583,10 @@ type EditForm = {
   name: string;
   enabled: boolean;
   routes: string[];
+  protocols: string[];
+  ipAllowlist: string[];
   quotas: QuotaFormState;
+  limits: LimitsFormState;
 };
 
 type RevealedKey = { name: string; token: string };
@@ -339,16 +620,26 @@ export default function ApiKeysPage() {
   const [showRevealDialog, setShowRevealDialog] = useState(false);
   const [copiedRevealKey, setCopiedRevealKey] = useState(false);
 
-  const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null);
+  const [addKeyDialogFor, setAddKeyDialogFor] = useState<Consumer | null>(null);
+  const [addKeyForm, setAddKeyForm] = useState<{ name: string; expiresPreset: ExpirePreset }>({
+    name: "",
+    expiresPreset: "never",
+  });
 
-  const [keyExpiryEdit, setKeyExpiryEdit] = useState<{
-    consumerId: string;
-    keyId: string;
-    preset: ExpirePreset;
-  } | null>(null);
+  const [editKeyDialogFor, setEditKeyDialogFor] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
+  // expiresTouched tracks whether the user actually picked a validity preset
+  // in this dialog session: expires_at is only included in the submitted
+  // UpdateConsumerKey when true, so opening the dialog just to rename a key
+  // can never silently clear its expiry (nil expires_at means "unchanged").
+  const [editKeyForm, setEditKeyForm] = useState<{ name: string; expiresPreset: ExpirePreset; expiresTouched: boolean }>({
+    name: "",
+    expiresPreset: "never",
+    expiresTouched: false,
+  });
 
   const [consumerToDelete, setConsumerToDelete] = useState<Consumer | null>(null);
   const [keyToRegenerate, setKeyToRegenerate] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
+  const [keyToDelete, setKeyToDelete] = useState<{ consumer: Consumer; key: ConsumerKey } | null>(null);
   const [errorDialog, setErrorDialog] = useState<{ title: string; description?: string } | null>(null);
 
   function formatErrorMessage(error: unknown) {
@@ -427,17 +718,18 @@ export default function ApiKeysPage() {
     },
   });
 
-  const generateKeyMut = useMutation({
-    mutationFn: ({ consumerId }: { consumerId: string }) =>
-      backend<ConsumerKey>("add_consumer_key", { id: consumerId, input: { name: "default" } as CreateConsumerKey }),
+  const addKeyMut = useMutation({
+    mutationFn: ({ consumerId, input }: { consumerId: string; input: CreateConsumerKey }) =>
+      backend<ConsumerKey>("add_consumer_key", { id: consumerId, input }),
     onSuccess: (created) => {
       invalidateConsumers();
+      setAddKeyDialogFor(null);
       if (created.token) {
         openRevealDialog({ name: created.name, token: created.token });
       }
     },
     onError: (error: unknown) => {
-      showErrorDialog("生成 Key 失败", "Failed to generate key", error);
+      showErrorDialog("新增 Key 失败", "Failed to add key", error);
     },
   });
 
@@ -459,12 +751,23 @@ export default function ApiKeysPage() {
 
   const regenerateKeyMut = useMutation({
     mutationFn: async ({ consumerId, key }: { consumerId: string; key: ConsumerKey }) => {
+      // consumer_keys has a UNIQUE(consumer_id, name) constraint, so adding the
+      // replacement under the *same* name while the old row still exists would
+      // always violate it. Create it under a throwaway temp name first (add
+      // before delete, so a failed add leaves the old key intact), delete the
+      // old key, then rename the replacement back to the original name.
+      const tempName = `${key.name}~regen~${crypto.randomUUID()}`;
       const created = await backend<ConsumerKey>("add_consumer_key", {
         id: consumerId,
-        input: { name: key.name, expires_at: key.expires_at },
+        input: { name: tempName, expires_at: key.expires_at },
       });
       await backend("delete_consumer_key", { id: consumerId, keyId: key.id });
-      return created;
+      await backend<ConsumerKey>("update_consumer_key", {
+        id: consumerId,
+        keyId: created.id,
+        input: { name: key.name },
+      });
+      return { ...created, name: key.name };
     },
     onSuccess: (created) => {
       invalidateConsumers();
@@ -474,6 +777,15 @@ export default function ApiKeysPage() {
     },
     onError: (error: unknown) => {
       showErrorDialog("重新生成 Key 失败", "Failed to regenerate key", error);
+    },
+  });
+
+  const deleteKeyMut = useMutation({
+    mutationFn: ({ consumerId, keyId }: { consumerId: string; keyId: string }) =>
+      backend("delete_consumer_key", { id: consumerId, keyId }),
+    onSuccess: () => invalidateConsumers(),
+    onError: (error: unknown) => {
+      showErrorDialog("删除 Key 失败", "Failed to delete key", error);
     },
   });
 
@@ -504,135 +816,117 @@ export default function ApiKeysPage() {
       name: item.name,
       enabled: item.enabled,
       routes: item.routes ?? [],
+      protocols: item.protocols ?? [],
+      ipAllowlist: ipAllowlistToForm(item.ip_allowlist),
       quotas: quotasToForm(item.quotas),
+      limits: limitsToForm(item.limits),
     });
   }
 
-  async function copyKeyPrefix(key: ConsumerKey) {
-    await navigator.clipboard.writeText(key.key_prefix);
-    setCopiedKeyId(key.id);
-    setTimeout(() => setCopiedKeyId(null), 1500);
+  function openAddKeyDialog(consumer: Consumer) {
+    setAddKeyForm({ name: "", expiresPreset: "never" });
+    setAddKeyDialogFor(consumer);
   }
 
+  // expiresPreset starts at "never" rather than trying to reverse-map
+  // key.expires_at to a preset (presets are relative day-offsets computed at
+  // selection time, so an existing absolute timestamp generally can't be
+  // mapped back to one) — expiresTouched starts false so this default is
+  // never actually submitted unless the user picks a preset themselves.
+  function openEditKeyDialog(consumer: Consumer, key: ConsumerKey) {
+    setEditKeyForm({ name: key.name, expiresPreset: "never", expiresTouched: false });
+    setEditKeyDialogFor({ consumer, key });
+  }
+
+  /** Renders one count badge per access dimension (models/protocols/IP
+   *  allowlist) that has a restriction set, instead of one badge per bound
+   *  item — keeps the card width independent of how many models/protocols/IPs
+   *  are configured. A dimension with nothing set means default-allow, so it
+   *  renders no badge at all. */
+  function renderAccessBadges(consumer: Consumer) {
+    const dims: { count: number; zh: string; en: string; className: string }[] = [
+      { count: consumer.routes?.length ?? 0, zh: "模型", en: "Models", className: "bg-cyan-50 text-cyan-700" },
+      { count: consumer.protocols?.length ?? 0, zh: "协议", en: "Protocols", className: "bg-violet-50 text-violet-700" },
+      { count: consumer.ip_allowlist?.length ?? 0, zh: "白名单", en: "IPs", className: "bg-slate-100 text-slate-600" },
+    ];
+    return dims
+      .filter((d) => d.count > 0)
+      .map((d) => (
+        <Badge key={d.en} variant="warning" className={`connect-label-badge ${d.className}`}>
+          {`${isZh ? d.zh : d.en} ${d.count}`}
+        </Badge>
+      ));
+  }
+
+  /** Renders exactly one badge per quota type present, so the card's width
+   *  never grows with the number of configured rules — extra rules of the
+   *  same type fold into a "+N" suffix on that one badge instead of adding
+   *  more badges. */
   function renderQuotaBadges(quotas: ConsumerQuota[] | undefined) {
-    return (quotas ?? []).map((q, idx) => {
-      const label = quotaBadgeLabel(q.quota_type, isZh);
-      const text = q.window ? `${label} ${q.quota_limit}/${q.window}` : `${label} ${q.quota_limit}`;
-      return (
+    return quotaSummaryOrder.flatMap(({ type, zh, en }, idx) => {
+      const rows = (quotas ?? []).filter((q) => q.quota_type === type);
+      if (rows.length === 0) return [];
+      const label = isZh ? zh : en;
+      const suffix = rows.length > 1 ? ` +${rows.length - 1}` : "";
+      return [
         <Badge
-          key={q.id ?? `${q.quota_type}-${idx}`}
+          key={type}
           variant="warning"
           className={`connect-label-badge ${quotaBadgeColors[idx % quotaBadgeColors.length]}`}
         >
-          {text}
-        </Badge>
-      );
+          {`${label} ${formatQuotaRule(rows[0])}${suffix}`}
+        </Badge>,
+      ];
     });
   }
 
   // Single-key simplification: the backend keeps keys[] as 1:N, but the UI
   // always operates on the consumer's primary key (keys[0]) and never exposes
   // per-key add/delete.
-  function renderPrimaryKeySection(consumer: Consumer) {
-    const key = consumer.keys?.[0];
-    if (!key) {
-      return (
-        <div className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
-          <p className="text-xs text-slate-400">
-            {isZh ? "该 consumer 暂无可用密钥，无法鉴权。" : "No key yet — this consumer cannot authenticate."}
-          </p>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            disabled={generateKeyMut.isPending}
-            onClick={() => generateKeyMut.mutate({ consumerId: consumer.id })}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {generateKeyMut.isPending ? (isZh ? "生成中..." : "Generating...") : (isZh ? "生成 Key" : "Generate key")}
-          </Button>
-        </div>
-      );
-    }
-
+  function renderKeyRow(consumer: Consumer, key: ConsumerKey) {
     const keyExpired = isApiKeyExpired(key.expires_at);
-    const isEditingExpiry = keyExpiryEdit?.consumerId === consumer.id && keyExpiryEdit.keyId === key.id;
     return (
-      <div className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
+      <div key={key.id} className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold text-slate-600">{isZh ? "API Key" : "API Key"}</span>
-          <code className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600">
-            {formatKeyPrefix(key.key_prefix)}
+          <span className="inline-flex h-5 items-center text-xs text-slate-800">{key.name}</span>
+          <code
+            title={
+              isZh
+                ? "完整 Key 仅在创建/新增/重新生成时展示一次，此处仅展示部分字符，无法复制完整 Key"
+                : "Full key is shown once on create/add/regenerate; this is a partial preview and cannot be copied here"
+            }
+            className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600"
+          >
+            {formatKeyPreview(key.key_preview)}
           </code>
+          {!key.enabled && (
+            <Badge variant="danger" className="connect-label-badge">
+              {isZh ? "已禁用" : "Disabled"}
+            </Badge>
+          )}
           <Badge variant={keyExpired ? "danger" : "success"} className="connect-label-badge">
             {formatValidityLabel(keyExpired, isZh)}
           </Badge>
-          {isEditingExpiry ? (
-            <div className="flex items-center gap-1">
-              <Select
-                value={keyExpiryEdit.preset}
-                onValueChange={(value: ExpirePreset) =>
-                  setKeyExpiryEdit((prev) => (prev ? { ...prev, preset: value } : prev))
-                }
-              >
-                <SelectTrigger className="h-7 w-32 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {expirePresetOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {isZh ? option.zh : option.en}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button
-                size="sm"
-                onClick={() => {
-                  updateKeyMut.mutate({
-                    consumerId: consumer.id,
-                    keyId: key.id,
-                    input: { expires_at: resolveExpiresAtForUpdate(keyExpiryEdit.preset) },
-                  });
-                  setKeyExpiryEdit(null);
-                }}
-              >
-                {isZh ? "保存" : "Save"}
-              </Button>
-              <Button size="sm" variant="secondary" onClick={() => setKeyExpiryEdit(null)}>
-                {isZh ? "取消" : "Cancel"}
-              </Button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() =>
-                setKeyExpiryEdit({ consumerId: consumer.id, keyId: key.id, preset: "never" })
-              }
-              className="cursor-pointer text-xs text-slate-500 underline decoration-dotted hover:text-slate-700"
-              title={isZh ? "点击修改过期时间" : "Click to edit expiry"}
-            >
-              {formatExpiresText(key.expires_at, isZh)}
-            </button>
-          )}
+          <span className="text-xs text-slate-500">{formatExpiresText(key.expires_at, isZh)}</span>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
           <button
-            onClick={() => copyKeyPrefix(key)}
-            title={
-              copiedKeyId === key.id
-                ? (isZh ? "已复制前缀" : "Prefix copied")
-                : (isZh
-                  ? "复制前缀（完整 Key 仅在创建/重新生成时展示一次，此处无法复制完整 Key）"
-                  : "Copy prefix only (full key is shown once on create/regenerate, not copyable here)")
-            }
-            className={`cursor-pointer rounded-lg p-1.5 transition-colors ${
-              copiedKeyId === key.id
-                ? "text-green-500 hover:bg-green-50"
-                : "text-slate-400 hover:bg-slate-100 hover:text-slate-700"
-            }`}
+            onClick={() => updateKeyMut.mutate({ consumerId: consumer.id, keyId: key.id, input: { enabled: !key.enabled } })}
+            title={key.enabled ? (isZh ? "禁用" : "Disable") : (isZh ? "启用" : "Enable")}
+            className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
           >
-            {copiedKeyId === key.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            {key.enabled ? (
+              <ToggleRight className="h-4 w-4 text-green-500" />
+            ) : (
+              <ToggleLeft className="h-4 w-4 text-slate-400" />
+            )}
+          </button>
+          <button
+            onClick={() => openEditKeyDialog(consumer, key)}
+            title={isZh ? "编辑名称 / 有效期" : "Edit name / validity"}
+            className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-500"
+          >
+            <Pencil className="h-4 w-4" />
           </button>
           <button
             onClick={() => setKeyToRegenerate({ consumer, key })}
@@ -641,9 +935,34 @@ export default function ApiKeysPage() {
           >
             <RotateCw className="h-4 w-4" />
           </button>
+          <button
+            onClick={() => setKeyToDelete({ consumer, key })}
+            title={isZh ? "删除该 Key" : "Delete key"}
+            className="cursor-pointer rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
         </div>
       </div>
     );
+  }
+
+  function renderKeysSection(consumer: Consumer) {
+    const keys = consumer.keys ?? [];
+    if (keys.length === 0) {
+      return (
+        <div className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
+          <p className="text-xs text-slate-400">
+            {isZh ? "该 consumer 暂无可用密钥，无法鉴权。" : "No key yet — this consumer cannot authenticate."}
+          </p>
+          <Button type="button" size="sm" variant="secondary" onClick={() => openAddKeyDialog(consumer)}>
+            <Plus className="h-3.5 w-3.5" />
+            {isZh ? "新增 Key" : "Add key"}
+          </Button>
+        </div>
+      );
+    }
+    return <div className="space-y-1.5">{keys.map((key) => renderKeyRow(consumer, key))}</div>;
   }
 
   return (
@@ -673,14 +992,14 @@ export default function ApiKeysPage() {
           <h2 className="text-lg font-semibold text-slate-900">{isZh ? "创建 Consumer" : "Create Consumer"}</h2>
           <div className="space-y-5">
             <div className="space-y-3">
-              <p className="text-sm font-semibold text-slate-700">{isZh ? "1. 基本信息" : "1. Basic Information"}</p>
+              <SectionTitle>{isZh ? "1. 基本信息" : "1. Basic Information"}</SectionTitle>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
+                  <FieldLabel required>{isZh ? "名称" : "Name"}</FieldLabel>
                   <Input
                     value={createForm.name}
                     onChange={(e) => setCreateForm((prev) => ({ ...prev, name: e.target.value }))}
-                    placeholder={isZh ? "例如 Frontend App" : "e.g. Frontend App"}
+                    placeholder={isZh ? "如：生产环境" : "e.g. Production"}
                   />
                 </div>
                 <div className="space-y-2">
@@ -714,35 +1033,79 @@ export default function ApiKeysPage() {
             <div className="h-px bg-slate-200/70" />
 
             <div className="space-y-3">
-              <p className="text-sm font-semibold text-slate-700">{isZh ? "2. 访问权限" : "2. Access Permission"}</p>
-              <div className="space-y-2">
-                <FieldLabel>
-                  {isZh
-                    ? "绑定模型（不勾选=不可访问受控模型）"
-                    : "Bind Models (none = deny on protected models)"}
-                </FieldLabel>
-                <MultiSelect
-                  options={routeOptions}
-                  values={createForm.routes}
-                  placeholder={
-                    isZh ? "选择可访问的受控模型" : "Select protected models this key can access"
-                  }
-                  searchPlaceholder={isZh ? "搜索模型..." : "Search models..."}
-                  emptyText={isZh ? "无匹配模型" : "No matching models"}
-                  onChange={(next) => setCreateForm((prev) => ({ ...prev, routes: next }))}
-                />
+              <SectionTitle>{isZh ? "2. 访问权限" : "2. Access Permission"}</SectionTitle>
+              <div className="grid grid-cols-2 items-start gap-4">
+                <div className="space-y-2">
+                  <FieldLabel
+                    info={
+                      isZh
+                        ? "不绑定时默认允许访问所有受控模型"
+                        : "When left unbound, all protected models are accessible"
+                    }
+                  >
+                    {isZh ? "绑定模型" : "Bind Models"}
+                  </FieldLabel>
+                  <MultiSelect
+                    options={routeOptions}
+                    values={createForm.routes}
+                    placeholder={
+                      isZh ? "选择可访问的受控模型" : "Select protected models this key can access"
+                    }
+                    searchPlaceholder={isZh ? "搜索模型..." : "Search models..."}
+                    emptyText={isZh ? "无匹配模型" : "No matching models"}
+                    onChange={(next) => setCreateForm((prev) => ({ ...prev, routes: next }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <FieldLabel
+                    info={isZh ? "留空时不限制可用协议" : "Leaving this empty applies no protocol restriction"}
+                  >
+                    {isZh ? "允许协议" : "Allowed protocols"}
+                  </FieldLabel>
+                  <MultiSelect
+                    options={protocolOptions}
+                    values={createForm.protocols}
+                    placeholder={isZh ? "选择允许的协议" : "Select allowed protocols"}
+                    searchPlaceholder={isZh ? "搜索协议..." : "Search protocols..."}
+                    emptyText={isZh ? "无匹配协议" : "No matching protocols"}
+                    onChange={(next) => setCreateForm((prev) => ({ ...prev, protocols: next }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <FieldLabel
+                    info={isZh ? "留空时不限制来源 IP" : "Leaving this empty applies no restriction on source IP"}
+                  >
+                    {isZh ? "IP 白名单" : "IP allowlist"}
+                  </FieldLabel>
+                  <IPAllowlistEditor
+                    value={createForm.ipAllowlist}
+                    onChange={(next) => setCreateForm((prev) => ({ ...prev, ipAllowlist: next }))}
+                    isZh={isZh}
+                  />
+                </div>
               </div>
             </div>
 
             <div className="h-px bg-slate-200/70" />
 
             <div className="space-y-3">
-              <p className="text-sm font-semibold text-slate-700">{isZh ? "3. 访问限额" : "3. Access Quota"}</p>
+              <SectionTitle>{isZh ? "3. 访问限额" : "3. Access Quota"}</SectionTitle>
               <QuotaEditor
                 value={createForm.quotas}
                 onChange={(next) => setCreateForm((prev) => ({ ...prev, quotas: next }))}
                 isZh={isZh}
                 windowOptions={windowOptions}
+              />
+            </div>
+
+            <div className="h-px bg-slate-200/70" />
+
+            <div className="space-y-3">
+              <SectionTitle info={isZh ? "均为可选项，留空表示不做限制" : "All optional; leave empty for no limit"}>{isZh ? "4. 资源限额" : "4. Resource Limits"}</SectionTitle>
+              <LimitsEditor
+                value={createForm.limits}
+                onChange={(next) => setCreateForm((prev) => ({ ...prev, limits: next }))}
+                isZh={isZh}
               />
             </div>
           </div>
@@ -752,7 +1115,10 @@ export default function ApiKeysPage() {
                 createMut.mutate({
                   name: createForm.name.trim(),
                   routes: createForm.routes,
+                  protocols: createForm.protocols,
+                  ip_allowlist: buildAccessListPayload(createForm.ipAllowlist),
                   quotas: buildQuotasPayload(createForm.quotas),
+                  limits: buildLimitsPayload(createForm.limits),
                   keys: [
                     {
                       name: "default",
@@ -761,7 +1127,11 @@ export default function ApiKeysPage() {
                   ],
                 })
               }
-              disabled={createMut.isPending || !createForm.name.trim()}
+              disabled={
+                createMut.isPending ||
+                !createForm.name.trim() ||
+                createForm.ipAllowlist.some((ip) => !isValidIPOrCIDR(ip))
+              }
             >
               {createMut.isPending ? (isZh ? "创建中..." : "Creating...") : (isZh ? "创建" : "Create")}
             </Button>
@@ -807,10 +1177,10 @@ export default function ApiKeysPage() {
                   </div>
                   <div className="space-y-5">
                     <div className="space-y-3">
-                      <p className="text-sm font-semibold text-slate-700">{isZh ? "1. 基本信息" : "1. Basic Information"}</p>
+                      <SectionTitle>{isZh ? "1. 基本信息" : "1. Basic Information"}</SectionTitle>
                       <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
-                          <FieldLabel>{isZh ? "名称" : "Name"}</FieldLabel>
+                          <FieldLabel required>{isZh ? "名称" : "Name"}</FieldLabel>
                           <Input
                             value={editForm.name}
                             onChange={(e) => setEditForm((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
@@ -821,7 +1191,7 @@ export default function ApiKeysPage() {
                           <button
                             type="button"
                             onClick={() => setEditForm((prev) => (prev ? { ...prev, enabled: !prev.enabled } : prev))}
-                            className="flex h-10 cursor-pointer items-center gap-2 rounded-md border border-input px-3 text-sm"
+                            className="flex h-10 w-full cursor-pointer items-center gap-2 rounded-md border border-input px-3 text-sm"
                           >
                             {editForm.enabled ? (
                               <ToggleRight className="h-4 w-4 text-green-500" />
@@ -837,35 +1207,79 @@ export default function ApiKeysPage() {
                     <div className="h-px bg-slate-200/70" />
 
                     <div className="space-y-3">
-                      <p className="text-sm font-semibold text-slate-700">{isZh ? "2. 访问权限" : "2. Access Permission"}</p>
-                      <div className="space-y-2">
-                        <FieldLabel>
-                          {isZh
-                            ? "绑定模型（不勾选=不可访问受控模型）"
-                            : "Bind Models (none = deny on protected models)"}
-                        </FieldLabel>
-                        <MultiSelect
-                          options={routeOptions}
-                          values={editForm.routes}
-                          placeholder={
-                            isZh ? "选择可访问的受控模型" : "Select protected models this key can access"
-                          }
-                          searchPlaceholder={isZh ? "搜索模型..." : "Search models..."}
-                          emptyText={isZh ? "无匹配模型" : "No matching models"}
-                          onChange={(next) => setEditForm((prev) => (prev ? { ...prev, routes: next } : prev))}
-                        />
+                      <SectionTitle>{isZh ? "2. 访问权限" : "2. Access Permission"}</SectionTitle>
+                      <div className="grid grid-cols-2 items-start gap-4">
+                        <div className="space-y-2">
+                          <FieldLabel
+                    info={
+                      isZh
+                        ? "不绑定时默认允许访问所有受控模型"
+                        : "When left unbound, all protected models are accessible"
+                    }
+                  >
+                    {isZh ? "绑定模型" : "Bind Models"}
+                  </FieldLabel>
+                          <MultiSelect
+                            options={routeOptions}
+                            values={editForm.routes}
+                            placeholder={
+                              isZh ? "选择可访问的受控模型" : "Select protected models this key can access"
+                            }
+                            searchPlaceholder={isZh ? "搜索模型..." : "Search models..."}
+                            emptyText={isZh ? "无匹配模型" : "No matching models"}
+                            onChange={(next) => setEditForm((prev) => (prev ? { ...prev, routes: next } : prev))}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <FieldLabel
+                            info={isZh ? "留空时不限制可用协议" : "Leaving this empty applies no protocol restriction"}
+                          >
+                            {isZh ? "允许协议" : "Allowed protocols"}
+                          </FieldLabel>
+                          <MultiSelect
+                            options={protocolOptions}
+                            values={editForm.protocols}
+                            placeholder={isZh ? "选择允许的协议" : "Select allowed protocols"}
+                            searchPlaceholder={isZh ? "搜索协议..." : "Search protocols..."}
+                            emptyText={isZh ? "无匹配协议" : "No matching protocols"}
+                            onChange={(next) => setEditForm((prev) => (prev ? { ...prev, protocols: next } : prev))}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <FieldLabel
+                            info={isZh ? "留空时不限制来源 IP" : "Leaving this empty applies no restriction on source IP"}
+                          >
+                            {isZh ? "IP 白名单" : "IP allowlist"}
+                          </FieldLabel>
+                          <IPAllowlistEditor
+                            value={editForm.ipAllowlist}
+                            onChange={(next) => setEditForm((prev) => (prev ? { ...prev, ipAllowlist: next } : prev))}
+                            isZh={isZh}
+                          />
+                        </div>
                       </div>
                     </div>
 
                     <div className="h-px bg-slate-200/70" />
 
                     <div className="space-y-3">
-                      <p className="text-sm font-semibold text-slate-700">{isZh ? "3. 访问限额" : "3. Access Quota"}</p>
+                      <SectionTitle>{isZh ? "3. 访问限额" : "3. Access Quota"}</SectionTitle>
                       <QuotaEditor
                         value={editForm.quotas}
                         onChange={(next) => setEditForm((prev) => (prev ? { ...prev, quotas: next } : prev))}
                         isZh={isZh}
                         windowOptions={windowOptions}
+                      />
+                    </div>
+
+                    <div className="h-px bg-slate-200/70" />
+
+                    <div className="space-y-3">
+                      <SectionTitle info={isZh ? "均为可选项，留空表示不做限制" : "All optional; leave empty for no limit"}>{isZh ? "4. 资源限额" : "4. Resource Limits"}</SectionTitle>
+                      <LimitsEditor
+                        value={editForm.limits}
+                        onChange={(next) => setEditForm((prev) => (prev ? { ...prev, limits: next } : prev))}
+                        isZh={isZh}
                       />
                     </div>
                   </div>
@@ -878,11 +1292,14 @@ export default function ApiKeysPage() {
                             name: editForm.name.trim(),
                             enabled: editForm.enabled,
                             routes: editForm.routes,
+                            protocols: editForm.protocols,
+                            ip_allowlist: buildAccessListPayload(editForm.ipAllowlist),
                             quotas: buildQuotasPayload(editForm.quotas),
+                            limits: buildLimitsPayload(editForm.limits),
                           },
                         })
                       }
-                      disabled={updateMut.isPending}
+                      disabled={updateMut.isPending || editForm.ipAllowlist.some((ip) => !isValidIPOrCIDR(ip))}
                     >
                       {updateMut.isPending ? (isZh ? "保存中..." : "Saving...") : (isZh ? "保存" : "Save")}
                     </Button>
@@ -898,7 +1315,7 @@ export default function ApiKeysPage() {
                   </div>
 
                   <div className="h-px bg-slate-200/70" />
-                  {renderPrimaryKeySection(item)}
+                  {renderKeysSection(item)}
                 </div>
               );
             }
@@ -920,11 +1337,7 @@ export default function ApiKeysPage() {
                             {isZh ? "已禁用" : "Disabled"}
                           </Badge>
                         )}
-                        {(item.routes ?? []).map((model) => (
-                          <Badge key={model} variant="warning" className="connect-label-badge bg-cyan-50 text-cyan-700">
-                            {model}
-                          </Badge>
-                        ))}
+                        {renderAccessBadges(item)}
                         {renderQuotaBadges(item.quotas)}
                       </div>
                     </div>
@@ -942,6 +1355,13 @@ export default function ApiKeysPage() {
                       )}
                     </button>
                     <button
+                      onClick={() => openAddKeyDialog(item)}
+                      title={isZh ? "新增 Key" : "Add key"}
+                      className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-green-50 hover:text-green-600"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </button>
+                    <button
                       onClick={() => startEdit(item)}
                       className="cursor-pointer rounded-lg p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-500"
                     >
@@ -956,7 +1376,7 @@ export default function ApiKeysPage() {
                   </div>
                 </div>
 
-                {renderPrimaryKeySection(item)}
+                {renderKeysSection(item)}
               </div>
             );
           })}
@@ -1074,6 +1494,163 @@ export default function ApiKeysPage() {
           setKeyToRegenerate(null);
         }}
       />
+
+      <ConfirmDialog
+        open={Boolean(keyToDelete)}
+        onOpenChange={(open) => {
+          if (!open) setKeyToDelete(null);
+        }}
+        title={isZh ? "确认删除 Key" : "Confirm key deletion"}
+        description={
+          keyToDelete
+            ? ((keyToDelete.consumer.keys?.length ?? 0) <= 1
+              ? (isZh
+                ? `「${keyToDelete.key.name}」是「${keyToDelete.consumer.name}」目前唯一的 Key，删除后该 consumer 将没有可用凭证，无法鉴权。确认删除吗？`
+                : `"${keyToDelete.key.name}" is the only key for "${keyToDelete.consumer.name}". Deleting it leaves this consumer with no usable credential. Delete anyway?`)
+              : (isZh
+                ? `此操作不可撤销。确认删除「${keyToDelete.key.name}」吗？`
+                : `This action cannot be undone. Delete "${keyToDelete.key.name}"?`))
+            : undefined
+        }
+        cancelText={isZh ? "取消" : "Cancel"}
+        confirmText={isZh ? "删除" : "Delete"}
+        onConfirm={() => {
+          if (!keyToDelete) return;
+          deleteKeyMut.mutate({ consumerId: keyToDelete.consumer.id, keyId: keyToDelete.key.id });
+          setKeyToDelete(null);
+        }}
+      />
+
+      <Dialog
+        open={Boolean(addKeyDialogFor)}
+        onOpenChange={(open) => {
+          if (!open) setAddKeyDialogFor(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{isZh ? "新增 Key" : "Add Key"}</DialogTitle>
+            <DialogDescription>
+              {isZh
+                ? "Key 值会在创建后自动生成，仅在创建成功后展示一次。"
+                : "The key value is auto-generated and shown exactly once after creation."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <FieldLabel required>{isZh ? "名称" : "Name"}</FieldLabel>
+              <Input
+                value={addKeyForm.name}
+                onChange={(e) => setAddKeyForm((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder={isZh ? "如：default" : "e.g. default"}
+              />
+            </div>
+            <div className="space-y-2">
+              <FieldLabel>{isZh ? "有效期" : "Validity"}</FieldLabel>
+              <Select
+                value={addKeyForm.expiresPreset}
+                onValueChange={(value: ExpirePreset) => setAddKeyForm((prev) => ({ ...prev, expiresPreset: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {expirePresetOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {isZh ? option.zh : option.en}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setAddKeyDialogFor(null)}>
+              {isZh ? "取消" : "Cancel"}
+            </Button>
+            <Button
+              disabled={addKeyMut.isPending || !addKeyForm.name.trim()}
+              onClick={() => {
+                if (!addKeyDialogFor) return;
+                addKeyMut.mutate({
+                  consumerId: addKeyDialogFor.id,
+                  input: {
+                    name: addKeyForm.name.trim(),
+                    expires_at: resolveExpiresAt(addKeyForm.expiresPreset),
+                  },
+                });
+              }}
+            >
+              {addKeyMut.isPending ? (isZh ? "添加中..." : "Adding...") : (isZh ? "添加" : "Add")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(editKeyDialogFor)}
+        onOpenChange={(open) => {
+          if (!open) setEditKeyDialogFor(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{isZh ? "编辑 Key" : "Edit Key"}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <FieldLabel required>{isZh ? "名称" : "Name"}</FieldLabel>
+              <Input
+                value={editKeyForm.name}
+                onChange={(e) => setEditKeyForm((prev) => ({ ...prev, name: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <FieldLabel>{isZh ? "有效期" : "Validity"}</FieldLabel>
+              <Select
+                value={editKeyForm.expiresPreset}
+                onValueChange={(value: ExpirePreset) =>
+                  setEditKeyForm((prev) => ({ ...prev, expiresPreset: value, expiresTouched: true }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {expirePresetOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {isZh ? option.zh : option.en}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setEditKeyDialogFor(null)}>
+              {isZh ? "取消" : "Cancel"}
+            </Button>
+            <Button
+              disabled={updateKeyMut.isPending || !editKeyForm.name.trim()}
+              onClick={() => {
+                if (!editKeyDialogFor) return;
+                const input: UpdateConsumerKey = { name: editKeyForm.name.trim() };
+                if (editKeyForm.expiresTouched) {
+                  input.expires_at = resolveExpiresAtForUpdate(editKeyForm.expiresPreset);
+                }
+                updateKeyMut.mutate({
+                  consumerId: editKeyDialogFor.consumer.id,
+                  keyId: editKeyDialogFor.key.id,
+                  input,
+                });
+                setEditKeyDialogFor(null);
+              }}
+            >
+              {updateKeyMut.isPending ? (isZh ? "保存中..." : "Saving...") : (isZh ? "保存" : "Save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <ConfirmDialog
         open={Boolean(errorDialog)}


### PR DESCRIPTION
## Summary
- Redesign the Go consumer storage layer with `metadata`, `access` (models/protocols/ip_allowlist, default-allow), `quotas` (requests/tokens/concurrency/budgets), and per-request `limits` — no new tables, reuses the existing schema via new columns.
- Rework the WebUI api-keys create/edit forms: half-width layout, tooltip-based field hints (matching `providers.tsx` conventions) instead of inline parentheticals, row editors for requests/tokens/IP allowlist with a clear-vs-delete affordance, and IP/CIDR validation.
- Rename `consumer_keys.key_prefix` → `key_preview` (stores a leading+trailing slice of the raw key, still an exact-match indexed auth lookup) so the list can show a fixed-length masked preview (`sk-abc123****...****xyz789`) instead of a bare prefix; regenerated gorm/gen query code and the xds protobuf bindings for the rename.
- Reintroduce full multi-key management in the consumer list (add/edit/toggle/delete per key, with a last-key deletion warning) — previously the UI only exposed `keys[0]`.
- Fix key regeneration: it now creates the replacement under a throwaway temp name before deleting the old one, since `consumer_keys` has a `UNIQUE(consumer_id, name)` constraint that a same-name add would always violate while the old row still exists.

## Test plan
- [x] `cd go && go build ./... && go vet ./... && gofmt -l .` clean
- [x] `cd go && go test ./...` — all packages pass (storage, proxy, xds, admin, config, etc.)
- [x] `cd go/webui && npx tsc --noEmit` clean
- [x] `cd go/webui && npm run lint` — no errors (one pre-existing unrelated warning)
- [x] `cd go/webui && npm run test` — 39/39 passing
- [x] `cd go/webui && npm run build` succeeds
- [x] Manually exercised in a live embedded preview (separate scratch DB/port): create consumer, add/edit/regenerate/delete keys, quota row add/clear/delete, IP allowlist validation, tooltips