### PR TITLE
feat(go/cli): env-var layer with flag > env > default precedence

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/parquet-go/parquet-go v0.30.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
@@ -95,7 +96,6 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go/internal/envflag/envflag.go
+++ b/go/internal/envflag/envflag.go
@@ -1,0 +1,107 @@
+// Package envflag adds an environment-variable layer to the nyro cobra CLI,
+// giving every subcommand flag the industry-standard precedence
+//
+//	explicit flag  >  environment variable  >  built-in default
+//
+// It is wired once on the root command (see cmd wiring in nyro.go): Bind is
+// installed as the root's PersistentPreRunE so it runs for whichever leaf
+// command is executed, and Decorate rewrites each flag's help text to advertise
+// its env var. No subcommand code changes — a flag added to any current or
+// future subcommand gets env support automatically.
+//
+// The env var name for a flag is derived from the command path and flag name:
+//
+//	nyro admin       --listen               -> NYRO_ADMIN_LISTEN
+//	nyro gateway     --config-file          -> NYRO_GATEWAY_CONFIG_FILE
+//	nyro ca init     --dir                  -> NYRO_CA_INIT_DIR
+//	nyro ca sign-admin --out                -> NYRO_CA_SIGN_ADMIN_OUT
+package envflag
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// envPrefix is prepended to every generated env var name; it matches the root
+// command name ("nyro"). Kept separate from the per-command prefix so EnvKey
+// produces NYRO_<PREFIX>_<FLAG> rather than a doubled root segment.
+const envPrefix = "NYRO"
+
+// EnvKey builds the environment variable name for a flag under the given
+// per-command prefix (e.g. prefix "ADMIN", flag "config-poll-interval" ->
+// "NYRO_ADMIN_CONFIG_POLL_INTERVAL"). The flag name's dashes become
+// underscores and everything is upper-cased.
+func EnvKey(prefix, flagName string) string {
+	return envPrefix + "_" + prefix + "_" + normalize(flagName)
+}
+
+// normalize upper-cases a path/flag segment and turns dashes and spaces into
+// underscores, matching the shell convention for env var names.
+func normalize(s string) string {
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	return strings.ToUpper(s)
+}
+
+// prefixFromCommand derives the per-command env prefix from a command's full
+// path by dropping the leading root segment ("nyro") and joining the rest with
+// underscores, upper-cased. "nyro ca sign-admin" -> "CA_SIGN_ADMIN". Returns ""
+// for the bare root command (which carries no flags of its own).
+func prefixFromCommand(cmd *cobra.Command) string {
+	path := strings.Fields(cmd.CommandPath())
+	if len(path) <= 1 {
+		return ""
+	}
+	return normalize(strings.Join(path[1:], "_"))
+}
+
+// Bind is the root PersistentPreRunE. For the executed command it applies, for
+// each flag the user did NOT set explicitly on the command line, the value of
+// the corresponding env var when that var is present. This yields the
+// precedence explicit flag > env > default: an explicitly-set flag is skipped
+// (its Changed is already true), an env-supplied value is applied via Set
+// (which marks the flag Changed too, so downstream Changed()-based validation
+// treats an env value like an explicit one), and a flag left untouched keeps
+// its pflag default.
+func Bind(cmd *cobra.Command, _ []string) error {
+	prefix := prefixFromCommand(cmd)
+	if prefix == "" {
+		return nil
+	}
+	var bindErr error
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if bindErr != nil || f.Changed {
+			return
+		}
+		envName := EnvKey(prefix, f.Name)
+		val, ok := os.LookupEnv(envName)
+		if !ok {
+			return
+		}
+		if err := cmd.Flags().Set(f.Name, val); err != nil {
+			bindErr = fmt.Errorf("invalid value for %s: %w", envName, err)
+		}
+	})
+	return bindErr
+}
+
+// Decorate walks the command tree rooted at root and appends an "(env NYRO_...)"
+// hint to every flag's usage string so `--help` advertises the env var. It must
+// be called after the full command tree is assembled (all AddCommand calls
+// done), since it relies on CommandPath being complete.
+func Decorate(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		Decorate(cmd)
+	}
+	prefix := prefixFromCommand(root)
+	if prefix == "" {
+		return
+	}
+	root.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Usage = fmt.Sprintf("%s (env %s)", f.Usage, EnvKey(prefix, f.Name))
+	})
+}

