### PR TITLE
feat(go/configsync): add mTLS to the config-sync gRPC channel

### DIFF
--- a/go/cmd/admin/admin.go
+++ b/go/cmd/admin/admin.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/nyroway/nyro/go/internal/admin"
 	"github.com/nyroway/nyro/go/internal/bootstrap"
 	"github.com/nyroway/nyro/go/internal/configsync"
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
 	"github.com/nyroway/nyro/go/internal/observability"
 	"github.com/nyroway/nyro/go/internal/observability/parquet"
 	"github.com/nyroway/nyro/go/internal/storage"
@@ -55,13 +57,15 @@ func NewCmd() *cobra.Command {
 		Short: "Run the control plane (management API + WebUI)",
 	}
 	cmd.Flags().String("listen", "127.0.0.1:19531", "listen address for the control plane")
-	// Bound to loopback by default: this stream carries every upstream's
-	// credentials_json in the clear (no TLS, no auth — see internal/configsync)
-	// to any client that connects and subscribes. Defaulting it on (rather than
-	// disabled) makes admin+gateway on the same host work with zero flags;
-	// exposing it beyond loopback is a deliberate opt-in via an explicit
-	// --config-listen, not something a default should do for you.
+	// Bound to loopback by default. This stream carries every upstream's
+	// credentials_json — it always requires either mTLS (--config-tls-ca/
+	// -cert/-key, see internal/configsync/pki) or an explicit, no-implicit-
+	// default-allowed --config-insecure opt-in; see the RunE gating below.
 	cmd.Flags().String("config-listen", "127.0.0.1:19532", "listen address for the config-sync gRPC server (empty disables it)")
+	cmd.Flags().String("config-tls-ca", "", "config-sync mTLS: path to the CA certificate that signs admin/gateway leaf certs (see `nyro ca`); must be set together with --config-tls-cert/-key")
+	cmd.Flags().String("config-tls-cert", "", "config-sync mTLS: path to admin's server certificate")
+	cmd.Flags().String("config-tls-key", "", "config-sync mTLS: path to admin's server private key")
+	cmd.Flags().Bool("config-insecure", false, "run the config-sync gRPC server in plaintext with no --config-tls-*; DANGEROUS — the stream carries upstream credentials in the clear to any client that connects, regardless of --config-listen's address")
 	cmd.Flags().String("token", "", "Bearer token protecting /api/v1 admin routes")
 	cmd.Flags().String("webui-dir", "", "path to the built WebUI (serves the SPA at /)")
 	cmd.Flags().String("dsn", "", fmt.Sprintf("database DSN: sqlite://<path> (default %s), postgres://..., or mysql://...", defaultDSN()))
@@ -69,10 +73,23 @@ func NewCmd() *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		addr, _ := cmd.Flags().GetString("listen")
 		grpcAddr, _ := cmd.Flags().GetString("config-listen")
+		tlsCA, _ := cmd.Flags().GetString("config-tls-ca")
+		tlsCert, _ := cmd.Flags().GetString("config-tls-cert")
+		tlsKey, _ := cmd.Flags().GetString("config-tls-key")
+		insecure, _ := cmd.Flags().GetBool("config-insecure")
 		adminToken, _ := cmd.Flags().GetString("token")
 		webuiDir, _ := cmd.Flags().GetString("webui-dir")
 		dsn, _ := cmd.Flags().GetString("dsn")
 		obsDataDir, _ := cmd.Flags().GetString("obs-data-dir")
+
+		var configTLS *tls.Config
+		if grpcAddr != "" {
+			var err error
+			configTLS, err = resolveConfigSyncServerTLS(tlsCA, tlsCert, tlsKey, insecure)
+			if err != nil {
+				return err
+			}
+		}
 
 		usingDefaultDSN := dsn == ""
 		if usingDefaultDSN {
@@ -165,13 +182,17 @@ func NewCmd() *cobra.Command {
 		// gateways.
 		if grpcAddr != "" {
 			srv := configsync.NewConfigServer(st)
-			shutdown, err := configsync.ServeGRPC(ctx, grpcAddr, srv)
+			shutdown, err := configsync.ServeGRPC(ctx, grpcAddr, srv, configTLS)
 			if err != nil {
 				return err
 			}
 			defer shutdown()
 			admin.SetBroadcaster(srv)
 			admin.SetNodeLister(srv)
+			pki.WatchExpiry(ctx, configTLS, configExpiryCheckInterval, func(notAfter time.Time) {
+				slog.Warn("config-sync server certificate expiring soon — run `nyro ca sign-admin` and redistribute before it lapses",
+					"not_after", notAfter, "remaining", time.Until(notAfter).Round(time.Hour))
+			})
 		}
 
 		engine := chi.NewRouter()
@@ -198,6 +219,46 @@ func NewCmd() *cobra.Command {
 		return bootstrap.RunServer(engine, addr)
 	}
 	return cmd
+}
+
+// configExpiryCheckInterval is how often WatchExpiry re-checks the loaded
+// config-sync certificate once running (it always checks once immediately
+// at startup too). Daily is frequent enough given the ExpiryWarningWindow is
+// 30 days — see pki.WatchExpiry.
+const configExpiryCheckInterval = 24 * time.Hour
+
+// resolveConfigSyncServerTLS turns the --config-tls-ca/-cert/-key +
+// --config-insecure flags into a *tls.Config for the config-sync gRPC
+// server, or nil for plaintext (Tier 0). See the design note on
+// --config-listen above: there is no address-based default here, only these
+// flags decide.
+//
+//   - All three tls paths set: mTLS is used regardless of --config-insecure
+//     (certificates present always win).
+//   - Some but not all three set: a partial/likely-typo'd configuration —
+//     fail fast rather than silently falling back to plaintext or guessing
+//     which file is missing.
+//   - None set: requires explicit --config-insecure to proceed; otherwise
+//     refuses to start. When --config-insecure is used, a risk warning is
+//     always logged (independent of --config-listen's address).
+func resolveConfigSyncServerTLS(caPath, certPath, keyPath string, insecure bool) (*tls.Config, error) {
+	set := 0
+	for _, p := range []string{caPath, certPath, keyPath} {
+		if p != "" {
+			set++
+		}
+	}
+	switch {
+	case set == 3:
+		return pki.LoadServerTLS(caPath, certPath, keyPath)
+	case set > 0:
+		return nil, fmt.Errorf("--config-tls-ca, --config-tls-cert, and --config-tls-key must be set together (got %d of 3)", set)
+	case insecure:
+		slog.Warn("config-sync gRPC server running in plaintext (--config-insecure): no transport encryption or client authentication — the stream carries upstream credentials in the clear to any client that connects")
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("config-sync gRPC server requires --config-tls-ca/-cert/-key (see `nyro ca`), or pass --config-insecure to explicitly accept plaintext")
+	}
 }
 
 // legacyObsSignalSinkKeys are the deprecated per-signal sink keys, superseded

--- a/go/cmd/admin/configtls_test.go
+++ b/go/cmd/admin/configtls_test.go
@@ -1,0 +1,75 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+)
+
+func TestResolveConfigSyncServerTLS_NoFlagsRefuses(t *testing.T) {
+	_, err := resolveConfigSyncServerTLS("", "", "", false)
+	if err == nil {
+		t.Fatal("expected an error when no certs and no --config-insecure are given")
+	}
+}
+
+func TestResolveConfigSyncServerTLS_InsecureAllowsPlaintext(t *testing.T) {
+	cfg, err := resolveConfigSyncServerTLS("", "", "", true)
+	if err != nil {
+		t.Fatalf("resolveConfigSyncServerTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected a nil *tls.Config for the plaintext Tier 0 path")
+	}
+}
+
+func TestResolveConfigSyncServerTLS_PartialFlagsRejected(t *testing.T) {
+	if _, err := resolveConfigSyncServerTLS("ca.pem", "", "", false); err == nil {
+		t.Fatal("expected an error when only --config-tls-ca is set")
+	}
+	if _, err := resolveConfigSyncServerTLS("ca.pem", "cert.pem", "", true); err == nil {
+		t.Fatal("expected an error for a partial tls flag set even with --config-insecure also set")
+	}
+}
+
+func TestResolveConfigSyncServerTLS_AllThreeLoadsMTLS(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := pki.EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, keyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := dir + "/ca.pem"
+
+	cfg, err := resolveConfigSyncServerTLS(caPath, certPath, keyPath, false)
+	if err != nil {
+		t.Fatalf("resolveConfigSyncServerTLS: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected a non-nil *tls.Config when all three cert paths are given")
+	}
+}
+
+// TestRunE_RefusesConfigSyncWithoutCertsOrInsecure proves the CLI gate fires
+// before any storage/listener work — this is the default `nyro admin`
+// invocation (config-listen defaults to 127.0.0.1:19532) with no
+// --config-tls-* and no --config-insecure, which must now fail fast rather
+// than silently starting config-sync in plaintext.
+func TestRunE_RefusesConfigSyncWithoutCertsOrInsecure(t *testing.T) {
+	cmd := NewCmd()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error; config-sync defaults to enabled with no certs and no --config-insecure")
+	}
+	if !strings.Contains(err.Error(), "config-insecure") {
+		t.Errorf("error = %q; want it to mention --config-insecure", err.Error())
+	}
+}

--- a/go/cmd/ca/ca.go
+++ b/go/cmd/ca/ca.go
@@ -69,9 +69,9 @@ func newInitCmd() *cobra.Command {
 			return err
 		}
 		if existed {
-			fmt.Fprintf(cmd.OutOrStdout(), "reused existing CA in %s\n", *dir)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "reused existing CA in %s\n", *dir)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "generated new CA in %s (valid %s)\n", *dir, *valid)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "generated new CA in %s (valid %s)\n", *dir, *valid)
 		}
 		return nil
 	}
@@ -93,7 +93,7 @@ func newSignAdminCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (identity: spiffe://nyro/%s)\n", certPath, keyPath, pki.AdminSPIFFEID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (identity: spiffe://nyro/%s)\n", certPath, keyPath, pki.AdminSPIFFEID)
 		return nil
 	}
 	return cmd
@@ -123,7 +123,7 @@ func newSignGatewayCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (node-id: %s)\n", certPath, keyPath, id)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (node-id: %s)\n", certPath, keyPath, id)
 		return nil
 	}
 	return cmd

