### PR TITLE
feat(go/admin): add EpochWatcher for multi-replica config-sync HA

### DIFF
--- a/go/cmd/admin/admin.go
+++ b/go/cmd/admin/admin.go
@@ -70,6 +70,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().String("webui-dir", "", "path to the built WebUI (serves the SPA at /)")
 	cmd.Flags().String("dsn", "", fmt.Sprintf("database DSN: sqlite://<path> (default %s), postgres://..., or mysql://...", defaultDSN()))
 	cmd.Flags().String("obs-data-dir", filepath.Join(nyroHomeDir(), "obs"), "directory for admin-local observability parquet data (logs/metrics/traces)")
+	cmd.Flags().Duration("config-poll-interval", time.Second, "how often to poll the shared config_epoch setting for changes made by other admin replicas (0 disables polling; single-instance deployments can leave this at the default, it's a harmless no-op)")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		addr, _ := cmd.Flags().GetString("listen")
 		grpcAddr, _ := cmd.Flags().GetString("config-listen")
@@ -81,6 +82,7 @@ func NewCmd() *cobra.Command {
 		webuiDir, _ := cmd.Flags().GetString("webui-dir")
 		dsn, _ := cmd.Flags().GetString("dsn")
 		obsDataDir, _ := cmd.Flags().GetString("obs-data-dir")
+		configPollInterval, _ := cmd.Flags().GetDuration("config-poll-interval")
 
 		var configTLS *tls.Config
 		if grpcAddr != "" {
@@ -193,6 +195,24 @@ func NewCmd() *cobra.Command {
 				slog.Warn("config-sync server certificate expiring soon — run `nyro ca sign-admin` and redistribute before it lapses",
 					"not_after", notAfter, "remaining", time.Until(notAfter).Round(time.Hour))
 			})
+
+			// EpochWatcher lets this replica notice config_epoch bumps made
+			// by any other admin replica sharing the same DSN (not just
+			// writes made through this process), so multi-replica admin
+			// deployments converge on pushing every config change to every
+			// gateway, no matter which replica received the write. Seed
+			// before starting Run so the first poll tick doesn't re-push a
+			// snapshot gateways already got on connect.
+			if configPollInterval > 0 && (backend == "sqlite" || backend == "memory") {
+				slog.Warn("--config-poll-interval is set but --dsn uses a non-shared backend; multi-replica config sync requires all admin replicas to point at the same postgres/mysql --dsn",
+					"backend", backend)
+			}
+			watcher := configsync.NewEpochWatcher(st.Settings(), srv)
+			if err := watcher.Seed(ctx); err != nil {
+				return fmt.Errorf("seed config epoch watcher: %w", err)
+			}
+			admin.SetEpochWatcher(watcher)
+			go watcher.Run(ctx, configPollInterval)
 		}
 
 		engine := chi.NewRouter()