--- a/go/internal/envflag/envflag_test.go
+++ b/go/internal/envflag/envflag_test.go
@@ -1,0 +1,134 @@
+package envflag
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestCmd builds a leaf command "nyro admin" carrying string/bool/duration
+// flags, so Bind sees a realistic CommandPath ("nyro admin") and prefix
+// ("ADMIN"). The returned command is not executed; tests call Bind directly.
+func newTestCmd() *cobra.Command {
+	root := &cobra.Command{Use: "nyro"}
+	admin := &cobra.Command{Use: "admin", RunE: func(*cobra.Command, []string) error { return nil }}
+	admin.Flags().String("listen", "127.0.0.1:19531", "listen addr")
+	admin.Flags().Bool("auto-migrate", false, "auto migrate")
+	admin.Flags().Duration("config-poll-interval", 0, "poll interval")
+	root.AddCommand(admin)
+	return admin
+}
+
+func TestBindAppliesEnvWhenFlagUnset(t *testing.T) {
+	cmd := newTestCmd()
+	t.Setenv("NYRO_ADMIN_LISTEN", "0.0.0.0:29530")
+
+	if err := Bind(cmd, nil); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	got, _ := cmd.Flags().GetString("listen")
+	if got != "0.0.0.0:29530" {
+		t.Errorf("listen = %q, want env value 0.0.0.0:29530", got)
+	}
+	if !cmd.Flags().Changed("listen") {
+		t.Error("env-applied flag should report Changed()==true")
+	}
+}
+
+func TestExplicitFlagBeatsEnv(t *testing.T) {
+	cmd := newTestCmd()
+	// Simulate the user passing --listen explicitly on the command line.
+	if err := cmd.Flags().Set("listen", "1.2.3.4:1111"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NYRO_ADMIN_LISTEN", "0.0.0.0:29530")
+
+	if err := Bind(cmd, nil); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	got, _ := cmd.Flags().GetString("listen")
+	if got != "1.2.3.4:1111" {
+		t.Errorf("listen = %q, want explicit flag value 1.2.3.4:1111 (flag must beat env)", got)
+	}
+}
+
+func TestDefaultWhenNoEnvNoFlag(t *testing.T) {
+	cmd := newTestCmd()
+	if err := Bind(cmd, nil); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	got, _ := cmd.Flags().GetString("listen")
+	if got != "127.0.0.1:19531" {
+		t.Errorf("listen = %q, want default 127.0.0.1:19531", got)
+	}
+	if cmd.Flags().Changed("listen") {
+		t.Error("untouched flag should not be Changed()")
+	}
+}
+
+func TestBindTypedFlagsFromEnv(t *testing.T) {
+	cmd := newTestCmd()
+	t.Setenv("NYRO_ADMIN_AUTO_MIGRATE", "true")
+	t.Setenv("NYRO_ADMIN_CONFIG_POLL_INTERVAL", "5s")
+
+	if err := Bind(cmd, nil); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if b, _ := cmd.Flags().GetBool("auto-migrate"); !b {
+		t.Error("auto-migrate should be true from env")
+	}
+	if d, _ := cmd.Flags().GetDuration("config-poll-interval"); d != 5*time.Second {
+		t.Errorf("config-poll-interval = %v, want 5s from env", d)
+	}
+}
+
+func TestBindInvalidEnvValueErrors(t *testing.T) {
+	cmd := newTestCmd()
+	t.Setenv("NYRO_ADMIN_CONFIG_POLL_INTERVAL", "not-a-duration")
+
+	err := Bind(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid duration env value, got nil")
+	}
+}
+
+func TestEnvKey(t *testing.T) {
+	cases := []struct{ prefix, flag, want string }{
+		{"ADMIN", "listen", "NYRO_ADMIN_LISTEN"},
+		{"ADMIN", "config-poll-interval", "NYRO_ADMIN_CONFIG_POLL_INTERVAL"},
+		{"GATEWAY", "config-file", "NYRO_GATEWAY_CONFIG_FILE"},
+	}
+	for _, c := range cases {
+		if got := EnvKey(c.prefix, c.flag); got != c.want {
+			t.Errorf("EnvKey(%q,%q) = %q, want %q", c.prefix, c.flag, got, c.want)
+		}
+	}
+}
+
+func TestPrefixFromCommand(t *testing.T) {
+	root := &cobra.Command{Use: "nyro"}
+	ca := &cobra.Command{Use: "ca"}
+	signAdmin := &cobra.Command{Use: "sign-admin"}
+	ca.AddCommand(signAdmin)
+	root.AddCommand(ca)
+
+	if got := prefixFromCommand(signAdmin); got != "CA_SIGN_ADMIN" {
+		t.Errorf("prefixFromCommand(nyro ca sign-admin) = %q, want CA_SIGN_ADMIN", got)
+	}
+	if got := prefixFromCommand(root); got != "" {
+		t.Errorf("prefixFromCommand(root) = %q, want empty", got)
+	}
+}
+
+func TestDecorateAppendsEnvHint(t *testing.T) {
+	cmd := newTestCmd()
+	root := cmd.Parent()
+	Decorate(root)
+
+	usage := cmd.Flags().Lookup("listen").Usage
+	if want := "(env NYRO_ADMIN_LISTEN)"; !strings.Contains(usage, want) {
+		t.Errorf("listen usage = %q, want it to contain %q", usage, want)
+	}
+}

--- a/go/nyro.go
+++ b/go/nyro.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyroway/nyro/go/cmd/admin"
 	"github.com/nyroway/nyro/go/cmd/ca"
 	"github.com/nyroway/nyro/go/cmd/gateway"
+	"github.com/nyroway/nyro/go/internal/envflag"
 	"github.com/nyroway/nyro/go/internal/version"
 )
 