--- a/go/cmd/ca/ca.go
+++ b/go/cmd/ca/ca.go
@@ -1,0 +1,157 @@
+// Package ca implements the `nyro ca` subcommand group: an offline
+// certificate authority for the config-sync mTLS channel between admin
+// (control plane) and gateway (data plane). It never runs online — it's a
+// one-shot CLI for generating a CA and signing leaf certificates that get
+// distributed to admin/gateway hosts and loaded via their
+// --config-tls-ca/-cert/-key flags.
+package ca
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+)
+
+// defaultDir is ~/.nyro/pki, matching the admin control plane's ~/.nyro home
+// convention (see cmd/admin's nyroHomeDir). Falls back to ./.nyro/pki if the
+// OS user home directory can't be resolved.
+func defaultDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".nyro", "pki")
+	}
+	return filepath.Join(home, ".nyro", "pki")
+}
+
+const (
+	defaultCAValid   = 87600 * time.Hour // 10y
+	defaultLeafValid = 8760 * time.Hour  // 1y
+)
+
+// NewCmd builds the `nyro ca` command group.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ca",
+		Short: "Offline certificate authority for config-sync mTLS",
+	}
+	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newSignAdminCmd())
+	cmd.AddCommand(newSignGatewayCmd())
+	return cmd
+}
+
+func newInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create (or reuse) the config-sync CA",
+	}
+	dir := cmd.Flags().String("dir", defaultDir(), "directory to write ca.pem/ca-key.pem into")
+	valid := cmd.Flags().Duration("valid", defaultCAValid, "CA certificate validity period")
+	force := cmd.Flags().Bool("force", false, "regenerate the CA even if one already exists (invalidates all certs it previously signed)")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		if *force {
+			for _, f := range []string{"ca.pem", "ca-key.pem"} {
+				p := filepath.Join(*dir, f)
+				if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("--force: remove existing %s: %w", p, err)
+				}
+			}
+		}
+		existed := caExists(*dir)
+		if _, err := pki.EnsureCA(*dir, *valid); err != nil {
+			return err
+		}
+		if existed {
+			fmt.Fprintf(cmd.OutOrStdout(), "reused existing CA in %s\n", *dir)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "generated new CA in %s (valid %s)\n", *dir, *valid)
+		}
+		return nil
+	}
+	return cmd
+}
+
+func newSignAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign-admin",
+		Short: "Sign admin's config-sync server certificate",
+	}
+	dir := cmd.Flags().String("dir", defaultDir(), "directory containing ca.pem/ca-key.pem (from `nyro ca init`)")
+	valid := cmd.Flags().Duration("valid", defaultLeafValid, "leaf certificate validity period")
+	out := cmd.Flags().String("out", "admin", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		certPath, keyPath, err := signWithCA(*dir, func(c *pki.CA) (string, string, error) {
+			return c.SignServer(*dir, *out, *valid)
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (identity: spiffe://nyro/%s)\n", certPath, keyPath, pki.AdminSPIFFEID)
+		return nil
+	}
+	return cmd
+}
+
+func newSignGatewayCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign-gateway",
+		Short: "Sign a gateway node's config-sync client certificate",
+	}
+	dir := cmd.Flags().String("dir", defaultDir(), "directory containing ca.pem/ca-key.pem (from `nyro ca init`)")
+	nodeID := cmd.Flags().String("node-id", "", "node identity for the SPIFFE SAN (spiffe://nyro/gateway/<node-id>); random if unset")
+	valid := cmd.Flags().Duration("valid", defaultLeafValid, "leaf certificate validity period")
+	out := cmd.Flags().String("out", "gateway", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		id := *nodeID
+		if id == "" {
+			var err error
+			id, err = randomNodeID()
+			if err != nil {
+				return err
+			}
+		}
+		certPath, keyPath, err := signWithCA(*dir, func(c *pki.CA) (string, string, error) {
+			return c.SignClient(*dir, *out, id, *valid)
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (node-id: %s)\n", certPath, keyPath, id)
+		return nil
+	}
+	return cmd
+}
+
+// signWithCA loads the CA at dir (must already exist — created via `nyro ca
+// init`) and runs sign against it.
+func signWithCA(dir string, sign func(*pki.CA) (certPath, keyPath string, err error)) (certPath, keyPath string, err error) {
+	if !caExists(dir) {
+		return "", "", fmt.Errorf("no CA found in %s — run `nyro ca init --dir %s` first", dir, dir)
+	}
+	c, err := pki.LoadCA(dir)
+	if err != nil {
+		return "", "", err
+	}
+	return sign(c)
+}
+
+func caExists(dir string) bool {
+	_, certErr := os.Stat(filepath.Join(dir, "ca.pem"))
+	_, keyErr := os.Stat(filepath.Join(dir, "ca-key.pem"))
+	return certErr == nil && keyErr == nil
+}
+
+func randomNodeID() (string, error) {
+	suffix := make([]byte, 4)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", fmt.Errorf("generate random node-id: %w", err)
+	}
+	return hex.EncodeToString(suffix), nil
+}

--- a/go/cmd/ca/ca_test.go
+++ b/go/cmd/ca/ca_test.go
@@ -1,0 +1,143 @@
+package ca
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+)
+
+func runCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := NewCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestInit_GeneratesCA(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatalf("ca init: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ca.pem")); err != nil {
+		t.Fatalf("ca.pem not written: %v", err)
+	}
+}
+
+func TestInit_ReuseWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	before, err := pki.LoadCA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	after, err := pki.LoadCA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Cert.SerialNumber.Cmp(after.Cert.SerialNumber) != 0 {
+		t.Fatal("expected `ca init` without --force to reuse the existing CA")
+	}
+}
+
+func TestInit_Force(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	before, err := pki.LoadCA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmd(t, "init", "--dir", dir, "--force"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := pki.LoadCA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Cert.SerialNumber.Cmp(after.Cert.SerialNumber) == 0 {
+		t.Fatal("expected --force to regenerate the CA (different serial)")
+	}
+}
+
+func TestSignAdmin_WritesCertWithAdminIdentity(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := runCmd(t, "sign-admin", "--dir", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout == "" {
+		t.Fatal("expected sign-admin to report the identity it signed")
+	}
+	certPath := filepath.Join(dir, "admin.pem")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Fatalf("admin.pem not written: %v", err)
+	}
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pki.VerifyAdminIdentity(cert); err != nil {
+		t.Errorf("VerifyAdminIdentity: %v", err)
+	}
+}
+
+func TestSignAdmin_RequiresExistingCA(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "sign-admin", "--dir", dir); err == nil {
+		t.Fatal("expected error signing without a CA present")
+	}
+}
+
+func TestSignGateway_RandomNodeIDWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := runCmd(t, "sign-gateway", "--dir", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout == "" {
+		t.Fatal("expected sign-gateway to report the generated node-id")
+	}
+	certPath := filepath.Join(dir, "gateway.pem")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Fatalf("gateway.pem not written: %v", err)
+	}
+}
+
+func TestSignGateway_CustomOutName(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmd(t, "sign-gateway", "--dir", dir, "--node-id", "node-a", "--out", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node-a.pem")); err != nil {
+		t.Fatalf("node-a.pem not written: %v", err)
+	}
+}

--- a/go/cmd/gateway/configtls_test.go
+++ b/go/cmd/gateway/configtls_test.go
@@ -1,0 +1,66 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+)
+
+func TestResolveConfigSyncClientTLS_NoFlagsRefuses(t *testing.T) {
+	_, err := resolveConfigSyncClientTLS("", "", "", false)
+	if err == nil {
+		t.Fatal("expected an error when no certs and no --config-insecure are given")
+	}
+}
+
+func TestResolveConfigSyncClientTLS_InsecureAllowsPlaintext(t *testing.T) {
+	cfg, err := resolveConfigSyncClientTLS("", "", "", true)
+	if err != nil {
+		t.Fatalf("resolveConfigSyncClientTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected a nil *tls.Config for the plaintext Tier 0 path")
+	}
+}
+
+func TestResolveConfigSyncClientTLS_PartialFlagsRejected(t *testing.T) {
+	if _, err := resolveConfigSyncClientTLS("ca.pem", "cert.pem", "", true); err == nil {
+		t.Fatal("expected an error for a partial tls flag set even with --config-insecure also set")
+	}
+}
+
+func TestResolveConfigSyncClientTLS_AllThreeLoadsMTLS(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := pki.EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, keyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := dir + "/ca.pem"
+
+	cfg, err := resolveConfigSyncClientTLS(caPath, certPath, keyPath, false)
+	if err != nil {
+		t.Fatalf("resolveConfigSyncClientTLS: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected a non-nil *tls.Config when all three cert paths are given")
+	}
+}
+
+// TestRunE_RefusesConfigServerWithoutCertsOrInsecure proves the gateway CLI
+// gate fires as soon as --config-server is given without --config-tls-* or
+// --config-insecure, before touching the network.
+func TestRunE_RefusesConfigServerWithoutCertsOrInsecure(t *testing.T) {
+	cmd := NewCmd()
+	if err := cmd.ParseFlags([]string{"--config-server", "127.0.0.1:19532"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error when --config-server is set without certs or --config-insecure")
+	}
+}

--- a/go/cmd/gateway/gateway.go
+++ b/go/cmd/gateway/gateway.go
@@ -4,6 +4,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/nyroway/nyro/go/internal/bootstrap"
 	"github.com/nyroway/nyro/go/internal/config"
 	"github.com/nyroway/nyro/go/internal/configsync"
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
 	"github.com/nyroway/nyro/go/internal/observability"
 	"github.com/nyroway/nyro/go/internal/proxy"
 )
@@ -43,10 +45,18 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().String("listen", "0.0.0.0:19530", "listen address for the data plane")
 	cmd.Flags().String("config-file", "", "standalone YAML config file (no admin/DB needed)")
 	cmd.Flags().String("config-server", "", "admin gRPC config-sync endpoint (host:port) for config hot-reload")
