### PR TITLE
feat(webui): merge nodes host/port columns into a single service address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ go-webui-embed-build: go-webui-embed-assets
 	cd go && mkdir -p bin && go build -tags webui_embed -o bin/nyro .
 
 # Build and run the Go admin with embedded WebUI for local preview.
-# --grpc-addr defaults to 127.0.0.1:19532 (config-sync gRPC server, a
-# *separate* port from --addr's HTTP REST/WebUI), so
-# `nyro gateway --configsync-addr 127.0.0.1:19532` can connect for config
+# --config-listen defaults to 127.0.0.1:19532 (config-sync gRPC server, a
+# *separate* port from --listen's HTTP REST/WebUI), so
+# `nyro gateway --config-server 127.0.0.1:19532` can connect for config
 # hot-reload with no extra flags here.
 go-webui-embed-run: go-webui-embed-build
 	cd go && ./bin/nyro admin

--- a/go/cmd/admin/admin.go
+++ b/go/cmd/admin/admin.go
@@ -26,7 +26,7 @@ import (
 
 // nyroHomeDir returns ~/.nyro, the default home for admin-local state
 // (sqlite DB, observability parquet data) when the user hasn't pointed
-// --db-dsn/--obs-data-dir elsewhere. Falls back to "./.nyro" (relative to
+// --dsn/--obs-data-dir elsewhere. Falls back to "./.nyro" (relative to
 // the working directory) if the OS user home directory can't be resolved —
 // best-effort, never fatal, so admin still starts.
 func nyroHomeDir() string {
@@ -37,71 +37,73 @@ func nyroHomeDir() string {
 	return filepath.Join(home, ".nyro")
 }
 
+// defaultDSN is the --dsn value used when the flag is left empty: a sqlite
+// file under the admin-managed ~/.nyro home.
+func defaultDSN() string {
+	return "sqlite://" + filepath.Join(nyroHomeDir(), "nyro.db")
+}
+
 // NewCmd builds the admin (control-plane) subcommand.
 //
 // In addition to the REST API + WebUI, the admin optionally runs a gRPC
-// ConfigService server (--grpc-addr) that pushes the full config snapshot to
-// every connected gateway. When enabled, every config write (providers, models,
-// api keys, settings) triggers an immediate push to all gateways.
+// ConfigService server (--config-listen) that pushes the full config snapshot
+// to every connected gateway. When enabled, every config write (providers,
+// models, api keys, settings) triggers an immediate push to all gateways.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin",
 		Short: "Run the control plane (management API + WebUI)",
 	}
-	cmd.Flags().String("addr", "127.0.0.1:19531", "listen address for the control plane")
+	cmd.Flags().String("listen", "127.0.0.1:19531", "listen address for the control plane")
 	// Bound to loopback by default: this stream carries every upstream's
 	// credentials_json in the clear (no TLS, no auth — see internal/configsync)
 	// to any client that connects and subscribes. Defaulting it on (rather than
 	// disabled) makes admin+gateway on the same host work with zero flags;
 	// exposing it beyond loopback is a deliberate opt-in via an explicit
-	// --grpc-addr, not something a default should do for you.
-	cmd.Flags().String("grpc-addr", "127.0.0.1:19532", "listen address for the config-sync gRPC server (empty disables it)")
-	cmd.Flags().String("admin-token", "", "Bearer token protecting /api/v1 admin routes")
+	// --config-listen, not something a default should do for you.
+	cmd.Flags().String("config-listen", "127.0.0.1:19532", "listen address for the config-sync gRPC server (empty disables it)")
+	cmd.Flags().String("token", "", "Bearer token protecting /api/v1 admin routes")
 	cmd.Flags().String("webui-dir", "", "path to the built WebUI (serves the SPA at /)")
-	cmd.Flags().String("storage", "sqlite", "storage backend: sqlite|postgres|mysql")
-	cmd.Flags().String("db-dsn", "", fmt.Sprintf("database path/DSN (sqlite: file path, default %s; postgres/mysql: full DSN, required)", filepath.Join(nyroHomeDir(), "nyro.db")))
+	cmd.Flags().String("dsn", "", fmt.Sprintf("database DSN: sqlite://<path> (default %s), postgres://..., or mysql://...", defaultDSN()))
 	cmd.Flags().String("obs-data-dir", filepath.Join(nyroHomeDir(), "obs"), "directory for admin-local observability parquet data (logs/metrics/traces)")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		addr, _ := cmd.Flags().GetString("addr")
-		grpcAddr, _ := cmd.Flags().GetString("grpc-addr")
-		adminToken, _ := cmd.Flags().GetString("admin-token")
+		addr, _ := cmd.Flags().GetString("listen")
+		grpcAddr, _ := cmd.Flags().GetString("config-listen")
+		adminToken, _ := cmd.Flags().GetString("token")
 		webuiDir, _ := cmd.Flags().GetString("webui-dir")
-		storageBackend, _ := cmd.Flags().GetString("storage")
-		dbDSN, _ := cmd.Flags().GetString("db-dsn")
+		dsn, _ := cmd.Flags().GetString("dsn")
 		obsDataDir, _ := cmd.Flags().GetString("obs-data-dir")
 
-		switch storageBackend {
-		case "sqlite":
-			usingDefaultDBDSN := dbDSN == ""
-			if usingDefaultDBDSN {
-				dbDSN = filepath.Join(nyroHomeDir(), "nyro.db")
-			}
+		usingDefaultDSN := dsn == ""
+		if usingDefaultDSN {
+			dsn = defaultDSN()
+		}
+
+		backend, driverDSN, err := bootstrap.ParseDSN(dsn)
+		if err != nil {
+			return err
+		}
+		if backend == "sqlite" {
 			// The sqlite driver opens/creates the DB file itself but never its
 			// parent directory. For the ~/.nyro default that's our own managed
 			// space, so auto-creating it (like ~/.aws, ~/.docker, ~/.kube) is
-			// expected. For an explicit --db-dsn, silently creating a missing
+			// expected. For an explicit --dsn, silently creating a missing
 			// directory risks masking a typo'd path with a fresh empty DB
 			// instead of the one the operator meant to open — fail loudly
 			// instead, matching how `postgres initdb -D <dir>` and friends
 			// treat an explicitly-named data directory.
-			if dir := filepath.Dir(dbDSN); dir != "" && dir != "." {
-				if usingDefaultDBDSN {
+			if dir := filepath.Dir(driverDSN); dir != "" && dir != "." {
+				if usingDefaultDSN {
 					if err := os.MkdirAll(dir, 0o755); err != nil {
-						return fmt.Errorf("create db-dsn directory %q: %w", dir, err)
+						return fmt.Errorf("create --dsn directory %q: %w", dir, err)
 					}
 				} else if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-					return fmt.Errorf("--db-dsn directory %q does not exist (create it first, or leave --db-dsn unset to use the default under ~/.nyro)", dir)
+					return fmt.Errorf("--dsn directory %q does not exist (create it first, or leave --dsn unset to use the default under ~/.nyro)", dir)
 				}
 			}
-		case "postgres", "mysql":
-			if dbDSN == "" {
-				return fmt.Errorf("--db-dsn is required for --storage %s", storageBackend)
-			}
-		default:
-			return fmt.Errorf("unknown --storage %q (want sqlite|postgres|mysql)", storageBackend)
 		}
 
-		// Same reasoning as --db-dsn above: the ~/.nyro default is auto-created
+		// Same reasoning as --dsn above: the ~/.nyro default is auto-created
 		// (parquet.NewSink MkdirAll's it on demand below), but an explicit
 		// --obs-data-dir naming a missing directory fails loudly instead of
 		// silently starting a fresh, empty observability store there.
@@ -111,7 +113,7 @@ func NewCmd() *cobra.Command {
 			}
 		}
 
-		st, err := bootstrap.OpenStorage(storageBackend, dbDSN)
+		st, err := bootstrap.OpenStorageFromDSN(dsn)
 		if err != nil {
 			return err
 		}
@@ -287,18 +289,18 @@ var obsSeedSignals = []string{"logs", "metrics", "traces"}
 // seedDefaultObsEndpoint runs after migration and, only if all three signals'
 // obs_<signal>_otlp_endpoint keys are still empty (fresh install, or a
 // migration that found nothing to copy), seeds every signal's OTLP endpoint
-// to point at this admin instance's own --addr, and defaults any still-empty
+// to point at this admin instance's own --listen, and defaults any still-empty
 // obs_<signal>_exporter to "otlp". This is a real, editable setting written
 // to storage — not an in-memory/runtime override of ObsConfig — so the user
 // can change it later via the WebUI.
 //
 // The seeded value must be a valid absolute URL: provider.go's OTLP builders
 // (otlploghttp/otlpmetrichttp/otlptracehttp) call WithEndpointURL, which
-// url.Parses the string — a schemeless "host:port" value (e.g. what --addr
+// url.Parses the string — a schemeless "host:port" value (e.g. what --listen
 // takes, "127.0.0.1:19531") fails to parse as an absolute URL and causes the
 // OTel SDK to silently fall back to its own built-in default
 // ("localhost:4318") instead of this admin's real address. addrToOTLPURL
-// below normalizes --addr into "http://host:port" (leaving an
+// below normalizes --listen into "http://host:port" (leaving an
 // already-schemed value untouched).
 //
 // Idempotent: if any endpoint is already set (user-configured or seeded on a
@@ -333,13 +335,13 @@ func seedDefaultObsEndpoint(s storage.SettingsStore, addr string) {
 	}
 }
 
-// addrToOTLPURL normalizes a --addr-style value into an absolute URL suitable
+// addrToOTLPURL normalizes a --listen-style value into an absolute URL suitable
 // for otlploghttp/otlpmetrichttp/otlptracehttp's WithEndpointURL, which
-// url.Parses its argument and requires a scheme. --addr is documented and
+// url.Parses its argument and requires a scheme. --listen is documented and
 // used elsewhere (bootstrap.RunServer) as a bare "host:port" listen address
 // (e.g. "127.0.0.1:19531", or ":8080"), so the common case just gets
 // "http://" prepended. If addr already carries an "http://" or "https://"
-// scheme (e.g. a user hand-editing the seeded value, or a future --addr that
+// scheme (e.g. a user hand-editing the seeded value, or a future --listen that
 // accepts a full URL), it is returned unchanged rather than double-prefixed.
 func addrToOTLPURL(addr string) string {
 	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") {

--- a/go/cmd/admin/admin_test.go
+++ b/go/cmd/admin/admin_test.go
@@ -11,43 +11,40 @@ import (
 
 func TestNewCmdFlags(t *testing.T) {
 	cmd := NewCmd()
-	if addr, _ := cmd.Flags().GetString("addr"); addr != "127.0.0.1:19531" {
-		t.Errorf("default addr = %q, want 127.0.0.1:19531", addr)
+	if addr, _ := cmd.Flags().GetString("listen"); addr != "127.0.0.1:19531" {
+		t.Errorf("default listen = %q, want 127.0.0.1:19531", addr)
 	}
 	if cmd.Use != "admin" {
 		t.Errorf("Use = %q, want admin", cmd.Use)
 	}
 }
 
-func TestNewCmdStorageFlagDefaults(t *testing.T) {
+func TestNewCmdDSNFlagDefault(t *testing.T) {
 	cmd := NewCmd()
-	if v, _ := cmd.Flags().GetString("storage"); v != "sqlite" {
-		t.Errorf("default storage = %q, want sqlite", v)
-	}
-	if v, _ := cmd.Flags().GetString("db-dsn"); v != "" {
-		t.Errorf("default db-dsn = %q, want empty (resolved at RunE time)", v)
+	if v, _ := cmd.Flags().GetString("dsn"); v != "" {
+		t.Errorf("default dsn = %q, want empty (resolved at RunE time)", v)
 	}
 }
 
-func TestRunE_RejectsMemoryStorage(t *testing.T) {
+func TestRunE_RejectsMemoryDSN(t *testing.T) {
 	cmd := NewCmd()
-	if err := cmd.ParseFlags([]string{"--storage", "memory"}); err != nil {
+	if err := cmd.ParseFlags([]string{"--dsn", "memory://"}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	err := cmd.RunE(cmd, nil)
 	if err == nil {
-		t.Fatal("expected an error rejecting --storage memory, got nil")
+		t.Fatal("expected an error rejecting --dsn memory://, got nil")
 	}
 }
 
-func TestRunE_RejectsUnknownStorage(t *testing.T) {
+func TestRunE_RejectsUnknownDSNScheme(t *testing.T) {
 	cmd := NewCmd()
-	if err := cmd.ParseFlags([]string{"--storage", "bogus"}); err != nil {
+	if err := cmd.ParseFlags([]string{"--dsn", "bogus://x"}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	err := cmd.RunE(cmd, nil)
 	if err == nil {
-		t.Fatal("expected an error rejecting --storage bogus, got nil")
+		t.Fatal("expected an error rejecting an unrecognized --dsn scheme, got nil")
 	}
 }
 
@@ -59,38 +56,38 @@ func TestNewCmdObsDataDirFlagDefault(t *testing.T) {
 	}
 }
 
-func TestNewCmdGRPCAddrFlagDefault(t *testing.T) {
+func TestNewCmdConfigListenFlagDefault(t *testing.T) {
 	cmd := NewCmd()
-	if v, _ := cmd.Flags().GetString("grpc-addr"); v != "127.0.0.1:19532" {
-		t.Errorf("default grpc-addr = %q, want 127.0.0.1:19532", v)
+	if v, _ := cmd.Flags().GetString("config-listen"); v != "127.0.0.1:19532" {
+		t.Errorf("default config-listen = %q, want 127.0.0.1:19532", v)
 	}
 }
 
-// An explicit --db-dsn naming a directory that doesn't exist must fail
+// An explicit --dsn naming a sqlite directory that doesn't exist must fail
 // loudly rather than silently create it — unlike the ~/.nyro default,
 // which is our own managed space and safe to auto-create. Silently
 // creating a typo'd explicit path risks masking the mistake with a fresh
 // empty DB instead of the one the operator meant to open.
-func TestRunE_ExplicitDBDSNMissingDirectoryErrors(t *testing.T) {
+func TestRunE_ExplicitDSNMissingDirectoryErrors(t *testing.T) {
 	cmd := NewCmd()
 	missing := filepath.Join(t.TempDir(), "does-not-exist", "nyro.db")
-	if err := cmd.ParseFlags([]string{"--db-dsn", missing}); err != nil {
+	if err := cmd.ParseFlags([]string{"--dsn", "sqlite://" + missing}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	err := cmd.RunE(cmd, nil)
 	if err == nil {
-		t.Fatal("expected an error for a missing explicit --db-dsn directory, got nil")
+		t.Fatal("expected an error for a missing explicit --dsn directory, got nil")
 	}
 }
 
-// Same as above, for --obs-data-dir. db-dsn is pointed at a valid temp
+// Same as above, for --obs-data-dir. --dsn is pointed at a valid temp
 // directory so the RunE reaches the obs-data-dir check rather than failing
 // there first — and so the test never touches the real ~/.nyro.
 func TestRunE_ExplicitObsDataDirMissingDirectoryErrors(t *testing.T) {
 	cmd := NewCmd()
 	dbDSN := filepath.Join(t.TempDir(), "nyro.db")
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
-	if err := cmd.ParseFlags([]string{"--db-dsn", dbDSN, "--obs-data-dir", missing}); err != nil {
+	if err := cmd.ParseFlags([]string{"--dsn", "sqlite://" + dbDSN, "--obs-data-dir", missing}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	err := cmd.RunE(cmd, nil)

--- a/go/cmd/gateway/gateway.go
+++ b/go/cmd/gateway/gateway.go
@@ -23,13 +23,14 @@ import (
 // NewCmd builds the gateway (data-plane) subcommand.
 //
 // Config sources (exactly one is required):
-//   - --config: standalone YAML (no admin/DB needed). The snapshot is built once
-//     at startup and never refreshed; edit + restart to change config.
-//   - --configsync-addr: admin's gRPC endpoint. The gateway subscribes to a
+//   - --config-file: standalone YAML (no admin/DB needed). The snapshot is
+//     built once at startup and never refreshed; edit + restart to change
+//     config.
+//   - --config-server: admin's gRPC endpoint. The gateway subscribes to a
 //     long-lived config stream and hot-reloads on every admin config change.
 //
 // Phase 3 removed the transitional Phase-1 DB-poll default — exactly one of
-// --config / --configsync-addr must now be set.
+// --config-file / --config-server must now be set.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gateway",
@@ -39,19 +40,19 @@ func NewCmd() *cobra.Command {
 	// from real clients (like nginx/envoy/traefik), often from outside its
 	// own host/container — unlike the admin control plane, which manages
 	// sensitive credentials and defaults to loopback-only on purpose.
-	cmd.Flags().String("addr", "0.0.0.0:19530", "listen address for the data plane")
-	cmd.Flags().String("config", "", "standalone YAML config file (no admin/DB needed)")
-	cmd.Flags().String("configsync-addr", "", "admin gRPC config-sync endpoint (host:port) for config hot-reload")
+	cmd.Flags().String("listen", "0.0.0.0:19530", "listen address for the data plane")
+	cmd.Flags().String("config-file", "", "standalone YAML config file (no admin/DB needed)")
+	cmd.Flags().String("config-server", "", "admin gRPC config-sync endpoint (host:port) for config hot-reload")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		addr, _ := cmd.Flags().GetString("addr")
-		cfgPath, _ := cmd.Flags().GetString("config")
-		configSyncAddr, _ := cmd.Flags().GetString("configsync-addr")
+		addr, _ := cmd.Flags().GetString("listen")
+		cfgPath, _ := cmd.Flags().GetString("config-file")
+		configSyncAddr, _ := cmd.Flags().GetString("config-server")
 
 		if cfgPath == "" && configSyncAddr == "" {
-			return errors.New("exactly one of --config or --configsync-addr is required (the legacy DB-poll default was removed in Phase 3)")
+			return errors.New("exactly one of --config-file or --config-server is required (the legacy DB-poll default was removed in Phase 3)")
 		}
 		if cfgPath != "" && configSyncAddr != "" {
-			return errors.New("--config and --configsync-addr are mutually exclusive (set exactly one)")
+			return errors.New("--config-file and --config-server are mutually exclusive (set exactly one)")
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -96,13 +97,13 @@ func servicePort(addr string) string {
 
 // buildGateway selects the config source and returns a ready, storage-free
 // Gateway plus an optional config-sync client stop function (nil unless
-// --configsync-addr) and the OTel provider (always non-nil on success —
+// --config-server) and the OTel provider (always non-nil on success —
 // telemetry is wired in every mode). It constructs the ObsProvider + Handles
 // and calls RegisterHooks exactly ONCE per process (the plugin registry
 // accumulates appends, so re-registering would double-emit). /readyz reflects
 // cache fill, not storage health.
 //
-// listenAddr is this gateway's own data-plane --addr (host:port); only its
+// listenAddr is this gateway's own data-plane --listen (host:port); only its
 // port is used, reported over config-sync as Subscribe.service_port so the
 // admin's node list can show where each gateway actually serves traffic
 // (distinct from the config-sync gRPC connection's ephemeral peer port).
@@ -161,7 +162,7 @@ func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr strin
 
 	default:
 		// Unreachable: RunE enforces the XOR. Guard anyway.
-		return nil, nil, nil, errors.New("exactly one of --config or --configsync-addr is required")
+		return nil, nil, nil, errors.New("exactly one of --config-file or --config-server is required")
 	}
 }
 

--- a/go/cmd/gateway/gateway_test.go
+++ b/go/cmd/gateway/gateway_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestNewCmdFlags(t *testing.T) {
 	cmd := NewCmd()
-	if addr, _ := cmd.Flags().GetString("addr"); addr != "0.0.0.0:19530" {
-		t.Errorf("default addr = %q; want 0.0.0.0:19530", addr)
+	if addr, _ := cmd.Flags().GetString("listen"); addr != "0.0.0.0:19530" {
+		t.Errorf("default listen = %q; want 0.0.0.0:19530", addr)
 	}
-	if cfg, _ := cmd.Flags().GetString("config"); cfg != "" {
-		t.Errorf("default config = %q; want empty", cfg)
+	if cfg, _ := cmd.Flags().GetString("config-file"); cfg != "" {
+		t.Errorf("default config-file = %q; want empty", cfg)
 	}
-	if cs, _ := cmd.Flags().GetString("configsync-addr"); cs != "" {
-		t.Errorf("default configsync-addr = %q; want empty", cs)
+	if cs, _ := cmd.Flags().GetString("config-server"); cs != "" {
+		t.Errorf("default config-server = %q; want empty", cs)
 	}
 	if cmd.Use != "gateway" {
 		t.Errorf("Use = %q; want gateway", cmd.Use)
@@ -30,13 +30,13 @@ func TestNewCmdFlags(t *testing.T) {
 }
 
 func TestBuildGateway_ConfigAndConfigSyncAreMutuallyExclusive(t *testing.T) {
-	// NOTE: buildGateway itself does NOT enforce XOR (it picks --config when both
+	// NOTE: buildGateway itself does NOT enforce XOR (it picks --config-file when both
 	// are set). The XOR is enforced in the cobra RunE. We exercise it via RunE
 	// below. This test documents that buildGateway picks config when both given.
 	_, _, _, err := buildGateway(context.Background(), "missing.yaml", "localhost:9999", "127.0.0.1:19530")
 	// missing.yaml → file error, proving the config branch was selected.
 	if err == nil {
-		t.Error("expected error selecting config branch with both flags; buildGateway must prefer --config")
+		t.Error("expected error selecting config branch with both flags; buildGateway must prefer --config-file")
 	}
 }
 
@@ -44,11 +44,11 @@ func TestRunE_RejectsBothConfigAndConfigSyncAddr(t *testing.T) {
 	cmd := NewCmd()
 	// ParseFlags binds the args to the flag set first. Calling RunE directly
 	// skips cobra's parse step, so without ParseFlags the flags read as
-	// default-empty, the --config/--configsync-addr XOR guard would NOT fire,
+	// default-empty, the --config-file/--config-server XOR guard would NOT fire,
 	// and RunE would fall through to the default branch and block on
 	// RunServer (test hang). The XOR check still returns before touching
 	// storage/listeners.
-	if err := cmd.ParseFlags([]string{"--config", "a.yaml", "--configsync-addr", "host:1234"}); err != nil {
+	if err := cmd.ParseFlags([]string{"--config-file", "a.yaml", "--config-server", "host:1234"}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	err := cmd.RunE(cmd, nil)

--- a/go/docs/cutover.md
+++ b/go/docs/cutover.md
@@ -26,9 +26,9 @@ go build -o /tmp/nyro .
 
 ```bash
 # data plane (shadow):
-/tmp/nyro gateway --addr 127.0.0.1:19529
+/tmp/nyro gateway --listen 127.0.0.1:19529
 # control plane (admin API + WebUI):
-/tmp/nyro admin --addr 127.0.0.1:19531 --webui-dir ../webui/dist --admin-token <token>
+/tmp/nyro admin --listen 127.0.0.1:19531 --webui-dir ../webui/dist --token <token>
 ```
 
 Both read the same upstream config (point the Go gateway at the same providers;
@@ -36,18 +36,18 @@ config is managed via its own `/api/v1` admin API or seeded from flags for the
 shadow phase).
 
 To hot-reload the gateway's config from the admin instead of a static
-`--config` YAML file, enable the admin's config-sync gRPC server and point the
-gateway at it:
+`--config-file` YAML file, enable the admin's config-sync gRPC server and point
+the gateway at it:
 
 ```bash
 # control plane, with config-sync enabled:
-/tmp/nyro admin --addr 127.0.0.1:19531 --grpc-addr 127.0.0.1:19532 --admin-token <token>
-# data plane, subscribing to config-sync instead of --config:
-/tmp/nyro gateway --addr 127.0.0.1:19529 --configsync-addr 127.0.0.1:19532
+/tmp/nyro admin --listen 127.0.0.1:19531 --config-listen 127.0.0.1:19532 --token <token>
+# data plane, subscribing to config-sync instead of --config-file:
+/tmp/nyro gateway --listen 127.0.0.1:19529 --config-server 127.0.0.1:19532
 ```
 
-`--config` and `--configsync-addr` are mutually exclusive — exactly one must
-be set. `--grpc-addr` is disabled (no config-sync server started) when left
+`--config-file` and `--config-server` are mutually exclusive — exactly one must
+be set. `--config-listen` is disabled (no config-sync server started) when left
 empty. Connected gateways are visible on the admin at `GET /api/v1/nodes`
 (and the WebUI's Nodes page) — a best-effort, in-memory view that reflects
 only currently-open connections.

--- a/go/internal/admin/admin.go
+++ b/go/internal/admin/admin.go
@@ -67,7 +67,7 @@ func Mount(r chi.Router, s storage.Storage, adminToken string, logs LogSource, s
 
 		// /nodes lists gateways currently connected over config-sync (best-effort,
 		// in-memory — never persisted). Returns an empty array (not an error) when
-		// config-sync is disabled (no --grpc-addr) or nothing is connected yet, so
+		// config-sync is disabled (no --config-listen) or nothing is connected yet, so
 		// the WebUI can render an empty state instead of handling a special error.
 		g.Get("/nodes", func(w http.ResponseWriter, r *http.Request) {
 			lister := nodeListerVal

--- a/go/internal/bootstrap/bootstrap.go
+++ b/go/internal/bootstrap/bootstrap.go
@@ -9,43 +9,104 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/nyroway/nyro/go/internal/storage"
 	"github.com/nyroway/nyro/go/internal/storage/database"
-	"github.com/nyroway/nyro/go/internal/storage/memory"
 )
 
-// OpenStorage selects and opens the storage backend. "memory" (the default) is
-// ephemeral; "sqlite"/"postgres"/"mysql" open a persistent DB and apply the
-// config-schema (upstreams/routes/consumers) tables via Migrate.
-func OpenStorage(backend, dsn string) (storage.Storage, error) {
+// ParseDSN parses a --dsn value into a storage backend name and the
+// driver-native DSN that backend's constructor (NewSQLite/NewPostgres/
+// NewMySQL) expects. Recognized schemes:
+//   - "sqlite://<path>": path is everything after "sqlite://" verbatim, so
+//     an absolute path is "sqlite:///abs/x.db", a relative path is
+//     "sqlite://./x.db", and an in-memory DB is "sqlite://:memory:".
+//   - "postgres://...": returned unchanged (with scheme) — gorm's postgres
+//     driver (pgx) accepts the URL form natively. "postgresql://" (the other
+//     libpq-recognized alias) is deliberately not accepted, to keep exactly
+//     one spelling per backend.
+//   - "mysql://user:pass@host:port/db?params": converted to gorm's mysql
+//     DSN form "user:pass@tcp(host:port)/db?params" (defaulting the port to
+//     3306 when omitted).
+//
+// Any other scheme (including "memory://" and "postgresql://") is a hard
+// error — there is no ephemeral backend reachable through --dsn.
+func ParseDSN(dsn string) (string, string, error) {
+	switch {
+	case strings.HasPrefix(dsn, "sqlite://"):
+		return "sqlite", strings.TrimPrefix(dsn, "sqlite://"), nil
+	case strings.HasPrefix(dsn, "postgres://"):
+		return "postgres", dsn, nil
+	case strings.HasPrefix(dsn, "mysql://"):
+		driverDSN, err := mysqlURLToGormDSN(dsn)
+		if err != nil {
+			return "", "", fmt.Errorf("parse mysql dsn: %w", err)
+		}
+		return "mysql", driverDSN, nil
+	default:
+		return "", "", fmt.Errorf("unrecognized --dsn scheme %q (want sqlite://, postgres://, or mysql://)", dsn)
+	}
+}
+
+// mysqlURLToGormDSN converts a "mysql://user:pass@host:port/db?params" URL
+// into gorm's mysql driver DSN form "user:pass@tcp(host:port)/db?params",
+// defaulting the port to 3306 when the URL omits it.
+func mysqlURLToGormDSN(dsn string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", err
+	}
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "3306"
+	}
+	var userinfo string
+	if u.User != nil {
+		userinfo = u.User.String()
+	}
+	db := strings.TrimPrefix(u.Path, "/")
+	driverDSN := fmt.Sprintf("%s@tcp(%s:%s)/%s", userinfo, host, port, db)
+	if u.RawQuery != "" {
+		driverDSN += "?" + u.RawQuery
+	}
+	return driverDSN, nil
+}
+
+// OpenStorageFromDSN parses dsn via ParseDSN and opens the resulting
+// backend, applying the config-schema (upstreams/routes/consumers) tables
+// via Migrate.
+func OpenStorageFromDSN(dsn string) (storage.Storage, error) {
+	backend, driverDSN, err := ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
 	switch backend {
-	case "", "memory":
-		return memory.New().Storage(), nil
 	case "sqlite":
-		b, err := database.NewSQLite(dsn)
+		b, err := database.NewSQLite(driverDSN)
 		if err != nil {
 			return nil, fmt.Errorf("open sqlite: %w", err)
 		}
 		return bootstrapSQL(b)
 	case "postgres":
-		b, err := database.NewPostgres(dsn)
+		b, err := database.NewPostgres(driverDSN)
 		if err != nil {
 			return nil, fmt.Errorf("open postgres: %w", err)
 		}
 		return bootstrapSQL(b)
 	case "mysql":
-		b, err := database.NewMySQL(dsn)
+		b, err := database.NewMySQL(driverDSN)
 		if err != nil {
 			return nil, fmt.Errorf("open mysql: %w", err)
 		}
 		return bootstrapSQL(b)
 	default:
-		return nil, fmt.Errorf("unknown storage backend %q (want memory|sqlite|postgres|mysql)", backend)
+		return nil, fmt.Errorf("unknown storage backend %q", backend)
 	}
 }
 

--- a/go/internal/bootstrap/bootstrap_test.go
+++ b/go/internal/bootstrap/bootstrap_test.go
@@ -1,22 +1,51 @@
 package bootstrap
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestOpenStorage(t *testing.T) {
-	t.Run("memory default", func(t *testing.T) {
-		st, err := OpenStorage("", "")
-		if err != nil {
-			t.Fatalf("memory: %v", err)
-		}
-		h, _ := st.Migrator().Health()
-		if h.Backend != "memory" {
-			t.Errorf("backend = %q, want memory", h.Backend)
-		}
-	})
+func TestParseDSN(t *testing.T) {
+	tests := []struct {
+		name        string
+		dsn         string
+		wantBackend string
+		wantDriver  string
+		wantErr     bool
+	}{
+		{"sqlite absolute path", "sqlite:///abs/x.db", "sqlite", "/abs/x.db", false},
+		{"sqlite relative path", "sqlite://./x.db", "sqlite", "./x.db", false},
+		{"sqlite memory", "sqlite://:memory:", "sqlite", ":memory:", false},
+		{"postgres passthrough", "postgres://user:pass@host:5432/db?sslmode=disable", "postgres", "postgres://user:pass@host:5432/db?sslmode=disable", false},
+		{"postgresql alias rejected", "postgresql://user:pass@host:5432/db", "", "", true},
+		{"mysql url to gorm dsn", "mysql://user:pass@host:3307/db?parseTime=true", "mysql", "user:pass@tcp(host:3307)/db?parseTime=true", false},
+		{"mysql url default port", "mysql://user:pass@host/db", "mysql", "user:pass@tcp(host:3306)/db", false},
+		{"memory scheme rejected", "memory://", "", "", true},
+		{"bad scheme", "redis://host:6379", "", "", true},
+		{"empty dsn rejected", "", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend, driver, err := ParseDSN(tt.dsn)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseDSN(%q): expected error, got backend=%q driver=%q", tt.dsn, backend, driver)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDSN(%q): unexpected error: %v", tt.dsn, err)
+			}
+			if backend != tt.wantBackend {
+				t.Errorf("ParseDSN(%q) backend = %q, want %q", tt.dsn, backend, tt.wantBackend)
+			}
+			if driver != tt.wantDriver {
+				t.Errorf("ParseDSN(%q) driver = %q, want %q", tt.dsn, driver, tt.wantDriver)
+			}
+		})
+	}
+}
+
+func TestOpenStorageFromDSN(t *testing.T) {
 	t.Run("sqlite in-memory migrates and serves", func(t *testing.T) {
-		st, err := OpenStorage("sqlite", ":memory:")
+		st, err := OpenStorageFromDSN("sqlite://:memory:")
 		if err != nil {
 			t.Fatalf("sqlite: %v", err)
 		}
@@ -28,9 +57,9 @@ func TestOpenStorage(t *testing.T) {
 			t.Errorf("Upstreams().List after migrate: %v", err)
 		}
 	})
-	t.Run("unknown backend errors", func(t *testing.T) {
-		if _, err := OpenStorage("bogus", ""); err == nil {
-			t.Error("expected error for bogus backend")
+	t.Run("bad scheme errors", func(t *testing.T) {
+		if _, err := OpenStorageFromDSN("bogus://x"); err == nil {
+			t.Error("expected error for bogus scheme")
 		}
 	})
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -554,7 +554,7 @@ func flattenObservabilitySignal(out map[string]string, signal observability.Sign
 
 // BuildSnapshot constructs a configsync.ConfigSnapshot directly from the YAML
 // config (no persistent storage). This is the standalone-mode path: `nyro
-// gateway --config` swaps this snapshot into the gateway's cache so config
+// gateway --config-file` swaps this snapshot into the gateway's cache so config
 // reads work without an admin or DB. It seeds a throwaway in-memory backend
 // via the same ApplyTo used by persistent backends and reads the snapshot
 // back through configsync.LoadFromStorage — there is no separate

--- a/go/internal/config/doc.go
+++ b/go/internal/config/doc.go
@@ -1,5 +1,5 @@
 // Package config loads the standalone YAML configuration and seeds it into a
-// storage backend. Used by `nyro gateway --config` to run without an
+// storage backend. Used by `nyro gateway --config-file` to run without an
 // admin/DB.
 //
 // The YAML shape mirrors the config-schema plan's final config.yaml: version +

--- a/go/internal/configsync/pb/configsync/v1/configsync.pb.go
+++ b/go/internal/configsync/pb/configsync/v1/configsync.pb.go
@@ -27,7 +27,7 @@ type Subscribe struct {
 	NodeId        string                 `protobuf:"bytes,2,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`                // stable per-process identifier (survives reconnects)
 	AppVersion    string                 `protobuf:"bytes,3,opt,name=app_version,json=appVersion,proto3" json:"app_version,omitempty"`    // gateway build version, for node visibility
 	Hostname      string                 `protobuf:"bytes,4,opt,name=hostname,proto3" json:"hostname,omitempty"`                          // gateway's os.Hostname(), for node visibility
-	ServicePort   string                 `protobuf:"bytes,5,opt,name=service_port,json=servicePort,proto3" json:"service_port,omitempty"` // port the gateway's data-plane listener is bound to (from --addr), for node visibility
+	ServicePort   string                 `protobuf:"bytes,5,opt,name=service_port,json=servicePort,proto3" json:"service_port,omitempty"` // port the gateway's data-plane listener is bound to (from --listen), for node visibility
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/go/nyro_test.go
+++ b/go/nyro_test.go
@@ -24,10 +24,7 @@ func TestRootCmdSubcommands(t *testing.T) {
 
 func TestRootCmdNoGlobalStorageFlags(t *testing.T) {
 	root := newRootCmd()
-	if f := root.PersistentFlags().Lookup("storage"); f != nil {
-		t.Error("--storage must not be a global/root flag (it belongs to admin only)")
-	}
-	if f := root.PersistentFlags().Lookup("db-dsn"); f != nil {
-		t.Error("--db-dsn must not be a global/root flag (it belongs to admin only)")
+	if f := root.PersistentFlags().Lookup("dsn"); f != nil {
+		t.Error("--dsn must not be a global/root flag (it belongs to admin only)")
 	}
 }

--- a/go/proto/configsync/v1/configsync.proto
+++ b/go/proto/configsync/v1/configsync.proto
@@ -21,7 +21,7 @@ message Subscribe {
   string node_id = 2;      // stable per-process identifier (survives reconnects)
   string app_version = 3;  // gateway build version, for node visibility
   string hostname = 4;      // gateway's os.Hostname(), for node visibility
-  string service_port = 5; // port the gateway's data-plane listener is bound to (from --addr), for node visibility
+  string service_port = 5; // port the gateway's data-plane listener is bound to (from --listen), for node visibility
 }
 
 // ConfigSnapshot is a full, immutable configuration snapshot (config-schema:

--- a/go/webui/src/pages/nodes.tsx
+++ b/go/webui/src/pages/nodes.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { Server } from "lucide-react";
+import { Info, Server } from "lucide-react";
 import { backend } from "@/lib/backend";
 import type { GatewayNode } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Locale-specific formatting: zh-CN reads as 24-hour "YYYY/MM/DD HH:mm:ss",
 // en-US as 12-hour "MM/DD/YYYY hh:mm:ss AM/PM" — Intl.DateTimeFormat with
@@ -40,7 +41,22 @@ function formatAddressHost(addr: string) {
   return addr.slice(0, lastColon);
 }
 
-const COLUMN_COUNT = 8;
+// formatServiceAddress combines the two independently-sourced pieces that
+// together make up "where this gateway actually serves traffic": the host
+// from remote_addr (the real gRPC peer IP, observed by admin) and the port
+// from service_port (self-reported by the gateway from its own --listen).
+// Either can be missing on its own (an older gateway build, or a connection
+// still mid-handshake), so each falls back independently rather than the
+// whole cell collapsing to "-" when only one side is present.
+function formatServiceAddress(remoteAddr: string, servicePort: string) {
+  const host = formatAddressHost(remoteAddr);
+  if (!host && !servicePort) return "-";
+  if (!host) return `:${servicePort}`;
+  if (!servicePort) return host;
+  return `${host}:${servicePort}`;
+}
+
+const COLUMN_COUNT = 7;
 
 export default function NodesPage() {
   const { locale } = useLocale();
@@ -75,8 +91,32 @@ export default function NodesPage() {
               <tr>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "节点" : "Node"}</th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "主机名" : "Hostname"}</th>
-                <th className="px-3 py-2 text-left font-medium">{isZh ? "主机地址" : "Host Address"}</th>
-                <th className="px-3 py-2 text-left font-medium">{isZh ? "服务端口" : "Service Port"}</th>
+                <th className="px-3 py-2 text-left font-medium">
+                  <span className="inline-flex items-center gap-1">
+                    {isZh ? "服务地址" : "Service Address"}
+                    <TooltipProvider delayDuration={120}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="inline-flex cursor-help text-slate-400 hover:text-slate-600"
+                            aria-label={
+                              isZh
+                                ? "主机来自与该网关的实际连接地址；端口为网关自行上报的服务端口，两者拼接而成"
+                                : "Host is the real connection address to this gateway; port is self-reported by the gateway"
+                            }
+                          >
+                            <Info className="h-3.5 w-3.5" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {isZh
+                            ? "主机来自与该网关的实际连接地址；端口为网关自行上报的服务端口，两者拼接而成"
+                            : "Host is the real connection address to this gateway; port is self-reported by the gateway"}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </span>
+                </th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "网关版本" : "Gateway Version"}</th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "配置版本" : "Config Version"}</th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "连接时间" : "Connected At"}</th>
@@ -109,8 +149,9 @@ export default function NodesPage() {
                     </span>
                   </td>
                   <td className="px-3 py-2">{n.hostname || "-"}</td>
-                  <td className="px-3 py-2 font-mono text-xs">{formatAddressHost(n.remote_addr) || "-"}</td>
-                  <td className="px-3 py-2 font-mono text-xs">{n.service_port || "-"}</td>
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {formatServiceAddress(n.remote_addr, n.service_port)}
+                  </td>
                   <td className="px-3 py-2">{n.app_version || "-"}</td>
                   <td className="px-3 py-2">{n.applied_version}</td>
                   <td className="px-3 py-2">{formatConnectedAt(n.connected_at, isZh)}</td>


### PR DESCRIPTION
Align gateway/admin CLI flag names with their concepts (--listen,
--config-file/--config-server, --config-listen) and replace
--storage/--db-dsn with a single scheme-prefixed --dsn (sqlite://,
postgres://, mysql://), parsed via a new bootstrap.ParseDSN. Pre-release
breaking rename, no back-compat aliases, matching the repo's existing
destructive-migration convention.