@@ -25,10 +26,17 @@ func newRootCmd() *cobra.Command {
 	// disable cobra's auto-added `completion` subcommand rather than ship an
 	// unmaintained surface.
 	root.CompletionOptions.DisableDefaultCmd = true
+	// Give every subcommand flag an environment-variable layer with precedence
+	// explicit flag > env > default. Bind runs (as the inherited PersistentPreRunE)
+	// for whichever leaf command executes; Decorate advertises each flag's env
+	// var in --help. Both derive NYRO_<SUB>_<FLAG> names from the command path,
+	// so no subcommand code needs to know about env binding.
+	root.PersistentPreRunE = envflag.Bind
 	root.AddCommand(gateway.NewCmd())
 	root.AddCommand(admin.NewCmd())
 	root.AddCommand(ca.NewCmd())
 	root.AddCommand(newVersionCmd())
+	envflag.Decorate(root)
 	return root
 }
 


### PR DESCRIPTION
## What

Adds an environment-variable layer to the `nyro` CLI so every subcommand flag follows the standard 12-factor precedence:

```
explicit flag  >  environment variable  >  built-in default
```

Before this change, `nyro` used plain cobra/pflag with no env layer — the only precedence was `explicit flag > default`.

## How

- **New package `go/internal/envflag`**:
  - `Bind` — installed as the root's `PersistentPreRunE`. For the executed leaf command, it applies the `NYRO_<SUB>_<FLAG>` env var to any flag the user did **not** set explicitly (`!Changed`), via `Flags().Set` (which also marks it Changed, so downstream validation treats an env value like an explicit one).
  - `Decorate` — appends an `(env NYRO_...)` hint to every flag's `--help` usage for discoverability.
  - Env var names are derived automatically from `CommandPath()`: `nyro admin --dsn` → `NYRO_ADMIN_DSN`, `nyro gateway --listen` → `NYRO_GATEWAY_LISTEN`, `nyro ca sign-admin --out` → `NYRO_CA_SIGN_ADMIN_OUT`.
- **`go/nyro.go`**: two lines — wire `PersistentPreRunE` and call `Decorate` after the tree is assembled. `admin.go` / `gateway.go` / `ca.go` are untouched; future subcommands/flags get env support automatically.
- `go.mod`: `spf13/pflag` promoted to a direct dependency.

## Examples

```
NYRO_ADMIN_DSN=mysql://user:pass@host:3306/db nyro admin
NYRO_GATEWAY_LISTEN=0.0.0.0:29530 nyro gateway --config-file cfg.yaml
```

## Testing

- `go build ./...` and `go test ./...` pass.
- New `envflag_test.go` covers precedence (flag beats env, env beats default), typed parsing (bool/duration), invalid-value errors, name mapping, prefix derivation for nested subcommands, and help decoration.
- Verified end-to-end: `NYRO_CA_INIT_DIR=<dir> nyro ca init` writes the CA there, and an explicit `--dir` overrides the env var.