+	cmd.Flags().String("config-tls-ca", "", "config-sync mTLS: path to the CA certificate that signs admin/gateway leaf certs (see `nyro ca`); must be set together with --config-tls-cert/-key")
+	cmd.Flags().String("config-tls-cert", "", "config-sync mTLS: path to this gateway's client certificate")
+	cmd.Flags().String("config-tls-key", "", "config-sync mTLS: path to this gateway's client private key")
+	cmd.Flags().Bool("config-insecure", false, "connect to --config-server in plaintext with no --config-tls-*; DANGEROUS — no transport encryption or server authentication, regardless of --config-server's address")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		addr, _ := cmd.Flags().GetString("listen")
 		cfgPath, _ := cmd.Flags().GetString("config-file")
 		configSyncAddr, _ := cmd.Flags().GetString("config-server")
+		tlsCA, _ := cmd.Flags().GetString("config-tls-ca")
+		tlsCert, _ := cmd.Flags().GetString("config-tls-cert")
+		tlsKey, _ := cmd.Flags().GetString("config-tls-key")
+		insecure, _ := cmd.Flags().GetBool("config-insecure")
 
 		if cfgPath == "" && configSyncAddr == "" {
 			return errors.New("exactly one of --config-file or --config-server is required (the legacy DB-poll default was removed in Phase 3)")
@@ -55,10 +65,19 @@ func NewCmd() *cobra.Command {
 			return errors.New("--config-file and --config-server are mutually exclusive (set exactly one)")
 		}
 
+		var configTLS *tls.Config
+		if configSyncAddr != "" {
+			var err error
+			configTLS, err = resolveConfigSyncClientTLS(tlsCA, tlsCert, tlsKey, insecure)
+			if err != nil {
+				return err
+			}
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		gw, stopConfigSync, obsProvider, err := buildGateway(ctx, cfgPath, configSyncAddr, addr)
+		gw, stopConfigSync, obsProvider, err := buildGateway(ctx, cfgPath, configSyncAddr, addr, configTLS)
 		if err != nil {
 			return err
 		}
@@ -84,6 +103,11 @@ func NewCmd() *cobra.Command {
 // shutdownTimeout bounds the OTel provider flush on graceful exit.
 const shutdownTimeout = 5 * time.Second
 
+// configExpiryCheckInterval is how often WatchExpiry re-checks the loaded
+// config-sync client certificate once running (it always checks once
+// immediately at startup too). See pki.WatchExpiry / ExpiryWarningWindow.
+const configExpiryCheckInterval = 24 * time.Hour
+
 // servicePort extracts the port from a host:port listen address for
 // node-visibility reporting. Returns "" (best-effort, never fatal) if addr
 // isn't in host:port form.
@@ -107,7 +131,7 @@ func servicePort(addr string) string {
 // port is used, reported over config-sync as Subscribe.service_port so the
 // admin's node list can show where each gateway actually serves traffic
 // (distinct from the config-sync gRPC connection's ephemeral peer port).
-func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr string) (gw *proxy.Gateway, stopConfigSync func(), obs *observability.ObsProvider, err error) {
+func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr string, configTLS *tls.Config) (gw *proxy.Gateway, stopConfigSync func(), obs *observability.ObsProvider, err error) {
 	switch {
 	case cfgPath != "":
 		// Standalone YAML: build the config snapshot directly (no DB). The
@@ -144,8 +168,12 @@ func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr strin
 		// Observability config is read from the cache snapshot (published by
 		// the admin) once it arrives.
 		cache := &configsync.ConfigCache{}
-		client := configsync.NewConfigClient(configSyncAddr, cache, servicePort(listenAddr))
+		client := configsync.NewConfigClient(configSyncAddr, cache, servicePort(listenAddr), configTLS)
 		go func() { _ = client.Run(ctx) }()
+		pki.WatchExpiry(ctx, configTLS, configExpiryCheckInterval, func(notAfter time.Time) {
+			slog.Warn("config-sync client certificate expiring soon — run `nyro ca sign-gateway` and redistribute before it lapses",
+				"not_after", notAfter, "remaining", time.Until(notAfter).Round(time.Hour))
+		})
 		gw = proxy.NewGatewayWithCache(cache)
 
 		// Read obs settings from the cache snapshot when present (the control-
@@ -163,6 +191,37 @@ func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr strin
 	default:
 		// Unreachable: RunE enforces the XOR. Guard anyway.
 		return nil, nil, nil, errors.New("exactly one of --config-file or --config-server is required")
+	}
+}
+
+// resolveConfigSyncClientTLS turns the --config-tls-ca/-cert/-key +
+// --config-insecure flags into a *tls.Config for dialing --config-server, or
+// nil for plaintext (Tier 0). Same all-or-none / explicit-insecure-only
+// gating as resolveConfigSyncServerTLS on the admin side — see that
+// function's doc comment for the rationale.
+//
+// There is deliberately no --config-server-name-style override here:
+// pki.LoadClientTLS verifies admin's server certificate by SPIFFE identity
+// (spiffe://nyro/admin), not by matching its SAN against the dial address,
+// so the address used in --config-server (direct, load balancer, k8s
+// Service name, IP) never affects verification.
+func resolveConfigSyncClientTLS(caPath, certPath, keyPath string, insecure bool) (*tls.Config, error) {
+	set := 0
+	for _, p := range []string{caPath, certPath, keyPath} {
+		if p != "" {
+			set++
+		}
+	}
+	switch {
+	case set == 3:
+		return pki.LoadClientTLS(caPath, certPath, keyPath)
+	case set > 0:
+		return nil, fmt.Errorf("--config-tls-ca, --config-tls-cert, and --config-tls-key must be set together (got %d of 3)", set)
+	case insecure:
+		slog.Warn("config-sync client connecting to --config-server in plaintext (--config-insecure): no transport encryption or server authentication")
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("--config-server requires --config-tls-ca/-cert/-key (see `nyro ca`), or pass --config-insecure to explicitly accept plaintext")
 	}
 }
 

--- a/go/cmd/gateway/gateway_test.go
+++ b/go/cmd/gateway/gateway_test.go
@@ -33,7 +33,7 @@ func TestBuildGateway_ConfigAndConfigSyncAreMutuallyExclusive(t *testing.T) {
 	// NOTE: buildGateway itself does NOT enforce XOR (it picks --config-file when both
 	// are set). The XOR is enforced in the cobra RunE. We exercise it via RunE
 	// below. This test documents that buildGateway picks config when both given.
-	_, _, _, err := buildGateway(context.Background(), "missing.yaml", "localhost:9999", "127.0.0.1:19530")
+	_, _, _, err := buildGateway(context.Background(), "missing.yaml", "localhost:9999", "127.0.0.1:19530", nil)
 	// missing.yaml → file error, proving the config branch was selected.
 	if err == nil {
 		t.Error("expected error selecting config branch with both flags; buildGateway must prefer --config-file")
@@ -82,7 +82,7 @@ consumers:
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gw, stopConfigSync, obs, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530")
+	gw, stopConfigSync, obs, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530", nil)
 	if err != nil {
 		t.Fatalf("buildGateway: %v", err)
 	}
@@ -129,7 +129,7 @@ consumers: []
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530")
+	_, _, _, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530", nil)
 	if err == nil {
 		t.Fatal("expected an error: traces.exporter=otlp declared in YAML with no endpoint must fail fast, proving the YAML setting was read")
 	}
@@ -154,7 +154,7 @@ consumers: []
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, obs, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530")
+	_, _, obs, err := buildGateway(context.Background(), path, "", "127.0.0.1:19530", nil)
 	if err != nil {
 		t.Fatalf("buildGateway: %v (OTEL_* env vars must not be consulted when the YAML declares nothing)", err)
 	}

--- a/go/docs/cutover.md
+++ b/go/docs/cutover.md
@@ -37,13 +37,31 @@ shadow phase).
 
 To hot-reload the gateway's config from the admin instead of a static
 `--config-file` YAML file, enable the admin's config-sync gRPC server and point
-the gateway at it:
+the gateway at it. This channel carries every upstream's `credentials_json`,
+so it always requires either mTLS or an explicit `--config-insecure`
+acknowledgment — see [config-sync mTLS](security/config-sync-mtls.md) for the
+full `nyro ca` workflow. For same-host shadow testing, plaintext + loopback is
+the fastest path:
 
 ```bash
-# control plane, with config-sync enabled:
-/tmp/nyro admin --listen 127.0.0.1:19531 --config-listen 127.0.0.1:19532 --token <token>
+# control plane, with config-sync enabled (loopback, explicitly plaintext):
+/tmp/nyro admin --listen 127.0.0.1:19531 --config-listen 127.0.0.1:19532 --config-insecure --token <token>
 # data plane, subscribing to config-sync instead of --config-file:
-/tmp/nyro gateway --listen 127.0.0.1:19529 --config-server 127.0.0.1:19532
+/tmp/nyro gateway --listen 127.0.0.1:19529 --config-server 127.0.0.1:19532 --config-insecure
+```
+
+For anything crossing a host boundary, sign certificates first and drop
+`--config-insecure` in favor of `--config-tls-ca/-cert/-key`:
+
+```bash
+nyro ca init
+nyro ca sign-admin
+nyro ca sign-gateway --node-id gw-1
+# distribute ca.pem + admin.{pem,key.pem} / gateway.{pem,key.pem}, then:
+/tmp/nyro admin --config-listen 0.0.0.0:19532 \
+  --config-tls-ca ~/.nyro/pki/ca.pem --config-tls-cert ~/.nyro/pki/admin.pem --config-tls-key ~/.nyro/pki/admin-key.pem
+/tmp/nyro gateway --config-server admin.internal:19532 \
+  --config-tls-ca ~/.nyro/pki/ca.pem --config-tls-cert ~/.nyro/pki/gateway.pem --config-tls-key ~/.nyro/pki/gateway-key.pem
 ```
 
 `--config-file` and `--config-server` are mutually exclusive — exactly one must

--- a/go/docs/security/config-sync-mtls.md
+++ b/go/docs/security/config-sync-mtls.md
@@ -1,0 +1,151 @@
+# config-sync mTLS
+
+The config-sync gRPC channel is how admin (control plane) pushes the live
+config snapshot — including every upstream's `credentials_json` — to every
+connected gateway (data plane). It always requires one of:
+
+- **mTLS** (`--config-tls-ca/-cert/-key`, all three together), or
+- **`--config-insecure`**, an explicit, unconditional opt-out of transport
+  security. There is no address-based exemption (not even loopback) — the
+  flag alone decides, matching CockroachDB's `--insecure`/`--certs-dir`
+  model. Passing it always logs a startup warning.
+
+There is no third state and no implicit default: a config-sync listener/dial
+target with no certs and no `--config-insecure` refuses to start.
+
+## The three commands
+
+`nyro ca` is an **offline** certificate authority — it never runs as a
+service. Everything it produces is a plain file you distribute yourself (scp,
+Ansible, a Secret, a Docker volume, whatever fits your deployment).
+
+```bash
+nyro ca init [--dir ~/.nyro/pki] [--valid 87600h] [--force]
+nyro ca sign-admin [--dir ~/.nyro/pki] [--valid 8760h] [--out admin]
+nyro ca sign-gateway [--dir ~/.nyro/pki] [--node-id <id>] [--valid 8760h] [--out gateway]
+```
+
+- `init` creates (or, without `--force`, reuses) the CA: `ca.pem` +
+  `ca-key.pem` in `--dir`.
+- `sign-admin` issues admin's server certificate, with a **fixed identity**
+  encoded as a SPIFFE URI SAN (`spiffe://nyro/admin`) — not a DNS/IP SAN list.
+  There is no `--advertise`-style flag: gateway verifies this certificate by
+  identity, not by matching a hostname it dialed against a SAN list, so the
+  same certificate is valid no matter what address a gateway uses to reach
+  admin (direct, load balancer, Kubernetes Service name, IP — see "Why
+  identity, not hostname" below).
+- `sign-gateway` issues one gateway's client certificate, with its identity
+  encoded as a SPIFFE URI SAN (`spiffe://nyro/gateway/<node-id>`). Run once
+  per gateway node (or once per shared cert if you're intentionally pooling
+  identity across a fleet — see "elastic scaling" below). `--node-id`
+  defaults to a random value if omitted.
+
+All three write fixed filenames — `<out>.pem` / `<out>-key.pem` — into
+`--dir`. That directory is purely `nyro ca`'s own bookkeeping; admin/gateway
+never read it directly (see below).
+
+## Runtime: explicit paths only, no directory auto-discovery
+
+`admin` and `gateway` do **not** know about `nyro ca`'s output directory.
+They only ever load three explicit file paths:
+
+```bash
+admin --config-tls-ca ~/.nyro/pki/ca.pem \
+      --config-tls-cert ~/.nyro/pki/admin.pem \
+      --config-tls-key ~/.nyro/pki/admin-key.pem
+
+gateway --config-tls-ca ~/.nyro/pki/ca.pem \
+        --config-tls-cert ~/.nyro/pki/gateway.pem \
+        --config-tls-key ~/.nyro/pki/gateway-key.pem
+```
+
+All three flags must be given together, or not at all — a partial set (e.g.
+just `--config-tls-cert`) is rejected at startup rather than silently
+guessing at a directory convention for the missing pieces. This keeps the
+loading logic to a single path with no precedence rules to reason about, and
+it means a certificate and its CA can never be silently mismatched from two
+different sources.
+
+The two lifecycles — `nyro ca`'s offline, one-shot signing and admin/gateway's
+long-running runtime load — are deliberately decoupled. In practice you write
+the three paths once into whatever starts the process (systemd unit,
+docker-compose, Helm values), not on every interactive invocation.
+
+### Why identity, not hostname
+
+gateway's config-sync client verifies admin's server certificate by SPIFFE
+identity (`spiffe://nyro/admin`), not by matching a hostname/IP SAN against
+the address in `--config-server` — the classic web-PKI model most CLI tools
+default to. That classic model needs a `--config-server-name`-style escape
+hatch the moment the dial address and the cert's SAN diverge (a load
+balancer, a Kubernetes Service name, an IP dialed against a DNS-only cert),
+and that escape hatch is itself a footgun: it's easy to reach for as "make
+the error go away" and easy to leave silently pointed at the wrong thing
+after a rename.
+
+Identity-based verification sidesteps the whole problem: `--config-server`
+can be a direct address, a load balancer, or a Kubernetes Service name — none
+of it matters, because the check is "does this certificate say
+`spiffe://nyro/admin`", not "does this certificate's SAN match the string I
+dialed". There is deliberately no override flag for this on the gateway side.
+
+## BYO external PKI
+
+`--config-tls-ca/-cert/-key` accept any PEM files — certificates from
+cert-manager, Vault, or another external PKI work identically to `nyro ca`'s
+own output. admin/gateway have no notion of "self-signed vs. external"; it's
+just three file paths either way.
+
+## Four scenarios
+
+**Same host** (shadow testing, local dev): skip PKI entirely.
+
+```bash
+admin --config-listen 127.0.0.1:19532 --config-insecure
+gateway --config-server 127.0.0.1:19532 --config-insecure
+```
+
+**Cross-host, self-signed**: run the three `nyro ca` commands once (from CI or
+an operator's machine), distribute `ca.pem` + the relevant leaf cert/key pair
+to each host, then start both processes with the three `--config-tls-*` flags
+pointed at the distributed files.
+
+**BYO external PKI**: point `--config-tls-ca/-cert/-key` at cert-manager- or
+Vault-issued files directly.
+
+**Elastic scaling (containers/k8s)**: `ca.pem` is safe to bake into the image
+(it's a public certificate, not a secret). `gateway.pem`/`gateway-key.pem`
+should **not** — mount them via a Kubernetes Secret (`items`/`subPath` to
+rename into whatever path your command line expects), or use cert-manager to
+issue a fresh per-pod certificate on scheduling. Either way, the private key
+never lands in the image layer.
+
+## Certificate lifetime and rotation
+
+- CA: 10 years by default (`nyro ca init --valid`).
+- Leaf certificates (admin/gateway): 1 year by default (`--valid` on
+  `sign-admin`/`sign-gateway`).
+- Rotation is manual and offline: re-run the relevant `sign-*` command,
+  redistribute the new cert/key, restart the process. There is no online
+  enrollment or auto-renewal (see "Non-goals" below).
+- Because rotation is manual, admin/gateway log a startup **and** daily
+  warning once a loaded leaf certificate is within 30 days of expiring
+  (`pki.ExpiryWarningWindow`). Watch for `"certificate expiring soon"` in
+  logs — an expired certificate doesn't crash the process, it just makes the
+  mTLS handshake fail, silently stalling config-sync until it's renewed.
+
+## Non-goals (by design)
+
+- **No bearer token / API key on this channel.** Node identity comes from
+  the client certificate's SPIFFE SAN, not a shared secret.
+- **No online enrollment service.** Provisioning new gateway certs at scale
+  is cert-manager's/SPIRE's job, not something nyro re-implements.
+- **No CRL/OCSP revocation.** If a certificate needs to be revoked before its
+  natural expiry, rotate the CA (`nyro ca init --force`) and re-sign
+  everything — there's no partial-revocation mechanism. Short leaf TTLs (the
+  1-year default, or shorter if you set `--valid` tighter) are the mitigation
+  for a lost/compromised leaf key.
+
+A future iteration could add online enrollment (short-lived tokens exchanged
+for certs) if fleet size makes offline signing impractical — deliberately out
+of scope for now.

--- a/go/internal/configsync/client.go
+++ b/go/internal/configsync/client.go
@@ -3,6 +3,7 @@ package configsync
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"log"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	pb "github.com/nyroway/nyro/go/internal/configsync/pb/configsync/v1"
@@ -49,7 +51,18 @@ type ConfigClient struct {
 // publishes received snapshots to cache. servicePort is this gateway's own
 // data-plane listen port (for node-visibility reporting only — pass "" if
 // unknown/not applicable, e.g. in tests).
-func NewConfigClient(target string, cache *ConfigCache, servicePort string) *ConfigClient {
+//
+// tlsConfig is nil for the plaintext Tier 0 (--config-insecure); when set
+// (see pki.LoadClientTLS), the client authenticates itself to admin with a
+// client certificate and verifies admin's server certificate against the
+// configured CA. Callers are responsible for the --config-insecure gating
+// decision (whether nil is actually allowed here) — this constructor just
+// dials with whatever credentials it's given.
+func NewConfigClient(target string, cache *ConfigCache, servicePort string, tlsConfig *tls.Config) *ConfigClient {
+	creds := insecure.NewCredentials()
+	if tlsConfig != nil {
+		creds = credentials.NewTLS(tlsConfig)
+	}
 	return &ConfigClient{
 		target:         target,
 		cache:          cache,
@@ -60,7 +73,7 @@ func NewConfigClient(target string, cache *ConfigCache, servicePort string) *Con
 		initialBackoff: 500 * time.Millisecond,
 		maxBackoff:     30 * time.Second,
 		dialOpts: []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithTransportCredentials(creds),
 		},
 	}
 }
@@ -182,7 +195,13 @@ func (c *ConfigClient) backoff(attempt int) time.Duration {
 // ServeGRPC starts a gRPC server listening on addr serving srv. It blocks until
 // the listener returns (always in a goroutine for ctx-driven shutdown). The
 // returned shutdown function stops the server gracefully.
-func ServeGRPC(ctx context.Context, addr string, srv pb.ConfigServiceServer) (shutdown func(), err error) {
+//
+// tlsConfig is nil for the plaintext Tier 0 (--config-insecure); when set, it
+// must require and verify client certificates (see pki.LoadServerTLS) — the
+// gateway's node identity is then derived from the verified client
+// certificate's SPIFFE SAN rather than trusted from Subscribe.node_id (see
+// StreamConfig).
+func ServeGRPC(ctx context.Context, addr string, srv pb.ConfigServiceServer, tlsConfig *tls.Config) (shutdown func(), err error) {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		// If the address looks like it lacks a port, surface a clearer error.
@@ -191,7 +210,11 @@ func ServeGRPC(ctx context.Context, addr string, srv pb.ConfigServiceServer) (sh
 		}
 		return nil, err
 	}
-	gs := grpc.NewServer()
+	var opts []grpc.ServerOption
+	if tlsConfig != nil {
+		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+	}
+	gs := grpc.NewServer(opts...)
 	pb.RegisterConfigServiceServer(gs, srv)
 	go func() {
 		<-ctx.Done()

--- a/go/internal/configsync/client_mtls_test.go
+++ b/go/internal/configsync/client_mtls_test.go
@@ -1,0 +1,97 @@
+package configsync
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/nyroway/nyro/go/internal/configsync/pb/configsync/v1"
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+	"github.com/nyroway/nyro/go/internal/storage/memory"
+)
+
+// bufconnMTLSDialer starts an mTLS-secured ConfigServer behind bufconn and
+// returns a plain (non-credentialed) DialOption for reaching it — the caller
+// still has to supply transport credentials via ConfigClient.dialOpts,
+// exactly like a real gateway would via NewConfigClient's tlsConfig param.
+func bufconnMTLSDialer(t *testing.T, store *memory.Backend, fx mtlsFixture) (dialOpt grpc.DialOption, teardown func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	serverTLS, err := pki.LoadServerTLS(fx.caPath, fx.serverCertPath, fx.serverKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewConfigServer(store.Storage())
+	gs := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
+	pb.RegisterConfigServiceServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	dialOpt = grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	})
+	return dialOpt, gs.GracefulStop
+}
+
+func TestConfigClient_MTLS_ReceivesOverSecureChannel(t *testing.T) {
+	st, _, rOpen, _, _, _ := newPopulatedStorage(t)
+	fx := newMTLSFixture(t)
+	dialOpt, stop := bufconnMTLSDialer(t, st, fx)
+	defer stop()
+
+	clientTLS, err := pki.LoadClientTLS(fx.caPath, fx.clientCertPath, fx.clientKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := &ConfigCache{}
+	c := NewConfigClient("passthrough:///bufnet", cache, "19530", clientTLS)
+	c.initialBackoff = 20 * time.Millisecond
+	c.maxBackoff = 100 * time.Millisecond
+	c.dialOpts = []grpc.DialOption{dialOpt, grpc.WithTransportCredentials(credentials.NewTLS(clientTLS))}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = c.Run(ctx) }()
+
+	waitFor(t, 2*time.Second, func() bool {
+		return cache.Ready() && cache.Load().RouteByModel(rOpen.Model) != nil
+	})
+}
+
+func TestConfigClient_MTLS_WrongCARejected(t *testing.T) {
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	fx := newMTLSFixture(t)
+	dialOpt, stop := bufconnMTLSDialer(t, st, fx)
+	defer stop()
+
+	otherDir := t.TempDir()
+	// A second, unrelated CA that did NOT sign admin's server cert. The
+	// client below trusts only this CA, so it must reject admin's server
+	// certificate during the TLS handshake.
+	if _, err := pki.EnsureCA(otherDir, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	wrongCAPath := filepath.Join(otherDir, "ca.pem")
+
+	clientTLS, err := pki.LoadClientTLS(wrongCAPath, fx.clientCertPath, fx.clientKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := &ConfigCache{}
+	c := NewConfigClient("passthrough:///bufnet", cache, "19530", clientTLS)
+	c.initialBackoff = 20 * time.Millisecond
+	c.maxBackoff = 50 * time.Millisecond
+	c.dialOpts = []grpc.DialOption{dialOpt, grpc.WithTransportCredentials(credentials.NewTLS(clientTLS))}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = c.Run(ctx)
+
+	if cache.Ready() {
+		t.Fatal("expected cache to remain unfilled when the server cert isn't trusted")
+	}
+}

--- a/go/internal/configsync/client_test.go
+++ b/go/internal/configsync/client_test.go
@@ -13,7 +13,7 @@ import (
 
 // newClient builds a ConfigClient pointed at the bufconn env via dialOpts.
 func newClient(cache *ConfigCache, dialOpt grpc.DialOption) *ConfigClient {
-	c := NewConfigClient("passthrough:///bufnet", cache, "19530")
+	c := NewConfigClient("passthrough:///bufnet", cache, "19530", nil)
 	c.initialBackoff = 20 * time.Millisecond
 	c.maxBackoff = 100 * time.Millisecond
 	c.dialOpts = []grpc.DialOption{

--- a/go/internal/configsync/pki/ca.go
+++ b/go/internal/configsync/pki/ca.go
@@ -1,0 +1,150 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	caCertFile = "ca.pem"
+	caKeyFile  = "ca-key.pem"
+
+	dirPerm  = 0o700
+	filePerm = 0o600
+)
+
+// CA is a loaded (or freshly generated) certificate authority: its
+// certificate (used to build trust chains / ClientCAs / RootCAs pools) and
+// private key (used to sign leaf certificates). The private key is only ever
+// needed by the offline `nyro ca sign-*` commands, never by admin/gateway at
+// runtime.
+type CA struct {
+	Cert *x509.Certificate
+	Key  *ecdsa.PrivateKey
+
+	// certPEM is the PEM encoding of Cert, cached so signers don't need to
+	// re-marshal it for every leaf certificate they issue.
+	certPEM []byte
+}
+
+// EnsureCA loads the CA at dir if both ca.pem and ca-key.pem already exist,
+// or generates a fresh self-signed CA (valid for ttl) and writes it there
+// otherwise. dir is created (0700) if missing; files are written 0600.
+func EnsureCA(dir string, ttl time.Duration) (*CA, error) {
+	certPath := filepath.Join(dir, caCertFile)
+	keyPath := filepath.Join(dir, caKeyFile)
+
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	switch {
+	case certErr == nil && keyErr == nil:
+		return LoadCA(dir)
+	case certErr != nil && keyErr != nil:
+		return generateCA(dir, ttl)
+	default:
+		// One file present without the other is an inconsistent/corrupt
+		// state we should never silently paper over.
+		return nil, fmt.Errorf("pki: incomplete CA at %s (one of ca.pem/ca-key.pem missing)", dir)
+	}
+}
+
+// LoadCA loads an existing CA from dir. Returns an error if either file is
+// missing or invalid.
+func LoadCA(dir string) (*CA, error) {
+	certPath := filepath.Join(dir, caCertFile)
+	keyPath := filepath.Join(dir, caKeyFile)
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("pki: read CA cert: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("pki: read CA key: %w", err)
+	}
+
+	cert, err := parseCertPEM(certPEM)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse CA cert: %w", err)
+	}
+	key, err := parseECKeyPEM(keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse CA key: %w", err)
+	}
+	if !cert.IsCA {
+		return nil, errors.New("pki: ca.pem is not a CA certificate")
+	}
+	return &CA{Cert: cert, Key: key, certPEM: certPEM}, nil
+}
+
+// generateCA creates a fresh self-signed CA, writes it to dir, and returns it.
+func generateCA(dir string, ttl time.Duration) (*CA, error) {
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return nil, fmt.Errorf("pki: create dir %s: %w", dir, err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("pki: generate CA key: %w", err)
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "nyro config-sync CA"},
+		NotBefore:             now.Add(-5 * time.Minute), // small backdate to tolerate clock skew
+		NotAfter:              now.Add(ttl),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("pki: create CA certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse generated CA certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM, err := encodeECKeyPEM(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, caCertFile), certPEM, filePerm); err != nil {
+		return nil, fmt.Errorf("pki: write ca.pem: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, caKeyFile), keyPEM, filePerm); err != nil {
+		return nil, fmt.Errorf("pki: write ca-key.pem: %w", err)
+	}
+
+	return &CA{Cert: cert, Key: key, certPEM: certPEM}, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("pki: generate serial number: %w", err)
+	}
+	return serial, nil
+}

--- a/go/internal/configsync/pki/doc.go
+++ b/go/internal/configsync/pki/doc.go
@@ -1,0 +1,16 @@
+// Package pki provides the offline certificate authority and TLS config
+// construction used to secure the config-sync gRPC channel between admin
+// (control plane) and gateway (data plane) nodes.
+//
+// The trust model is a single self-signed CA per deployment (or an external
+// BYO PKI producing files in the same shape): the CA signs a server leaf
+// certificate for admin (DNS/IP SANs from --advertise) and a client leaf
+// certificate per gateway (a SPIFFE URI SAN carrying the node identity,
+// spiffe://nyro/gateway/<node-id>). admin/gateway load these at runtime via
+// LoadServerTLS/LoadClientTLS from three explicit file paths — there is no
+// directory-scanning or auto-discovery at runtime; only the offline `nyro ca`
+// commands write to a conventional directory.
+//
+// Everything in this package is pure (reads/writes only the paths passed in)
+// so it is fully unit-testable without a running server.
+package pki

--- a/go/internal/configsync/pki/expiry.go
+++ b/go/internal/configsync/pki/expiry.go
@@ -1,0 +1,77 @@
+package pki
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"time"
+)
+
+// ExpiryWarningWindow is how far ahead of a leaf certificate's expiry
+// admin/gateway should start logging a renewal warning. Certificates here
+// are offline-signed and manually rotated (see nyro ca sign-*); nothing
+// renews them automatically, so operators need advance notice before the
+// config-sync channel silently stops working.
+const ExpiryWarningWindow = 30 * 24 * time.Hour
+
+// LeafNotAfter returns the NotAfter time of a loaded TLS certificate's leaf
+// (the first certificate in the chain, i.e. the one LoadServerTLS/
+// LoadClientTLS presented for this node — not the CA).
+func LeafNotAfter(cert tls.Certificate) (time.Time, error) {
+	if len(cert.Certificate) == 0 {
+		return time.Time{}, fmt.Errorf("pki: tls.Certificate has no leaf")
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("pki: parse leaf certificate: %w", err)
+	}
+	return leaf.NotAfter, nil
+}
+
+// ExpiringSoon reports whether notAfter is within ExpiryWarningWindow of now
+// (or already past).
+func ExpiringSoon(notAfter, now time.Time) bool {
+	return notAfter.Sub(now) <= ExpiryWarningWindow
+}
+
+// WatchExpiry checks every leaf certificate in cfg immediately, then again
+// every interval until ctx is cancelled, invoking warn(notAfter) for each one
+// that's within ExpiryWarningWindow of expiring. These certificates are
+// offline-signed and manually rotated (see nyro ca sign-*) — nothing renews
+// them — so this is the only mechanism that gives an operator advance notice
+// before the config-sync channel silently stops working. A nil cfg (Tier 0,
+// --config-insecure) is a no-op: there's nothing to expire.
+//
+// warn is called synchronously from the goroutine WatchExpiry starts;
+// callers needing more than a log line should keep it fast and non-blocking.
+func WatchExpiry(ctx context.Context, cfg *tls.Config, interval time.Duration, warn func(notAfter time.Time)) {
+	if cfg == nil {
+		return
+	}
+	check := func() {
+		now := time.Now()
+		for _, cert := range cfg.Certificates {
+			notAfter, err := LeafNotAfter(cert)
+			if err != nil {
+				continue
+			}
+			if ExpiringSoon(notAfter, now) {
+				warn(notAfter)
+			}
+		}
+	}
+	check()
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				check()
+			}
+		}
+	}()
+}

--- a/go/internal/configsync/pki/identity.go
+++ b/go/internal/configsync/pki/identity.go
@@ -1,0 +1,65 @@
+package pki
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+)
+
+// AdminSPIFFEID is the fixed identity every admin server certificate carries
+// (spiffe://nyro/admin) and the identity gateway's config-sync client
+// verifies admin's server certificate against — see VerifyAdminIdentity.
+// Unlike gateway identities, it does not vary per instance: config-sync has
+// exactly one logical admin peer, and pinning it to a constant means
+// verification is fully decoupled from network topology (LB, k8s Service
+// name, IP, hostname — none of it matters, only the identity in the cert
+// does), so there is no --config-server-name-style override to maintain.
+const AdminSPIFFEID = "admin"
+
+// identityFromCert extracts the raw path (minus leading slash) from cert's
+// spiffe://<trust-domain>/... URI SAN, e.g. "admin" or "gateway/<node-id>".
+// Returns an error if cert carries no such SAN.
+func identityFromCert(cert *x509.Certificate) (string, error) {
+	for _, u := range cert.URIs {
+		if u.Scheme != "spiffe" || u.Host != spiffeTrustDomain {
+			continue
+		}
+		id := strings.TrimPrefix(u.Path, "/")
+		if id == "" {
+			continue
+		}
+		return id, nil
+	}
+	return "", fmt.Errorf("pki: certificate %q has no spiffe://%s/... URI SAN", cert.Subject.CommonName, spiffeTrustDomain)
+}
+
+// GatewayNodeIDFromCert extracts the node identity from a gateway's client
+// certificate's SPIFFE URI SAN (spiffe://nyro/gateway/<node-id>), returning
+// just the <node-id> segment — the same shape as the gateway's
+// self-reported node_id, so callers can substitute one for the other
+// transparently. Returns an error if cert carries no spiffe:// URI SAN under
+// the expected gateway path shape.
+func GatewayNodeIDFromCert(cert *x509.Certificate) (string, error) {
+	id, err := identityFromCert(cert)
+	if err != nil {
+		return "", err
+	}
+	nodeID, ok := strings.CutPrefix(id, "gateway/")
+	if !ok || nodeID == "" {
+		return "", fmt.Errorf("pki: certificate %q identity %q is not a spiffe://%s/gateway/<node-id> SAN", cert.Subject.CommonName, id, spiffeTrustDomain)
+	}
+	return nodeID, nil
+}
+
+// VerifyAdminIdentity reports whether cert's SPIFFE URI SAN identifies it as
+// admin (spiffe://nyro/admin) — see AdminSPIFFEID.
+func VerifyAdminIdentity(cert *x509.Certificate) error {
+	id, err := identityFromCert(cert)
+	if err != nil {
+		return err
+	}
+	if id != AdminSPIFFEID {
+		return fmt.Errorf("pki: certificate %q identity is %q, want %q", cert.Subject.CommonName, id, AdminSPIFFEID)
+	}
+	return nil
+}

--- a/go/internal/configsync/pki/pem.go
+++ b/go/internal/configsync/pki/pem.go
@@ -1,0 +1,52 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+func parseCertPEM(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("pki: expected a CERTIFICATE PEM block")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func parseECKeyPEM(data []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("pki: no PEM block found for private key")
+	}
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		ecKey, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("pki: private key is not ECDSA (got %T)", key)
+		}
+		return ecKey, nil
+	default:
+		return nil, fmt.Errorf("pki: unsupported private key PEM block type %q", block.Type)
+	}
+}
+
+func encodeECKeyPEM(key *ecdsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("pki: marshal private key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
+}
+
+func encodeCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}

--- a/go/internal/configsync/pki/pki_test.go
+++ b/go/internal/configsync/pki/pki_test.go
@@ -1,0 +1,408 @@
+package pki
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEnsureCA_GeneratesThenReloads(t *testing.T) {
+	dir := t.TempDir()
+
+	ca1, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatalf("EnsureCA (generate): %v", err)
+	}
+	if !ca1.Cert.IsCA {
+		t.Fatalf("generated cert is not a CA")
+	}
+	for _, f := range []string{caCertFile, caKeyFile} {
+		info, err := os.Stat(filepath.Join(dir, f))
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", f, err)
+		}
+		if info.Mode().Perm() != filePerm {
+			t.Fatalf("%s perm = %v, want %v", f, info.Mode().Perm(), filePerm)
+		}
+	}
+
+	ca2, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatalf("EnsureCA (reload): %v", err)
+	}
+	if ca1.Cert.SerialNumber.Cmp(ca2.Cert.SerialNumber) != 0 {
+		t.Fatalf("EnsureCA regenerated instead of reloading existing CA")
+	}
+}
+
+func TestEnsureCA_IncompletePairErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, caCertFile), []byte("not a real cert"), filePerm); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureCA(dir, time.Hour); err == nil {
+		t.Fatal("expected error for incomplete CA pair, got nil")
+	}
+}
+
+func TestSignServer_AdminIdentity(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath, keyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	if err != nil {
+		t.Fatalf("SignServer: %v", err)
+	}
+
+	cert, err := loadLeafCert(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyAdminIdentity(cert); err != nil {
+		t.Errorf("VerifyAdminIdentity: %v", err)
+	}
+	if got := cert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageServerAuth {
+		t.Errorf("ExtKeyUsage = %v, want [ServerAuth]", got)
+	}
+
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key file missing: %v", err)
+	}
+}
+
+func TestSignClient_SPIFFESAN(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath, _, err := ca.SignClient(dir, "gateway", "node-abcd", time.Hour)
+	if err != nil {
+		t.Fatalf("SignClient: %v", err)
+	}
+	cert, err := loadLeafCert(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := GatewayNodeIDFromCert(cert)
+	if err != nil {
+		t.Fatalf("GatewayNodeIDFromCert: %v", err)
+	}
+	if id != "node-abcd" {
+		t.Errorf("identity = %q, want %q", id, "node-abcd")
+	}
+	if got := cert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageClientAuth {
+		t.Errorf("ExtKeyUsage = %v, want [ClientAuth]", got)
+	}
+	if err := VerifyAdminIdentity(cert); err == nil {
+		t.Fatal("expected a gateway client cert to fail VerifyAdminIdentity")
+	}
+}
+
+func TestGatewayNodeIDFromCert_RejectsAdminCert(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, _, err := ca.SignServer(dir, "admin", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := loadLeafCert(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := GatewayNodeIDFromCert(cert); err == nil {
+		t.Fatal("expected error extracting a gateway node-id from admin's own certificate")
+	}
+}
+
+// TestMTLSRoundTrip exercises LoadServerTLS/LoadClientTLS end-to-end over a
+// real TCP loopback listener: a server presenting an admin cert requiring
+// client certs, and three client dial attempts (matching CA + cert, wrong
+// CA, no cert) to confirm accept/reject behavior.
+func TestMTLSRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCertPath, serverKeyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, caCertFile)
+
+	serverTLS, err := LoadServerTLS(caPath, serverCertPath, serverKeyPath)
+	if err != nil {
+		t.Fatalf("LoadServerTLS: %v", err)
+	}
+
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer lis.Close()
+
+	acceptOnce := func() <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			conn, err := lis.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer conn.Close()
+			tlsConn, ok := conn.(*tls.Conn)
+			if !ok {
+				errCh <- nil
+				return
+			}
+			errCh <- tlsConn.Handshake()
+		}()
+		return errCh
+	}
+
+	t.Run("valid client cert succeeds", func(t *testing.T) {
+		errCh := acceptOnce()
+		clientTLS, err := LoadClientTLS(caPath, clientCertPath, clientKeyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn, err := tls.Dial("tcp", lis.Addr().String(), clientTLS)
+		if err != nil {
+			t.Fatalf("client dial: %v", err)
+		}
+		conn.Close()
+		if err := <-errCh; err != nil {
+			t.Fatalf("server-side handshake: %v", err)
+		}
+	})
+
+	t.Run("wrong CA client cert rejected", func(t *testing.T) {
+		otherDir := t.TempDir()
+		otherCA, err := EnsureCA(otherDir, time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+		otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "gateway", "node-1", time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		errCh := acceptOnce()
+		clientTLS, err := LoadClientTLS(caPath, otherCertPath, otherKeyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn, dialErr := tls.Dial("tcp", lis.Addr().String(), clientTLS)
+		if dialErr == nil {
+			conn.Close()
+		}
+		serverErr := <-errCh
+		if dialErr == nil && serverErr == nil {
+			t.Fatal("expected handshake to fail for a client cert signed by a different CA")
+		}
+	})
+
+	t.Run("no client cert rejected", func(t *testing.T) {
+		errCh := acceptOnce()
+		// Bypass identity verification here (InsecureSkipVerify) so the
+		// handshake actually reaches the point where the server enforces
+		// RequireAndVerifyClientCert — this subtest is specifically about
+		// the server rejecting a missing client cert, not about client-side
+		// verification of admin's identity.
+		conn, dialErr := tls.Dial("tcp", lis.Addr().String(), &tls.Config{InsecureSkipVerify: true})
+		if dialErr == nil {
+			conn.Close()
+		}
+		serverErr := <-errCh
+		if dialErr == nil && serverErr == nil {
+			t.Fatal("expected handshake to fail with no client certificate presented")
+		}
+	})
+}
+
+// TestLoadClientTLS_RejectsNonAdminServerIdentity proves LoadClientTLS's
+// VerifyConnection checks identity, not just chain validity: a certificate
+// signed by the trusted CA but not carrying the AdminSPIFFEID identity (here,
+// a gateway's own client cert, reused as a server cert) must be rejected
+// even though the chain itself verifies fine.
+func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SignClient's cert has no ServerAuth EKU and identifies as
+	// "gateway/impersonator", not "admin" — either alone is grounds for
+	// LoadClientTLS to reject it.
+	notAdminCertPath, notAdminKeyPath, err := ca.SignClient(dir, "not-admin", "impersonator", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, caCertFile)
+
+	// tls.Listen doesn't itself enforce the serving cert's EKU, so this is a
+	// faithful stand-in for "some entity presents a CA-signed cert that
+	// isn't admin's" regardless of which specific property makes it invalid.
+	rawServerTLS := &tls.Config{MinVersion: tls.VersionTLS12}
+	tlsCert, err := tls.LoadX509KeyPair(notAdminCertPath, notAdminKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawServerTLS.Certificates = []tls.Certificate{tlsCert}
+
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", rawServerTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+	go func() {
+		conn, err := lis.Accept()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	clientTLS, err := LoadClientTLS(caPath, clientCertPath, clientKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, dialErr := tls.Dial("tcp", lis.Addr().String(), clientTLS)
+	if dialErr == nil {
+		conn.Close()
+		t.Fatal("expected the client to reject a server certificate that isn't identified as admin")
+	}
+}
+
+func TestExpiringSoon(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name     string
+		notAfter time.Time
+		want     bool
+	}{
+		{"far future", now.Add(365 * 24 * time.Hour), false},
+		{"within window", now.Add(10 * 24 * time.Hour), true},
+		{"already expired", now.Add(-time.Hour), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExpiringSoon(tc.notAfter, now); got != tc.want {
+				t.Errorf("ExpiringSoon(%v) = %v, want %v", tc.notAfter, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLeafNotAfter(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, keyPath, err := ca.SignServer(dir, "admin", 2*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notAfter, err := LeafNotAfter(tlsCert)
+	if err != nil {
+		t.Fatalf("LeafNotAfter: %v", err)
+	}
+	if time.Until(notAfter) < time.Hour || time.Until(notAfter) > 2*time.Hour+time.Minute {
+		t.Errorf("notAfter = %v, want ~2h from now", notAfter)
+	}
+}
+
+func TestWatchExpiry_WarnsImmediatelyForSoonExpiringCert(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Valid for less than the warning window: should trigger a warning on
+	// the very first (synchronous, pre-ticker) check.
+	certPath, keyPath, err := ca.SignServer(dir, "admin", 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+
+	var warned atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	WatchExpiry(ctx, cfg, time.Hour, func(time.Time) { warned.Store(true) })
+
+	if !warned.Load() {
+		t.Fatal("expected an immediate warning for a certificate expiring within the window")
+	}
+}
+
+func TestWatchExpiry_NoWarningForFreshCert(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath, keyPath, err := ca.SignServer(dir, "admin", 8760*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+
+	var warned atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	WatchExpiry(ctx, cfg, time.Hour, func(time.Time) { warned.Store(true) })
+
+	if warned.Load() {
+		t.Fatal("did not expect a warning for a freshly issued 1y certificate")
+	}
+}
+
+func TestWatchExpiry_NilConfigIsNoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Must not panic and must never invoke warn.
+	WatchExpiry(ctx, nil, time.Hour, func(time.Time) { t.Fatal("warn should not be called for a nil *tls.Config") })
+}
+
+func loadLeafCert(path string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseCertPEM(data)
+}

--- a/go/internal/configsync/pki/pki_test.go
+++ b/go/internal/configsync/pki/pki_test.go
@@ -157,7 +157,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tls.Listen: %v", err)
 	}
-	defer lis.Close()
+	defer func() { _ = lis.Close() }()
 
 	acceptOnce := func() <-chan error {
 		errCh := make(chan error, 1)
@@ -167,7 +167,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 				errCh <- err
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			tlsConn, ok := conn.(*tls.Conn)
 			if !ok {
 				errCh <- nil
@@ -188,7 +188,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("client dial: %v", err)
 		}
-		conn.Close()
+		_ = conn.Close()
 		if err := <-errCh; err != nil {
 			t.Fatalf("server-side handshake: %v", err)
 		}
@@ -212,7 +212,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 		}
 		conn, dialErr := tls.Dial("tcp", lis.Addr().String(), clientTLS)
 		if dialErr == nil {
-			conn.Close()
+			_ = conn.Close()
 		}
 		serverErr := <-errCh
 		if dialErr == nil && serverErr == nil {
@@ -229,7 +229,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 		// verification of admin's identity.
 		conn, dialErr := tls.Dial("tcp", lis.Addr().String(), &tls.Config{InsecureSkipVerify: true})
 		if dialErr == nil {
-			conn.Close()
+			_ = conn.Close()
 		}
 		serverErr := <-errCh
 		if dialErr == nil && serverErr == nil {
@@ -276,7 +276,7 @@ func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer lis.Close()
+	defer func() { _ = lis.Close() }()
 	go func() {
 		conn, err := lis.Accept()
 		if err == nil {
@@ -290,7 +290,7 @@ func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
 	}
 	conn, dialErr := tls.Dial("tcp", lis.Addr().String(), clientTLS)
 	if dialErr == nil {
-		conn.Close()
+		_ = conn.Close()
 		t.Fatal("expected the client to reject a server certificate that isn't identified as admin")
 	}
 }

--- a/go/internal/configsync/pki/sign.go
+++ b/go/internal/configsync/pki/sign.go
@@ -1,0 +1,128 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// spiffeTrustDomain is the fixed SPIFFE trust domain for every nyro
+// deployment's config-sync PKI. Each --dir is its own independent CA/trust
+// root, so a single fixed domain string is sufficient to namespace node
+// identities within it; it does not need to vary per deployment.
+const spiffeTrustDomain = "nyro"
+
+// SignServer issues admin's server leaf certificate (ExtKeyUsage:
+// ServerAuth), carrying the fixed identity AdminSPIFFEID as a SPIFFE URI SAN
+// (spiffe://nyro/admin) — the same identity-based verification model as
+// SignClient, so gateway's config-sync client checks "is this cert admin?"
+// rather than "does this cert's SAN match the hostname I dialed?". That
+// means admin's certificate stays valid no matter what address/hostname a
+// gateway uses to reach it (direct, load balancer, k8s Service name, IP —
+// all of it), with no per-deployment DNS/IP SAN list to maintain and no
+// --config-server-name-style override needed on the client side.
+//
+// The resulting cert/key are written to <dir>/<name>.pem and
+// <dir>/<name>-key.pem (0600) and their paths are returned. name is only the
+// output file basename (see --out) — it does not affect the identity baked
+// into the certificate, which is always AdminSPIFFEID.
+func (ca *CA) SignServer(dir, name string, ttl time.Duration) (certPath, keyPath string, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("pki: generate server key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return "", "", err
+	}
+
+	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/" + AdminSPIFFEID}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: AdminSPIFFEID},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(ttl),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		URIs:         []*url.URL{spiffeURI},
+	}
+
+	return ca.signAndWrite(dir, name, tmpl, key)
+}
+
+// SignClient issues a client leaf certificate (ExtKeyUsage: ClientAuth) for
+// a gateway node, carrying its identity as a SPIFFE URI SAN
+// (spiffe://nyro/gateway/<nodeID>). The resulting cert/key are written to
+// <dir>/<name>.pem and <dir>/<name>-key.pem (0600) and their paths are
+// returned.
+func (ca *CA) SignClient(dir, name, nodeID string, ttl time.Duration) (certPath, keyPath string, err error) {
+	if nodeID == "" {
+		return "", "", fmt.Errorf("pki: SignClient requires a non-empty node-id")
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("pki: generate client key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return "", "", err
+	}
+
+	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/gateway/" + nodeID}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: nodeID},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(ttl),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		URIs:         []*url.URL{spiffeURI},
+	}
+
+	return ca.signAndWrite(dir, name, tmpl, key)
+}
+
+// signAndWrite finalizes tmpl (signed by ca), writes the PEM-encoded
+// certificate and private key to <dir>/<name>.pem / <dir>/<name>-key.pem
+// (0600, dir created 0700 if missing), and returns their paths.
+func (ca *CA) signAndWrite(dir, name string, tmpl *x509.Certificate, key *ecdsa.PrivateKey) (certPath, keyPath string, err error) {
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return "", "", fmt.Errorf("pki: create dir %s: %w", dir, err)
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Cert, &key.PublicKey, ca.Key)
+	if err != nil {
+		return "", "", fmt.Errorf("pki: sign leaf certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return "", "", fmt.Errorf("pki: parse signed leaf certificate: %w", err)
+	}
+	certPEM := encodeCertPEM(cert)
+	keyPEM, err := encodeECKeyPEM(key)
+	if err != nil {
+		return "", "", err
+	}
+
+	certPath = filepath.Join(dir, name+".pem")
+	keyPath = filepath.Join(dir, name+"-key.pem")
+	if err := os.WriteFile(certPath, certPEM, filePerm); err != nil {
+		return "", "", fmt.Errorf("pki: write %s: %w", certPath, err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, filePerm); err != nil {
+		return "", "", fmt.Errorf("pki: write %s: %w", keyPath, err)
+	}
+	return certPath, keyPath, nil
+}

--- a/go/internal/configsync/pki/tls.go
+++ b/go/internal/configsync/pki/tls.go
@@ -1,0 +1,95 @@
+package pki
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// LoadServerTLS builds the *tls.Config for admin's config-sync gRPC listener:
+// it presents (certPath, keyPath) as its server certificate and requires +
+// verifies every client certificate against caPath. All three paths are
+// mandatory — callers (the admin CLI) are responsible for enforcing that
+// --config-tls-ca/-cert/-key are given all together or not at all; this
+// function has no directory-scanning fallback.
+func LoadServerTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
+	pool, err := loadCertPool(caPath)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("pki: load server keypair: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}
+
+// LoadClientTLS builds the *tls.Config for a gateway's config-sync client: it
+// trusts caPath as the root for verifying admin's server certificate and
+// presents (certPath, keyPath) as its own client certificate.
+//
+// Verification is identity-based, not hostname-based: the default Go TLS
+// client behavior (matching the server cert's DNS/IP SANs against the dial
+// address) is replaced with VerifyConnection checking that the presented
+// server certificate is signed by caPath, carries the ServerAuth extended
+// key usage, and identifies as AdminSPIFFEID (see VerifyAdminIdentity) — the
+// same check regardless of what address/hostname was dialed (direct, load
+// balancer, k8s Service name, IP). This is why there is no
+// --config-server-name-style override flag: identity verification is fully
+// decoupled from network topology by design.
+func LoadClientTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
+	pool, err := loadCertPool(caPath)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("pki: load client keypair: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS13,
+		// The default verifier also does hostname matching, which we don't
+		// want (see doc comment above) — InsecureSkipVerify disables ALL
+		// default verification (chain included), so VerifyConnection below
+		// must redo chain verification itself, not just the identity check.
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return fmt.Errorf("pki: server presented no certificate")
+			}
+			leaf := cs.PeerCertificates[0]
+			opts := x509.VerifyOptions{
+				Roots:         pool,
+				Intermediates: x509.NewCertPool(),
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			}
+			for _, c := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(c)
+			}
+			if _, err := leaf.Verify(opts); err != nil {
+				return fmt.Errorf("pki: verify server certificate chain: %w", err)
+			}
+			return VerifyAdminIdentity(leaf)
+		},
+	}, nil
+}
+
+func loadCertPool(caPath string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("pki: read CA cert %s: %w", caPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("pki: %s does not contain a valid CA certificate", caPath)
+	}
+	return pool, nil
+}

--- a/go/internal/configsync/server.go
+++ b/go/internal/configsync/server.go
@@ -7,10 +7,12 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/nyroway/nyro/go/internal/configsync/pb/configsync/v1"
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
 	"github.com/nyroway/nyro/go/internal/storage"
 )
 
@@ -82,8 +84,25 @@ func NewConfigServer(store storage.Storage) *ConfigServer {
 func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreamingServer[pb.ConfigSnapshot]) error {
 	ctx := stream.Context()
 	remoteAddr := ""
-	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
-		remoteAddr = p.Addr.String()
+	nodeID := req.GetNodeId()
+	if p, ok := peer.FromContext(ctx); ok {
+		if p.Addr != nil {
+			remoteAddr = p.Addr.String()
+		}
+		// Under mTLS (Tier 1), the peer's verified client certificate is the
+		// authoritative source of node identity — it overrides whatever the
+		// gateway self-reported in Subscribe.node_id, which is otherwise
+		// trivially spoofable. Under Tier 0 (plaintext, --config-insecure),
+		// p.AuthInfo carries no TLS state, so this is a no-op and the
+		// self-reported node_id passes through unchanged (existing behavior).
+		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok && len(tlsInfo.State.VerifiedChains) > 0 && len(tlsInfo.State.VerifiedChains[0]) > 0 {
+			leaf := tlsInfo.State.VerifiedChains[0][0]
+			if id, err := pki.GatewayNodeIDFromCert(leaf); err == nil {
+				nodeID = id
+			} else {
+				log.Printf("configsync: client cert has no usable identity, keeping self-reported node_id: %v", err)
+			}
+		}
 	}
 
 	// Register BEFORE the initial push. This way, any Notify that arrives
@@ -92,7 +111,7 @@ func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreami
 	// initial push. The gateway dedups by version, so a follow-up is harmless.
 	c := &streamClient{
 		ch:          make(chan *pb.ConfigSnapshot, 1),
-		nodeID:      req.GetNodeId(),
+		nodeID:      nodeID,
 		appVersion:  req.GetAppVersion(),
 		hostname:    req.GetHostname(),
 		servicePort: req.GetServicePort(),

--- a/go/internal/configsync/server_mtls_test.go
+++ b/go/internal/configsync/server_mtls_test.go
@@ -1,0 +1,193 @@
+package configsync
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/nyroway/nyro/go/internal/configsync/pb/configsync/v1"
+	"github.com/nyroway/nyro/go/internal/configsync/pki"
+)
+
+// mtlsFixture is a self-signed CA plus an admin server leaf cert and a
+// gateway client leaf cert (identity "cert-node"), all issued for these
+// mTLS-focused tests.
+type mtlsFixture struct {
+	caPath                        string
+	serverCertPath, serverKeyPath string
+	clientCertPath, clientKeyPath string
+}
+
+func newMTLSFixture(t *testing.T) mtlsFixture {
+	t.Helper()
+	dir := t.TempDir()
+	ca, err := pki.EnsureCA(dir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCert, serverKey, err := ca.SignServer(dir, "admin", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCert, clientKey, err := ca.SignClient(dir, "gateway", "cert-node", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mtlsFixture{
+		caPath:         filepath.Join(dir, "ca.pem"),
+		serverCertPath: serverCert,
+		serverKeyPath:  serverKey,
+		clientCertPath: clientCert,
+		clientKeyPath:  clientKey,
+	}
+}
+
+// bufconnMTLSEnv wires a ConfigServer behind an mTLS-secured bufconn
+// listener (mirrors bufconnEnv in server_test.go, but with ServeGRPC's TLS
+// server option instead of a bare grpc.NewServer()).
+func bufconnMTLSEnv(t *testing.T, srv *ConfigServer, fx mtlsFixture) (dial func(t *testing.T, clientTLS *tls.Config) (pb.ConfigService_StreamConfigClient, func()), teardown func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	serverTLS, err := pki.LoadServerTLS(fx.caPath, fx.serverCertPath, fx.serverKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gs := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
+	pb.RegisterConfigServiceServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+
+	dial = func(t *testing.T, clientTLS *tls.Config) (pb.ConfigService_StreamConfigClient, func()) {
+		t.Helper()
+		dialOpt := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		})
+		conn, err := grpc.NewClient("passthrough:///bufnet", dialOpt, grpc.WithTransportCredentials(credentials.NewTLS(clientTLS)))
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		stream, err := pb.NewConfigServiceClient(conn).StreamConfig(context.Background(), &pb.Subscribe{
+			Version: 0,
+			NodeId:  "self-reported-should-be-overridden",
+		})
+		if err != nil {
+			_ = conn.Close()
+			return nil, func() {}
+		}
+		return stream, func() { _ = conn.Close() }
+	}
+	return dial, gs.GracefulStop
+}
+
+func TestStreamConfig_MTLS_IdentityFromCertOverridesSelfReported(t *testing.T) {
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	fx := newMTLSFixture(t)
+	srv := NewConfigServer(st.Storage())
+	dial, stop := bufconnMTLSEnv(t, srv, fx)
+	defer stop()
+
+	clientTLS, err := pki.LoadClientTLS(fx.caPath, fx.clientCertPath, fx.clientKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stream, closeFn := dial(t, clientTLS)
+	if stream == nil {
+		t.Fatal("expected successful mTLS StreamConfig")
+	}
+	defer closeFn()
+
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return len(srv.Nodes()) == 1 })
+
+	nodes := srv.Nodes()
+	if len(nodes) != 1 {
+		t.Fatalf("Nodes() len = %d; want 1", len(nodes))
+	}
+	if nodes[0].NodeID != "cert-node" {
+		t.Errorf("NodeID = %q; want %q (identity must come from the verified client cert, not Subscribe.node_id)", nodes[0].NodeID, "cert-node")
+	}
+}
+
+func TestStreamConfig_MTLS_RejectsWrongCACert(t *testing.T) {
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	fx := newMTLSFixture(t)
+	srv := NewConfigServer(st.Storage())
+	dial, stop := bufconnMTLSEnv(t, srv, fx)
+	defer stop()
+
+	otherDir := t.TempDir()
+	otherCA, err := pki.EnsureCA(otherDir, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "gateway", "cert-node", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientTLS, err := pki.LoadClientTLS(fx.caPath, otherCertPath, otherKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stream, closeFn := dial(t, clientTLS)
+	defer closeFn()
+	if stream != nil {
+		if _, err := stream.Recv(); err == nil {
+			t.Fatal("expected mTLS handshake/stream to fail for a client cert signed by a different CA")
+		}
+	}
+}
+
+func TestStreamConfig_MTLS_RejectsNoClientCert(t *testing.T) {
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	fx := newMTLSFixture(t)
+	srv := NewConfigServer(st.Storage())
+	dial, stop := bufconnMTLSEnv(t, srv, fx)
+	defer stop()
+
+	// Bypass identity verification here (InsecureSkipVerify) so the
+	// handshake actually reaches the point where the server enforces
+	// RequireAndVerifyClientCert — this test is specifically about the
+	// server rejecting a missing client cert.
+	noCertTLS := &tls.Config{InsecureSkipVerify: true}
+
+	stream, closeFn := dial(t, noCertTLS)
+	defer closeFn()
+	if stream != nil {
+		if _, err := stream.Recv(); err == nil {
+			t.Fatal("expected mTLS handshake/stream to fail with no client certificate presented")
+		}
+	}
+}
+
+func TestStreamConfig_Tier0_PlaintextStillUsesSelfReportedNodeID(t *testing.T) {
+	// Regression: with tlsConfig=nil (Tier 0), peer.AuthInfo carries no TLS
+	// state, so identity derivation must be a no-op and self-reported
+	// node_id must pass through exactly as before this change.
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	srv, dialOpt, stop := bufconnEnv(t, st)
+	defer stop()
+
+	stream, closeFn := dialClient(t, dialOpt)
+	defer closeFn()
+
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return len(srv.Nodes()) == 1 })
+
+	nodes := srv.Nodes()
+	if len(nodes) != 1 || nodes[0].NodeID != "test-node-1" {
+		t.Fatalf("Nodes() = %+v; want self-reported node_id %q preserved under Tier 0", nodes, "test-node-1")
+	}
+}

--- a/go/nyro.go
+++ b/go/nyro.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nyroway/nyro/go/cmd/admin"
+	"github.com/nyroway/nyro/go/cmd/ca"
 	"github.com/nyroway/nyro/go/cmd/gateway"
 	"github.com/nyroway/nyro/go/internal/version"
 )
@@ -26,6 +27,7 @@ func newRootCmd() *cobra.Command {
 	root.CompletionOptions.DisableDefaultCmd = true
 	root.AddCommand(gateway.NewCmd())
 	root.AddCommand(admin.NewCmd())
+	root.AddCommand(ca.NewCmd())
 	root.AddCommand(newVersionCmd())
 	return root
 }


### PR DESCRIPTION
The admin->gateway config-sync stream carried every upstream's
credentials_json in the clear with no authentication. Add an offline
`nyro ca` CA (init/sign-admin/sign-gateway) and wire admin/gateway to
load mTLS from explicit --config-tls-ca/-cert/-key, or require an
explicit --config-insecure acknowledgment for plaintext. Gateway node
identity is derived from the client certificate's SPIFFE SAN rather
than trusted from the self-reported node_id.

Admin's server certificate also carries a fixed SPIFFE identity
(spiffe://nyro/admin) instead of DNS/IP SANs, and gateway verifies it
by identity rather than hostname — this decouples verification from
--config-server's network address entirely, so there's no
--config-server-name-style override needed.