### PR TITLE
feat(go/nodes): show connection uptime and transport-security icon

### DIFF
--- a/go/internal/configsync/server.go
+++ b/go/internal/configsync/server.go
@@ -49,6 +49,7 @@ type streamClient struct {
 	hostname    string
 	servicePort string
 	remoteAddr  string
+	connMode    string // "mtls" | "tls" | "plaintext"
 	connectedAt time.Time
 
 	mu          sync.Mutex
@@ -63,6 +64,7 @@ type NodeInfo struct {
 	AppVersion     string    `json:"app_version"`
 	ServicePort    string    `json:"service_port"`
 	RemoteAddr     string    `json:"remote_addr"`
+	ConnMode       string    `json:"conn_mode"`
 	ConnectedAt    time.Time `json:"connected_at"`
 	AppliedVersion int64     `json:"applied_version"`
 }
@@ -84,6 +86,7 @@ func NewConfigServer(store storage.Storage) *ConfigServer {
 func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreamingServer[pb.ConfigSnapshot]) error {
 	ctx := stream.Context()
 	remoteAddr := ""
+	connMode := "plaintext"
 	nodeID := req.GetNodeId()
 	if p, ok := peer.FromContext(ctx); ok {
 		if p.Addr != nil {
@@ -95,12 +98,20 @@ func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreami
 		// trivially spoofable. In plaintext mode, p.AuthInfo carries no TLS
 		// state, so this is a no-op and the self-reported node_id passes through
 		// unchanged.
-		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok && len(tlsInfo.State.VerifiedChains) > 0 && len(tlsInfo.State.VerifiedChains[0]) > 0 {
-			leaf := tlsInfo.State.VerifiedChains[0][0]
-			if id, err := pki.GatewayNodeIDFromCert(leaf); err == nil {
-				nodeID = id
+		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok {
+			// A verified client chain means the client authenticated with a
+			// cert (mutual TLS); TLS without a verified chain is server-only
+			// TLS. Both are surfaced for operational visibility.
+			if len(tlsInfo.State.VerifiedChains) > 0 && len(tlsInfo.State.VerifiedChains[0]) > 0 {
+				connMode = "mtls"
+				leaf := tlsInfo.State.VerifiedChains[0][0]
+				if id, err := pki.GatewayNodeIDFromCert(leaf); err == nil {
+					nodeID = id
+				} else {
+					log.Printf("configsync: client cert has no usable identity, keeping self-reported node_id: %v", err)
+				}
 			} else {
-				log.Printf("configsync: client cert has no usable identity, keeping self-reported node_id: %v", err)
+				connMode = "tls"
 			}
 		}
 	}
@@ -116,6 +127,7 @@ func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreami
 		hostname:    req.GetHostname(),
 		servicePort: req.GetServicePort(),
 		remoteAddr:  remoteAddr,
+		connMode:    connMode,
 		connectedAt: time.Now(),
 	}
 	s.register(c)
@@ -251,6 +263,7 @@ func (s *ConfigServer) Nodes() []NodeInfo {
 			AppVersion:     c.appVersion,
 			ServicePort:    c.servicePort,
 			RemoteAddr:     c.remoteAddr,
+			ConnMode:       c.connMode,
 			ConnectedAt:    c.connectedAt,
 			AppliedVersion: c.getLastVersion(),
 		})

--- a/go/webui/src/lib/format.ts
+++ b/go/webui/src/lib/format.ts
@@ -6,6 +6,24 @@ export function formatDuration(ms: number | null | undefined): string {
   return `${(ms / 3_600_000).toFixed(1)} h`;
 }
 
+// formatUptime renders how long a stream has been connected (now − fromIso) as
+// a compact, locale-independent two-unit string ("2d 3h" / "2h 15m" / "15m" /
+// "<1m"). Recomputed on each render, so callers relying on a polling refresh
+// see it tick up over time.
+export function formatUptime(fromIso: string): string {
+  const start = new Date(fromIso).getTime();
+  if (Number.isNaN(start)) return "–";
+  const ms = Date.now() - start;
+  if (ms < 60_000) return "<1m";
+  const totalMin = Math.floor(ms / 60_000);
+  const days = Math.floor(totalMin / 1440);
+  const hours = Math.floor((totalMin % 1440) / 60);
+  const mins = totalMin % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
 export function formatLogTime(ts: number | string | null | undefined): string {
   if (ts == null) return "–";
   const date = typeof ts === "number" ? new Date(ts) : (() => {

--- a/go/webui/src/lib/types.ts
+++ b/go/webui/src/lib/types.ts
@@ -272,6 +272,8 @@ export interface GatewayNode {
   app_version: string;
   service_port: string;
   remote_addr: string;
+  /** Transport security of the config-sync stream: "mtls" | "tls" | "plaintext". Optional for backward-compat with older gateways. */
+  conn_mode?: string;
   connected_at: string;
   applied_version: number;
 }

--- a/go/webui/src/pages/nodes.tsx
+++ b/go/webui/src/pages/nodes.tsx
@@ -1,29 +1,34 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Info, Server } from "lucide-react";
+import { Check, Copy, Info, Lock, LockOpen, Server } from "lucide-react";
 import { backend } from "@/lib/backend";
 import type { GatewayNode } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
+import { formatUptime } from "@/lib/format";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
-// Locale-specific formatting: zh-CN reads as 24-hour "YYYY/MM/DD HH:mm:ss",
-// en-US as 12-hour "MM/DD/YYYY hh:mm:ss AM/PM" — Intl.DateTimeFormat with
-// explicit "2-digit" parts (rather than the bare toLocaleString default)
-// guarantees single-digit month/day/hour are always zero-padded. Formats via
-// formatToParts (not .format) so the en-US locale's date/time separator
-// comma can be dropped in favor of a plain space.
-function formatConnectedAt(iso: string, isZh: boolean) {
+// The absolute connect timestamp is only shown on hover (the cell itself shows
+// uptime), so it uses one fixed, locale-independent format — "YYYY/MM/DD
+// HH:mm:ss", 24-hour, zero-padded — rather than branching on the UI language.
+function formatConnectedAt(iso: string) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  const parts = new Intl.DateTimeFormat(isZh ? "zh-CN" : "en-US", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: !isZh,
-  }).formatToParts(d);
-  return parts.map((p) => (p.type === "literal" ? p.value.replace(",", "") : p.value)).join("");
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}/${p(d.getMonth() + 1)}/${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+// connModeBadge maps the config-sync stream's transport security to an icon +
+// label. mTLS (mutually authenticated) reads as the secure baseline (green);
+// server-only TLS is amber; plaintext / unknown shows an open lock.
+function connModeBadge(mode: string | undefined, isZh: boolean) {
+  switch (mode) {
+    case "mtls":
+      return { Icon: Lock, label: "mTLS", className: "text-emerald-600" };
+    case "tls":
+      return { Icon: Lock, label: "TLS", className: "text-amber-600" };
+    default:
+      return { Icon: LockOpen, label: isZh ? "明文" : "Plaintext", className: "text-slate-400" };
+  }
 }
 
 // remote_addr is the config-sync gRPC connection's peer address (host +
@@ -54,6 +59,32 @@ function formatServiceAddress(remoteAddr: string, servicePort: string) {
   if (!host) return `:${servicePort}`;
   if (!servicePort) return host;
   return `${host}:${servicePort}`;
+}
+
+// CopyButton copies `value` to the clipboard and briefly swaps its icon to a
+// check as feedback. Self-contained so each row manages its own copied state.
+function CopyButton({ value, isZh }: { value: string; isZh: boolean }) {
+  const [copied, setCopied] = useState(false);
+  if (!value || value === "-") return null;
+  return (
+    <button
+      type="button"
+      aria-label={isZh ? "复制" : "Copy"}
+      title={copied ? (isZh ? "已复制" : "Copied") : isZh ? "复制" : "Copy"}
+      className="inline-flex text-slate-400 transition-colors hover:text-slate-600"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          // Clipboard may be unavailable (insecure context); ignore silently.
+        }
+      }}
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
 }
 
 const COLUMN_COUNT = 7;
@@ -119,7 +150,7 @@ export default function NodesPage() {
                 </th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "网关版本" : "Gateway Version"}</th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "配置版本" : "Config Version"}</th>
-                <th className="px-3 py-2 text-left font-medium">{isZh ? "连接时间" : "Connected At"}</th>
+                <th className="px-3 py-2 text-left font-medium">{isZh ? "连接" : "Connection"}</th>
                 <th className="px-3 py-2 text-left font-medium">{isZh ? "状态" : "Status"}</th>
               </tr>
             </thead>
@@ -150,13 +181,42 @@ export default function NodesPage() {
                   </td>
                   <td className="px-3 py-2">{n.hostname || "-"}</td>
                   <td className="px-3 py-2 font-mono text-xs">
-                    {formatServiceAddress(n.remote_addr, n.service_port)}
+                    <span className="inline-flex items-center gap-1.5">
+                      {formatServiceAddress(n.remote_addr, n.service_port)}
+                      <CopyButton value={formatServiceAddress(n.remote_addr, n.service_port)} isZh={isZh} />
+                    </span>
                   </td>
                   <td className="px-3 py-2">{n.app_version || "-"}</td>
                   <td className="px-3 py-2">{n.applied_version}</td>
-                  <td className="px-3 py-2">{formatConnectedAt(n.connected_at, isZh)}</td>
                   <td className="px-3 py-2">
-                    <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700">
+                    {(() => {
+                      const { Icon, label, className } = connModeBadge(n.conn_mode, isZh);
+                      return (
+                        <TooltipProvider delayDuration={120}>
+                          <span className="inline-flex items-center gap-1.5">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className={`inline-flex cursor-help ${className}`} aria-label={label}>
+                                  <Icon className="h-3.5 w-3.5" />
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>{label}</TooltipContent>
+                            </Tooltip>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="cursor-help text-slate-700">
+                                  {formatUptime(n.connected_at)}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>{formatConnectedAt(n.connected_at)}</TooltipContent>
+                            </Tooltip>
+                          </span>
+                        </TooltipProvider>
+                      );
+                    })()}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className="inline-flex items-center gap-1.5 text-xs font-bold text-emerald-700">
                       <span className="h-2 w-2 rounded-full bg-emerald-500" />
                       {isZh ? "已连接" : "Connected"}
                     </span>


### PR DESCRIPTION
## 背景

「节点」页面此前把「连接时间」显示为连接建立的绝对时间点。对运维视角来说，「已连接多久」（uptime）比「几点连上的」更直观。同时页面完全没有展示连接方式，而 config-sync 服务端在握手时其实已经能区分 mTLS / TLS / 明文，只是没有透出。

## 改动

**后端** `go/internal/configsync/server.go`
- `streamClient` 记录 `connMode`（`mtls` / `tls` / `plaintext`），复用已有的 `TLSInfo` 判定逻辑
- `NodeInfo` 新增 `conn_mode` 字段，经 `/api/v1/nodes` 自动 JSON 透出

**前端** `go/webui`
- `format.ts`：新增 `formatUptime`（紧凑、语言无关：`2h 15m` / `2d 3h` / `<1m`）
- `types.ts`：`GatewayNode` 加可选 `conn_mode`
- `nodes.tsx`：连接列改为「🔒 图标 + 时长」——图标颜色/形状表示模式（绿锁 mTLS / 琥珀锁 TLS / 灰开锁 明文，悬停 tooltip 显示模式名），时长悬停显示单一固定格式的精确连接时间点
- 服务地址列增加复制按钮

## 验证
- `go build ./... && go test ./internal/configsync/...` ✅
- `pnpm build`（含 tsc 类型检查）✅