--- a/go/internal/admin/admin.go
+++ b/go/internal/admin/admin.go
@@ -539,10 +539,19 @@ func conflict(w http.ResponseWriter, msg string) {
 func bumpEpoch(s storage.Storage) {
 	v, _ := s.Settings().Get("config_epoch")
 	n, _ := strconv.ParseInt(v, 10, 64)
-	_ = s.Settings().Set("config_epoch", strconv.FormatInt(n+1, 10))
-	// Push the new config to every connected gateway over config-sync, if a
-	// broadcaster (the admin's gRPC ConfigServer) has been wired in. No-op in
-	// tests/standalone.
+	n++
+	_ = s.Settings().Set("config_epoch", strconv.FormatInt(n, 10))
+	// Drive notification through the EpochWatcher when one is wired: it is
+	// the single decision point for whether/when to push, so a write made on
+	// this replica and the same write observed via polling by a peer replica
+	// (sharing the same DB) converge on calling Notify exactly once each.
+	// Fall back to the raw Broadcaster for standalone/tests where no watcher
+	// is registered (config-sync disabled, or single-instance deployments
+	// with polling turned off).
+	if w := epochWatcher(); w != nil {
+		w.Observe(n)
+		return
+	}
 	if b := configBroadcaster(); b != nil {
 		b.Notify()
 	}
@@ -563,6 +572,24 @@ var configBroadcasterVal Broadcaster
 func SetBroadcaster(b Broadcaster) { configBroadcasterVal = b }
 
 func configBroadcaster() Broadcaster { return configBroadcasterVal }
+
+// EpochObserver is implemented by configsync.EpochWatcher. It replaces the
+// raw Broadcaster as bumpEpoch's push target whenever multi-replica epoch
+// polling is enabled: Observe deduplicates by epoch so the same config write
+// isn't pushed twice (once locally here, once when this replica's own poll
+// tick later catches up to the epoch it just wrote).
+type EpochObserver interface {
+	Observe(epoch int64)
+}
+
+var epochWatcherVal EpochObserver
+
+// SetEpochWatcher wires the config-sync epoch watcher. Call once at admin
+// startup (after Mount) if the gRPC ConfigServer and epoch polling are
+// enabled. Safe to pass nil to fall back to the raw Broadcaster.
+func SetEpochWatcher(w EpochObserver) { epochWatcherVal = w }
+
+func epochWatcher() EpochObserver { return epochWatcherVal }
 
 // NodeLister exposes the set of gateways currently connected over
 // config-sync, for the /api/v1/nodes admin endpoint. The admin's config-sync

--- a/go/internal/admin/broadcast_test.go
+++ b/go/internal/admin/broadcast_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -55,4 +56,77 @@ func epochSetting(t *testing.T, s storage.Storage) string {
 		t.Fatalf("get config_epoch: %v", err)
 	}
 	return v
+}
+
+// fakeEpochObserver records every epoch bumpEpoch handed it.
+type fakeEpochObserver struct {
+	mu      sync.Mutex
+	observe []int64
+}
+
+func (f *fakeEpochObserver) Observe(epoch int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.observe = append(f.observe, epoch)
+}
+
+func (f *fakeEpochObserver) observed() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.observe...)
+}
+
+// TestBumpEpochPrefersEpochWatcher proves that once an EpochWatcher is wired,
+// bumpEpoch drives notification through it (Observe) instead of calling the
+// raw Broadcaster directly — this is the seam that lets a poller on another
+// admin replica also converge on the same epoch and notify its own gateways
+// exactly once.
+func TestBumpEpochPrefersEpochWatcher(t *testing.T) {
+	st := memory.New()
+	origWatcher := epochWatcherVal
+	origBroadcaster := configBroadcasterVal
+	t.Cleanup(func() {
+		epochWatcherVal = origWatcher
+		configBroadcasterVal = origBroadcaster
+	})
+
+	fb := &fakeBroadcaster{}
+	SetBroadcaster(fb)
+	fo := &fakeEpochObserver{}
+	SetEpochWatcher(fo)
+
+	bumpEpoch(st.Storage())
+	bumpEpoch(st.Storage())
+
+	if got := fo.observed(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("watcher observed = %v; want [1 2]", got)
+	}
+	// The raw broadcaster must not be called directly once a watcher is wired
+	// — the watcher is the sole decision point for whether/when to Notify.
+	if got := fb.callsCount(); got != 0 {
+		t.Errorf("broadcaster Notify calls = %d; want 0 (watcher should own notification)", got)
+	}
+}
+
+// TestBumpEpochFallsBackToBroadcasterWithoutWatcher proves standalone/legacy
+// wiring (a Broadcaster registered but no EpochWatcher) keeps working exactly
+// as before this change.
+func TestBumpEpochFallsBackToBroadcasterWithoutWatcher(t *testing.T) {
+	st := memory.New()
+	origWatcher := epochWatcherVal
+	origBroadcaster := configBroadcasterVal
+	t.Cleanup(func() {
+		epochWatcherVal = origWatcher
+		configBroadcasterVal = origBroadcaster
+	})
+
+	SetEpochWatcher(nil)
+	fb := &fakeBroadcaster{}
+	SetBroadcaster(fb)
+
+	bumpEpoch(st.Storage())
+
+	if got := fb.callsCount(); got != 1 {
+		t.Errorf("broadcaster Notify calls = %d; want 1", got)
+	}
 }

--- a/go/internal/configsync/epochwatch.go
+++ b/go/internal/configsync/epochwatch.go
@@ -1,0 +1,106 @@
+package configsync
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// Notifier is implemented by ConfigServer. EpochWatcher calls Notify exactly
+// once per epoch advance, regardless of whether the write happened on this
+// replica or was observed by polling shared storage.
+type Notifier interface {
+	Notify()
+}
+
+// EpochStore reads the shared config_epoch setting. Satisfied by
+// storage.SettingsStore.
+type EpochStore interface {
+	Get(key string) (string, error)
+}
+
+// EpochWatcher deduplicates config-change notifications across admin
+// replicas sharing one database: a write on any replica bumps config_epoch
+// in storage, and every replica converges on calling Notify() exactly once
+// for that epoch — the writer via an immediate Observe call, every other
+// replica via Run's poll loop. There is no leader; replicas are peers that
+// each watch the same epoch value.
+type EpochWatcher struct {
+	store    EpochStore
+	notifier Notifier
+
+	lastEpoch atomic.Int64
+}
+
+// NewEpochWatcher builds a watcher over store, pushing through notifier.
+func NewEpochWatcher(store EpochStore, notifier Notifier) *EpochWatcher {
+	return &EpochWatcher{store: store, notifier: notifier}
+}
+
+// Seed reads the current config_epoch and initializes lastEpoch without
+// notifying. Call once at startup, before Run: gateways already get the
+// current snapshot on connect, so re-pushing on the first poll tick would
+// just be a redundant no-op push.
+func (w *EpochWatcher) Seed(ctx context.Context) error {
+	epoch, err := w.readEpoch()
+	if err != nil {
+		return err
+	}
+	w.lastEpoch.Store(epoch)
+	return nil
+}
+
+// Observe advances lastEpoch and calls Notify if epoch is newer than what
+// this watcher has already pushed. Safe for concurrent callers: only the
+// call that wins the compare-and-swap invokes Notify, so a given epoch is
+// pushed at most once per watcher no matter how many callers observe it.
+func (w *EpochWatcher) Observe(epoch int64) {
+	for {
+		last := w.lastEpoch.Load()
+		if epoch <= last {
+			return
+		}
+		if w.lastEpoch.CompareAndSwap(last, epoch) {
+			w.notifier.Notify()
+			return
+		}
+	}
+}
+
+// Run polls config_epoch every interval and calls Observe on each read,
+// picking up changes committed by any replica sharing the same store.
+// Blocks until ctx is cancelled. Call Seed before Run. interval <= 0
+// disables polling and Run returns immediately — appropriate for
+// single-instance/standalone deployments where no other replica can bump
+// the epoch out from under this one.
+func (w *EpochWatcher) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			epoch, err := w.readEpoch()
+			if err != nil {
+				log.Printf("configsync: epoch poll failed: %v", err)
+				continue
+			}
+			w.Observe(epoch)
+		}
+	}
+}
+
+func (w *EpochWatcher) readEpoch() (int64, error) {
+	v, err := w.store.Get("config_epoch")
+	if err != nil {
+		return 0, err
+	}
+	n, _ := strconv.ParseInt(v, 10, 64)
+	return n, nil
+}

--- a/go/internal/configsync/epochwatch_test.go
+++ b/go/internal/configsync/epochwatch_test.go
@@ -1,0 +1,160 @@
+package configsync
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeNotifier records how many times Notify was called.
+type fakeNotifier struct {
+	calls int32
+}
+
+func (f *fakeNotifier) Notify() { atomic.AddInt32(&f.calls, 1) }
+func (f *fakeNotifier) callsCount() int32 {
+	return atomic.LoadInt32(&f.calls)
+}
+
+// fakeEpochStore is an in-memory EpochStore for tests.
+type fakeEpochStore struct {
+	mu    sync.Mutex
+	value string
+}
+
+func (f *fakeEpochStore) Get(key string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.value, nil
+}
+
+func (f *fakeEpochStore) set(v int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.value = strconv.FormatInt(v, 10)
+}
+
+func TestEpochWatcher_ObserveSkipsNonIncreasing(t *testing.T) {
+	n := &fakeNotifier{}
+	w := NewEpochWatcher(&fakeEpochStore{}, n)
+
+	w.Observe(5)
+	if got := n.callsCount(); got != 1 {
+		t.Fatalf("Notify calls after first Observe(5) = %d; want 1", got)
+	}
+
+	w.Observe(5)
+	w.Observe(3)
+	if got := n.callsCount(); got != 1 {
+		t.Fatalf("Notify calls after Observe(5), Observe(3) = %d; want 1 (no-op for <= lastEpoch)", got)
+	}
+
+	w.Observe(6)
+	if got := n.callsCount(); got != 2 {
+		t.Fatalf("Notify calls after Observe(6) = %d; want 2", got)
+	}
+}
+
+func TestEpochWatcher_ObserveConcurrentSameEpochNotifiesOnce(t *testing.T) {
+	n := &fakeNotifier{}
+	w := NewEpochWatcher(&fakeEpochStore{}, n)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			w.Observe(1)
+		})
+	}
+	wg.Wait()
+
+	if got := n.callsCount(); got != 1 {
+		t.Fatalf("Notify calls after 50 concurrent Observe(1) = %d; want 1", got)
+	}
+}
+
+func TestEpochWatcher_SeedDoesNotNotify(t *testing.T) {
+	n := &fakeNotifier{}
+	store := &fakeEpochStore{}
+	store.set(42)
+	w := NewEpochWatcher(store, n)
+
+	if err := w.Seed(context.Background()); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if got := n.callsCount(); got != 0 {
+		t.Fatalf("Notify calls after Seed = %d; want 0", got)
+	}
+
+	// A subsequent Observe at or below the seeded epoch is still a no-op.
+	w.Observe(42)
+	if got := n.callsCount(); got != 0 {
+		t.Fatalf("Notify calls after Observe(seeded epoch) = %d; want 0", got)
+	}
+
+	// But an epoch beyond the seed still triggers exactly one push.
+	w.Observe(43)
+	if got := n.callsCount(); got != 1 {
+		t.Fatalf("Notify calls after Observe(43) = %d; want 1", got)
+	}
+}
+
+func TestEpochWatcher_RunPollsAndObserves(t *testing.T) {
+	n := &fakeNotifier{}
+	store := &fakeEpochStore{}
+	store.set(1)
+	w := NewEpochWatcher(store, n)
+	if err := w.Seed(context.Background()); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx, 5*time.Millisecond)
+		close(done)
+	}()
+
+	// Simulate a remote replica bumping the shared epoch.
+	store.set(2)
+
+	deadline := time.After(time.Second)
+	for n.callsCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for Run to observe the new epoch")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if got := n.callsCount(); got != 1 {
+		t.Fatalf("Notify calls after epoch bump = %d; want 1", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after context cancellation")
+	}
+}
+
+func TestEpochWatcher_RunZeroIntervalDisablesPolling(t *testing.T) {
+	n := &fakeNotifier{}
+	store := &fakeEpochStore{}
+	store.set(1)
+	w := NewEpochWatcher(store, n)
+
+	done := make(chan struct{})
+	go func() {
+		w.Run(context.Background(), 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run(interval=0) did not return immediately")
+	}
+}


### PR DESCRIPTION
## Summary
- Multiple `nyro admin` replicas sharing one DB (`--dsn` pointing at the same postgres/mysql) previously only pushed config changes to gateways connected to whichever replica received the write — gateways connected to other replicas never got notified.
- Adds `EpochWatcher` (`internal/configsync/epochwatch.go`): polls the shared `config_epoch` setting and calls `Notify()` exactly once per epoch advance, whether the write was made locally (`bumpEpoch`) or observed via another replica's write.
- `bumpEpoch` now drives notification through the watcher when one is wired, falling back to the existing direct `Broadcaster.Notify()` path for standalone/single-instance deployments (no behavior change there).
- New `--config-poll-interval` flag on `nyro admin` (default `1s`; `0` disables polling). Warns if polling is enabled against a non-shared backend (sqlite/memory).
- Node listing (`/api/v1/nodes`) intentionally stays per-replica local view for this round — out of scope, documented in the plan doc.

Full design/rationale: `go/docs/superpowers/plans/2026-07-12-nyro-admin-multinode-ha.md`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `make go-lint` (0 issues)
- [x] `gofmt -l .` clean
- [x] Unit tests cover: `Observe` dedup/monotonic advance, concurrent `Observe` calls notify once, `Seed` doesn't notify, `Run` polls and observes a remote epoch bump, `Run(interval=0)` returns immediately, `bumpEpoch` prefers the watcher over the raw broadcaster, `bumpEpoch` falls back to the broadcaster when no watcher is wired
- [ ] Manual two-replica verification against a real shared Postgres (two admin instances, two gateways, cross-replica config push + failover) — not run in this environment (no local Postgres/container runtime available); steps are documented in the plan doc for follow-up