### PR TITLE
fix(go/observability): control-plane telemetry pipeline fixes

### DIFF
--- a/go/cmd/admin/admin.go
+++ b/go/cmd/admin/admin.go
@@ -183,6 +183,19 @@ func NewCmd() *cobra.Command {
 		}
 		rcv := observability.NewReceiver(logSink, metricSink, traceSink)
 
+		// Time-trigger flush: the sinks flush on their size trigger (maxRows) or
+		// on shutdown, so without this a low-traffic deployment would never fill a
+		// buffer and /logs + /stats would stay empty until restart. The cadence is
+		// the per-signal obs_<signal>_flush_interval settings (resolved into obsCfg
+		// by LoadConfig, each defaulting to DefaultFlushInterval) — siblings of the
+		// retention settings, edited in the WebUI's Local Telemetry card and applied
+		// at boot. Whichever trigger fires first wins.
+		rcv.StartFlusher(ctx, observability.SignalFlush{
+			Logs:    obsCfg.LogsFlushInterval,
+			Metrics: obsCfg.MetricsFlushInterval,
+			Traces:  obsCfg.TracesFlushInterval,
+		})
+
 		// Janitor sweeps aged parquet files per signal on an hourly tick; exits
 		// when ctx is cancelled (server shutdown).
 		observability.StartJanitor(ctx, obsCfg.DataDir, observability.SignalRetention{

--- a/go/cmd/gateway/gateway.go
+++ b/go/cmd/gateway/gateway.go
@@ -82,18 +82,18 @@ func NewCmd() *cobra.Command {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		gw, stopConfigSync, obsProvider, err := buildGateway(ctx, cfgPath, configSyncAddr, addr, configTLS)
+		gw, stopConfigSync, obsMgr, err := buildGateway(ctx, cfgPath, configSyncAddr, addr, configTLS)
 		if err != nil {
 			return err
 		}
 		if stopConfigSync != nil {
 			defer stopConfigSync()
 		}
-		if obsProvider != nil {
+		if obsMgr != nil {
 			defer func() {
 				shutCtx, shutCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 				defer shutCancel()
-				if err := obsProvider.Shutdown(shutCtx); err != nil {
+				if err := obsMgr.Shutdown(shutCtx); err != nil {
 					slog.Warn("observability provider shutdown failed", "error", err)
 				}
 			}()
@@ -126,17 +126,21 @@ func servicePort(addr string) string {
 
 // buildGateway selects the config source and returns a ready, storage-free
 // Gateway plus an optional config-sync client stop function (nil unless
-// --config-server) and the OTel provider (always non-nil on success —
-// telemetry is wired in every mode). It constructs the ObsProvider + Handles
-// and calls RegisterHooks exactly ONCE per process (the plugin registry
-// accumulates appends, so re-registering would double-emit). /readyz reflects
-// cache fill, not storage health.
+// --config-server) and the observability manager (always non-nil on success —
+// telemetry is wired in every mode). It constructs the initial ObsProvider,
+// wraps it in a SwappableProvider, and calls RegisterHooks exactly ONCE per
+// process (the plugin registry accumulates appends, so re-registering would
+// double-emit). In --config-server mode it also registers the manager's
+// hot-reload callback on the cache BEFORE starting the config stream, so the
+// control-plane-seeded obs settings (which arrive with the first snapshot,
+// after this initial build) are applied instead of stuck on the stdout default.
+// /readyz reflects cache fill, not storage health.
 //
 // listenAddr is this gateway's own data-plane --listen (host:port); only its
 // port is used, reported over config-sync as Subscribe.service_port so the
 // admin's node list can show where each gateway actually serves traffic
 // (distinct from the config-sync gRPC connection's ephemeral peer port).
-func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr string, configTLS *tls.Config) (gw *proxy.Gateway, stopConfigSync func(), obs *observability.ObsProvider, err error) {
+func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr string, configTLS *tls.Config) (gw *proxy.Gateway, stopConfigSync func(), obs *obsManager, err error) {
 	switch {
 	case cfgPath != "":
 		// Standalone YAML: build the config snapshot directly (no DB). The
@@ -159,39 +163,47 @@ func buildGateway(ctx context.Context, cfgPath, configSyncAddr, listenAddr strin
 		cache.Swap(snap)
 		gw = proxy.NewGatewayWithCache(cache)
 
+		// Standalone config is static: the snapshot is already in the cache, so
+		// the initial resolve sees the real (YAML-declared) obs config and no
+		// hot-reload callback is needed — the cache never swaps again.
 		obsCfg := resolveObsConfig(cache)
 		prov, perr := observability.NewProvider(ctx, obsCfg)
 		if perr != nil {
 			return nil, nil, nil, fmt.Errorf("observability provider: %w", perr)
 		}
-		attachObservability(gw, prov)
-		startMetricsServer(ctx, prov, obsCfg.Metrics.Params["path"])
-		return gw, nil, prov, nil
+		sp := observability.NewSwappableProvider(prov)
+		attachObservability(gw, prov, sp)
+		return gw, nil, newObsManager(ctx, cache, sp, prov, obsCfg), nil
 
 	case configSyncAddr != "":
 		// config-sync hot-reload: empty cache is filled by the stream.
-		// Observability config is read from the cache snapshot (published by
-		// the admin) once it arrives.
 		cache := &configsync.ConfigCache{}
+		gw = proxy.NewGatewayWithCache(cache)
+
+		// Build the INITIAL provider from the still-empty cache: it resolves to
+		// the fixed default (logs→stdout, metrics/traces disabled). The real obs
+		// config (the admin-seeded otlp settings, or anything an operator edits
+		// later) arrives with config-sync snapshots and is applied by
+		// mgr.rebuild. Registering SetOnSwap BEFORE starting the client is what
+		// closes the startup race that previously left the gateway stuck on the
+		// stdout default: no snapshot can be published until client.Run starts.
+		obsCfg := resolveObsConfig(cache)
+		prov, perr := observability.NewProvider(ctx, obsCfg)
+		if perr != nil {
+			return nil, nil, nil, fmt.Errorf("observability provider: %w", perr)
+		}
+		sp := observability.NewSwappableProvider(prov)
+		attachObservability(gw, prov, sp)
+		mgr := newObsManager(ctx, cache, sp, prov, obsCfg)
+		cache.SetOnSwap(mgr.rebuild)
+
 		client := configsync.NewConfigClient(configSyncAddr, cache, servicePort(listenAddr), configTLS)
 		go func() { _ = client.Run(ctx) }()
 		pki.WatchExpiry(ctx, configTLS, configExpiryCheckInterval, func(notAfter time.Time) {
 			slog.Warn("config-sync client certificate expiring soon — run `nyro ca sign-gateway` and redistribute before it lapses",
 				"not_after", notAfter, "remaining", time.Until(notAfter).Round(time.Hour))
 		})
-		gw = proxy.NewGatewayWithCache(cache)
-
-		// Read obs settings from the cache snapshot when present (the control-
-		// plane push); before the first push lands, or when nothing was pushed,
-		// apply the fixed default — never env vars (see resolveObsConfig).
-		obsCfg := resolveObsConfig(cache)
-		prov, perr := observability.NewProvider(ctx, obsCfg)
-		if perr != nil {
-			return nil, nil, nil, fmt.Errorf("observability provider: %w", perr)
-		}
-		attachObservability(gw, prov)
-		startMetricsServer(ctx, prov, obsCfg.Metrics.Params["path"])
-		return gw, nil, prov, nil
+		return gw, nil, mgr, nil
 
 	default:
 		// Unreachable: RunE enforces the XOR. Guard anyway.
@@ -226,12 +238,17 @@ func resolveConfigSyncClientTLS(caPath, certPath, keyPath string) (*tls.Config, 
 	}
 }
 
-// attachObservability wires the ObsProvider + Handles into the Gateway and
-// registers the OTel phase hooks ONCE per process. Safe to call exactly once.
-func attachObservability(gw *proxy.Gateway, prov *observability.ObsProvider) {
+// attachObservability wires the initial ObsProvider into the Gateway and
+// registers the OTel phase hooks ONCE per process against the SwappableProvider.
+// Must be called exactly once: the hooks read the current pipeline from sp on
+// every request, so a hot-reload swaps sp (obsManager.rebuild) rather than
+// re-registering. gw.Obs/gw.Handles are informational only (the proxy dispatch
+// path does not read them — telemetry flows entirely through the sp-backed
+// hooks) and reflect the initial provider.
+func attachObservability(gw *proxy.Gateway, prov *observability.ObsProvider, sp *observability.SwappableProvider) {
 	gw.Obs = prov
 	gw.Handles = observability.NewHandles(prov.Meter)
-	observability.RegisterHooks(prov.Tracer, prov.Logger, gw.Handles)
+	observability.RegisterHooks(sp)
 }
 
 // cacheObsGet returns a get-func that reads obs_* settings from the
@@ -320,49 +337,15 @@ func defaultObsGet(key string) (string, error) {
 	return "", nil
 }
 
-// startMetricsServer starts a second, independent http.Server exposing
-// Prometheus scrape output on obs.PromListen, but only when obs.PromHandler
-// is non-nil (i.e. the metrics signal is configured with exporter=prometheus
-// — see observability.NewProvider). It is a no-op otherwise: the gateway's
-// primary server (bootstrap.RunServer) never carries a /metrics route, so
-// nothing starts unless prometheus was actually selected.
-//
-// The server is best-effort: a bind/serve failure is logged (slog.Error) but
-// never fatal, since a broken scrape endpoint must not take down request
-// serving. It shuts down (with a bounded timeout, matching shutdownTimeout
-// used elsewhere in this file) once ctx is cancelled.
-func startMetricsServer(ctx context.Context, obs *observability.ObsProvider, path string) {
-	if obs == nil || obs.PromHandler == nil {
-		return
-	}
-	srv := newMetricsServer(obs, path)
-
-	go func() {
-		slog.Info("prometheus metrics server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("prometheus metrics server failed", "error", err)
-		}
-	}()
-
-	go func() {
-		<-ctx.Done()
-		shutCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := srv.Shutdown(shutCtx); err != nil {
-			slog.Warn("prometheus metrics server shutdown failed", "error", err)
-		}
-	}()
-}
-
-// newMetricsServer builds (without starting) the http.Server that
-// startMetricsServer runs: obs.PromHandler mounted at path on a fresh mux,
+// newMetricsServer builds (without starting) the http.Server the obsManager
+// runs for prometheus scraping: obs.PromHandler mounted at path on a fresh mux,
 // listening on obs.PromListen. path defaults to "/metrics" when empty —
 // defensive, since observability.LoadConfig always fills the prometheus
 // exporter's "path" field from its registry default when the signal is
 // configured, but NewProvider (and therefore ObsProvider) can also be built
 // directly from a hand-assembled ObsConfig that skipped LoadConfig. Split out
-// from startMetricsServer so tests can inspect routing/Addr without binding a
-// real network port.
+// from the obsManager's start path so tests can inspect routing/Addr without
+// binding a real network port.
 func newMetricsServer(obs *observability.ObsProvider, path string) *http.Server {
 	if path == "" {
 		path = "/metrics"

--- a/go/cmd/gateway/gateway_test.go
+++ b/go/cmd/gateway/gateway_test.go
@@ -2,13 +2,11 @@ package gateway
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/nyroway/nyro/go/internal/configsync"
 	"github.com/nyroway/nyro/go/internal/observability"
@@ -353,73 +351,3 @@ func TestNewMetricsServer_CustomPath(t *testing.T) {
 	}
 }
 
-func TestStartMetricsServer_NilHandlerIsNoOp(t *testing.T) {
-	// Must not panic and must not start anything when metrics isn't
-	// configured as prometheus (PromHandler == nil).
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	startMetricsServer(ctx, &observability.ObsProvider{}, "")
-	startMetricsServer(ctx, nil, "")
-}
-
-// TestStartMetricsServer_BindsAndShutsDownOnCtxCancel is the one test in this
-// file that binds a real port — deliberately picking an OS-assigned free port
-// (":0" via net.Listen, then closing immediately) to avoid a fixed-port
-// collision in CI, at the cost of a small, standard TOCTOU race window that
-// is common practice for this kind of test.
-func TestStartMetricsServer_BindsAndShutsDownOnCtxCancel(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("find free port: %v", err)
-	}
-	addr := ln.Addr().String()
-	if err := ln.Close(); err != nil {
-		t.Fatalf("close probe listener: %v", err)
-	}
-
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
-	obs := &observability.ObsProvider{PromHandler: h, PromListen: addr}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	startMetricsServer(ctx, obs, "")
-
-	var lastErr error
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://" + addr + "/metrics")
-		if err == nil {
-			statusCode := resp.StatusCode
-			if closeErr := resp.Body.Close(); closeErr != nil {
-				t.Fatalf("close response body: %v", closeErr)
-			}
-			if statusCode == http.StatusOK {
-				lastErr = nil
-				break
-			}
-		}
-		lastErr = err
-		time.Sleep(20 * time.Millisecond)
-	}
-	if lastErr != nil {
-		t.Fatalf("server never became reachable at %s: %v", addr, lastErr)
-	}
-
-	cancel()
-
-	deadline = time.Now().Add(2 * time.Second)
-	var shutErr error
-	for time.Now().Before(deadline) {
-		var resp *http.Response
-		resp, shutErr = http.Get("http://" + addr + "/metrics")
-		if resp != nil {
-			_ = resp.Body.Close()
-		}
-		if shutErr != nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if shutErr == nil {
-		t.Fatal("expected the metrics server to stop accepting connections after ctx cancellation")
-	}
-}

--- a/go/cmd/gateway/gateway_test.go
+++ b/go/cmd/gateway/gateway_test.go
@@ -350,4 +350,3 @@ func TestNewMetricsServer_CustomPath(t *testing.T) {
 		t.Error("default /metrics path should not respond when a custom path was configured")
 	}
 }
-

--- a/go/cmd/gateway/obs.go
+++ b/go/cmd/gateway/obs.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/nyroway/nyro/go/internal/configsync"
+	"github.com/nyroway/nyro/go/internal/observability"
+)
+
+// obsReloadGrace is how long a displaced ObsProvider is kept alive after a
+// hot-reload before being shut down. In-flight requests that already loaded the
+// old SwappableProvider set (e.g. a span started under the previous tracer)
+// finish emitting through it during this window; a request longer than the
+// grace may lose its final span/log export, which is acceptable for the rare
+// event of an operator changing observability config mid-flight.
+const obsReloadGrace = 30 * time.Second
+
+// obsManager owns the gateway's hot-reloadable observability pipeline. The OTel
+// provider is built once at startup (in config-server mode, from the still-empty
+// cache, so it resolves to the fixed stdout default) and rebuilt whenever a
+// config-sync snapshot changes the resolved ObsConfig — this is what lets the
+// control-plane-seeded otlp settings, which only arrive AFTER startup over the
+// config stream, actually take effect. The phase hooks read the current pipeline
+// through sp (SwappableProvider) so a rebuild never re-registers them.
+type obsManager struct {
+	ctx   context.Context
+	cache *configsync.ConfigCache
+	sp    *observability.SwappableProvider
+
+	mu         sync.Mutex
+	lastCfg    observability.ObsConfig
+	current    *observability.ObsProvider
+	metricsSrv *http.Server // running prometheus scrape server, nil if none
+}
+
+// newObsManager wires the manager around an already-built initial provider and
+// its resolved config, and starts the prometheus scrape server if that initial
+// config selected the prometheus metrics exporter. It does NOT register the
+// SetOnSwap callback — the caller does that (only config-server mode needs it),
+// after ensuring no snapshot can be published before the callback is in place.
+func newObsManager(ctx context.Context, cache *configsync.ConfigCache, sp *observability.SwappableProvider, initial *observability.ObsProvider, initialCfg observability.ObsConfig) *obsManager {
+	m := &obsManager{
+		ctx:     ctx,
+		cache:   cache,
+		sp:      sp,
+		lastCfg: initialCfg,
+		current: initial,
+	}
+	m.mu.Lock()
+	m.startMetricsLocked(initial, initialCfg.Metrics.Params["path"])
+	m.mu.Unlock()
+	return m
+}
+
+// rebuild re-resolves observability config from the current cache snapshot and,
+// if it changed, builds a fresh provider, swaps it into sp (so hooks pick it up),
+// reconciles the prometheus scrape server, and schedules the displaced provider
+// for shutdown after a grace period. It is the SetOnSwap callback, invoked
+// synchronously on the config-sync receive goroutine after each snapshot.
+//
+// A build failure is non-fatal: the current provider keeps serving and the error
+// is logged, so a malformed obs setting pushed by the control plane never breaks
+// telemetry (or, worse, request serving) on the data plane.
+func (m *obsManager) rebuild() {
+	newCfg := resolveObsConfig(m.cache)
+
+	m.mu.Lock()
+	if reflect.DeepEqual(newCfg, m.lastCfg) {
+		m.mu.Unlock()
+		return
+	}
+	newProv, err := observability.NewProvider(m.ctx, newCfg)
+	if err != nil {
+		m.mu.Unlock()
+		slog.Error("observability hot-reload: building new provider failed; keeping current pipeline", "error", err)
+		return
+	}
+	old := m.current
+	m.sp.Swap(newProv)
+	m.current = newProv
+	m.lastCfg = newCfg
+	m.stopMetricsLocked()
+	m.startMetricsLocked(newProv, newCfg.Metrics.Params["path"])
+	m.mu.Unlock()
+
+	slog.Info("observability hot-reload: applied new config from control plane",
+		"logs", newCfg.Logs.Kind, "metrics", newCfg.Metrics.Kind, "traces", newCfg.Traces.Kind)
+
+	// Shut the displaced provider down after a grace period so in-flight
+	// requests holding the old set can flush. Skipped when old==newProv (never)
+	// or old is nil.
+	if old != nil && old != newProv {
+		time.AfterFunc(obsReloadGrace, func() {
+			shutCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cancel()
+			if err := old.Shutdown(shutCtx); err != nil {
+				slog.Warn("observability hot-reload: displaced provider shutdown failed", "error", err)
+			}
+		})
+	}
+}
+
+// startMetricsLocked starts the prometheus scrape server for prov when its
+// metrics exporter is prometheus (PromHandler != nil); a no-op otherwise. The
+// caller must hold m.mu. Best-effort: a bind/serve failure is logged but never
+// fatal, matching the original startMetricsServer contract.
+func (m *obsManager) startMetricsLocked(prov *observability.ObsProvider, path string) {
+	if prov == nil || prov.PromHandler == nil {
+		return
+	}
+	srv := newMetricsServer(prov, path)
+	m.metricsSrv = srv
+	go func() {
+		slog.Info("prometheus metrics server starting", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("prometheus metrics server failed", "error", err)
+		}
+	}()
+}
+
+// stopMetricsLocked synchronously shuts down the running scrape server (if any).
+// Synchronous (rather than ctx-cancel + async) so a same-address restart during
+// reconciliation cannot race the old server for the port. The caller must hold
+// m.mu.
+func (m *obsManager) stopMetricsLocked() {
+	if m.metricsSrv == nil {
+		return
+	}
+	shutCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := m.metricsSrv.Shutdown(shutCtx); err != nil {
+		slog.Warn("prometheus metrics server shutdown failed", "error", err)
+	}
+	m.metricsSrv = nil
+}
+
+// Shutdown stops the scrape server and flushes the current provider. Called via
+// the gateway's graceful-exit defer. Displaced providers scheduled by a prior
+// rebuild are torn down by process exit if their grace timer has not yet fired.
+func (m *obsManager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopMetricsLocked()
+	if m.current != nil {
+		return m.current.Shutdown(ctx)
+	}
+	return nil
+}

--- a/go/cmd/gateway/obs_test.go
+++ b/go/cmd/gateway/obs_test.go
@@ -1,0 +1,168 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nyroway/nyro/go/internal/configsync"
+	"github.com/nyroway/nyro/go/internal/observability"
+)
+
+// buildManager wires an obsManager the way buildGateway's config-server branch
+// does: an initial provider resolved from cache, a SwappableProvider, and the
+// rebuild callback registered on the cache. Returns the manager and cache so a
+// test can push new snapshots and observe the hot-reload.
+func buildManager(t *testing.T, cache *configsync.ConfigCache) *obsManager {
+	t.Helper()
+	obsCfg := resolveObsConfig(cache)
+	prov, err := observability.NewProvider(context.Background(), obsCfg)
+	if err != nil {
+		t.Fatalf("initial NewProvider: %v", err)
+	}
+	sp := observability.NewSwappableProvider(prov)
+	mgr := newObsManager(context.Background(), cache, sp, prov, obsCfg)
+	cache.SetOnSwap(mgr.rebuild)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+	return mgr
+}
+
+// snapshotWith builds a config snapshot carrying the given settings, mirroring
+// what a control-plane push populates.
+func snapshotWith(settings map[string]string) *configsync.ConfigSnapshot {
+	var b configsync.Snapshot
+	for k, v := range settings {
+		b.SetSetting(k, v)
+	}
+	return b.Done()
+}
+
+// TestObsManager_HotReloadSwitchesLogsToOTLP is the regression test for the
+// reported bug: a config-server gateway builds its initial provider from an
+// empty cache (→ stdout logs default), and must switch to the otlp exporter the
+// control plane pushes with the first snapshot — WITHOUT a restart.
+func TestObsManager_HotReloadSwitchesLogsToOTLP(t *testing.T) {
+	cache := &configsync.ConfigCache{} // empty: initial resolve → stdout default
+	mgr := buildManager(t, cache)
+
+	if got := mgr.lastCfg.Logs.Kind; got != observability.ExporterKindStdout {
+		t.Fatalf("initial Logs.Kind = %q; want stdout default", got)
+	}
+	initial := mgr.current
+
+	// The admin push: all three signals seeded to otlp at the admin's endpoint.
+	cache.Swap(snapshotWith(map[string]string{
+		"obs_logs_exporter":         "otlp",
+		"obs_logs_otlp_endpoint":    "http://127.0.0.1:19531",
+		"obs_metrics_exporter":      "otlp",
+		"obs_metrics_otlp_endpoint": "http://127.0.0.1:19531",
+		"obs_traces_exporter":       "otlp",
+		"obs_traces_otlp_endpoint":  "http://127.0.0.1:19531",
+	}))
+
+	if got := mgr.lastCfg.Logs.Kind; got != observability.ExporterKindOTLP {
+		t.Errorf("after push Logs.Kind = %q; want otlp (hot-reload did not apply)", got)
+	}
+	if got := mgr.lastCfg.Traces.Kind; got != observability.ExporterKindOTLP {
+		t.Errorf("after push Traces.Kind = %q; want otlp", got)
+	}
+	if mgr.current == initial {
+		t.Error("expected the provider to be rebuilt (current still points at the initial provider)")
+	}
+}
+
+// TestObsManager_RebuildIsNoOpWhenConfigUnchanged ensures a snapshot that does
+// not change obs settings (the common case — most pushes are upstream/route
+// edits) does not churn the provider.
+func TestObsManager_RebuildIsNoOpWhenConfigUnchanged(t *testing.T) {
+	cache := &configsync.ConfigCache{}
+	mgr := buildManager(t, cache)
+	initial := mgr.current
+
+	// A push with no obs settings resolves to the same default → no rebuild.
+	cache.Swap(snapshotWith(map[string]string{"proxy.max_retries": "3"}))
+
+	if mgr.current != initial {
+		t.Error("provider was rebuilt for a snapshot that did not change obs config")
+	}
+}
+
+// TestObsManager_PrometheusServerLifecycle proves the scrape server is started
+// when the pushed config selects the prometheus metrics exporter, and stopped on
+// manager Shutdown. It binds a real, OS-assigned free port.
+func TestObsManager_PrometheusServerLifecycle(t *testing.T) {
+	addr := freePort(t)
+
+	cache := &configsync.ConfigCache{}
+	mgr := buildManager(t, cache) // starts with stdout logs, no metrics server
+
+	if mgr.metricsSrv != nil {
+		t.Fatal("no scrape server should run before prometheus is configured")
+	}
+
+	cache.Swap(snapshotWith(map[string]string{
+		"obs_metrics_exporter":          "prometheus",
+		"obs_metrics_prometheus_listen": addr,
+	}))
+
+	if mgr.metricsSrv == nil {
+		t.Fatal("scrape server should be running after prometheus was configured")
+	}
+	if !reachable(t, "http://"+addr+"/metrics") {
+		t.Fatalf("scrape endpoint never became reachable at %s", addr)
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("manager Shutdown: %v", err)
+	}
+	if stillUp(t, "http://"+addr+"/metrics") {
+		t.Error("scrape server still accepting connections after Shutdown")
+	}
+}
+
+// freePort returns an OS-assigned free "127.0.0.1:port" address (closing the
+// probe listener immediately — standard TOCTOU tradeoff for this kind of test).
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close probe listener: %v", err)
+	}
+	return addr
+}
+
+func reachable(t *testing.T, url string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func stillUp(t *testing.T, url string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return true
+}

--- a/go/internal/admin/admin.go
+++ b/go/internal/admin/admin.go
@@ -492,7 +492,7 @@ func bearerAuth(token string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h := r.Header.Get("Authorization")
 			if !strings.HasPrefix(h, "Bearer ") || strings.TrimPrefix(h, "Bearer ") != token {
-				webutil.Error(w, http.StatusUnauthorized, "unauthorized", "auth_error")
+				webutil.Error(w, http.StatusUnauthorized, "unauthorized", "AUTH_ERROR")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/go/internal/configsync/configcache.go
+++ b/go/internal/configsync/configcache.go
@@ -80,7 +80,7 @@ func LoadFromStorage(s storage.Storage) (*ConfigSnapshot, error) {
 		for _, k := range c.Keys {
 			// A key is only usable when both it and its owning consumer are
 			// enabled — disabling a consumer must revoke every key it owns.
-			b.AddConsumerKey(k.ID, c.ID, k.KeyPreview, k.KeyHash, k.Enabled && c.Enabled, k.ExpiresAt, c.Routes, c.Quotas)
+			b.AddConsumerKey(k.ID, c.ID, k.Name, k.KeyPreview, k.KeyHash, k.Enabled && c.Enabled, k.ExpiresAt, c.Routes, c.Quotas)
 		}
 	}
 

--- a/go/internal/configsync/configcache.go
+++ b/go/internal/configsync/configcache.go
@@ -12,13 +12,39 @@ import (
 // one. Until the first Swap, Load() returns nil and Ready() is false.
 type ConfigCache struct {
 	snap atomic.Pointer[ConfigSnapshot]
+	// onSwap is an optional callback fired after every Swap publishes a new
+	// snapshot. It is how the gateway learns a control-plane push arrived so it
+	// can re-resolve observability config and hot-reload the OTel provider (the
+	// obs pipeline is otherwise built once and would never pick up the seeded
+	// otlp settings the admin pushes after startup). Stored behind an atomic
+	// pointer so SetOnSwap is safe to call concurrently with Swap.
+	onSwap atomic.Pointer[func()]
 }
 
 // Load returns the current snapshot (nil before the first Swap).
 func (c *ConfigCache) Load() *ConfigSnapshot { return c.snap.Load() }
 
-// Swap atomically publishes a new snapshot.
-func (c *ConfigCache) Swap(s *ConfigSnapshot) { c.snap.Store(s) }
+// SetOnSwap registers (or replaces, when called again) the callback invoked
+// after each Swap. Pass nil to clear it. It is typically set once at startup,
+// before the config-sync client begins publishing snapshots.
+func (c *ConfigCache) SetOnSwap(fn func()) {
+	if fn == nil {
+		c.onSwap.Store(nil)
+		return
+	}
+	c.onSwap.Store(&fn)
+}
+
+// Swap atomically publishes a new snapshot, then fires the onSwap callback (if
+// any). The callback runs synchronously on the caller's goroutine (the
+// config-sync receive loop) after the snapshot is visible to readers, so it may
+// safely Load() the value just published.
+func (c *ConfigCache) Swap(s *ConfigSnapshot) {
+	c.snap.Store(s)
+	if fn := c.onSwap.Load(); fn != nil {
+		(*fn)()
+	}
+}
 
 // Ready reports whether a snapshot has been published.
 func (c *ConfigCache) Ready() bool { return c.snap.Load() != nil }

--- a/go/internal/configsync/configcache_test.go
+++ b/go/internal/configsync/configcache_test.go
@@ -195,3 +195,47 @@ func waitFor(t *testing.T, d time.Duration, cond func() bool) {
 	}
 	t.Fatalf("condition not met within %v", d)
 }
+
+// TestConfigCache_OnSwapFiresAfterPublish verifies the SetOnSwap callback runs
+// on every Swap and, crucially, AFTER the new snapshot is visible to readers
+// (so the callback may Load() what was just published). This is the hook the
+// gateway relies on to hot-reload observability config from a control-plane
+// push.
+func TestConfigCache_OnSwapFiresAfterPublish(t *testing.T) {
+	var c ConfigCache
+
+	var calls int
+	var seenModel string
+	c.SetOnSwap(func() {
+		calls++
+		if s := c.Load(); s != nil {
+			if r := s.RouteByModel("gpt-4o"); r != nil {
+				seenModel = r.Model
+			}
+		}
+	})
+
+	var b Snapshot
+	b.SetRoute(storage.Route{ID: "r1", Model: "gpt-4o"})
+	c.Swap(b.Done())
+
+	if calls != 1 {
+		t.Errorf("onSwap fired %d times; want 1", calls)
+	}
+	if seenModel != "gpt-4o" {
+		t.Errorf("callback saw model %q; want gpt-4o (snapshot not visible when callback ran)", seenModel)
+	}
+
+	// A second swap fires it again.
+	c.Swap(b.Done())
+	if calls != 2 {
+		t.Errorf("onSwap fired %d times after two swaps; want 2", calls)
+	}
+
+	// Clearing the callback stops further invocations.
+	c.SetOnSwap(nil)
+	c.Swap(b.Done())
+	if calls != 2 {
+		t.Errorf("onSwap fired %d times after clear; want 2", calls)
+	}
+}

--- a/go/internal/configsync/convert.go
+++ b/go/internal/configsync/convert.go
@@ -94,7 +94,7 @@ func SnapshotFromProto(in *pb.ConfigSnapshot) *ConfigSnapshot {
 			if k == nil || k.GetKeyPreview() == "" {
 				continue
 			}
-			b.AddConsumerKey(k.GetId(), k.GetConsumerId(), k.GetKeyPreview(), k.GetKeyHash(), k.GetEnabled(), k.GetExpiresAt(), routes, quotas)
+			b.AddConsumerKey(k.GetId(), k.GetConsumerId(), k.GetName(), k.GetKeyPreview(), k.GetKeyHash(), k.GetEnabled(), k.GetExpiresAt(), routes, quotas)
 		}
 	}
 
@@ -154,7 +154,7 @@ func SnapshotFromStorage(s storage.Storage, version int64) (*pb.ConfigSnapshot, 
 			// A key is only usable when both it and its owning consumer are
 			// enabled — disabling a consumer must revoke every key it owns.
 			pc.Keys = append(pc.Keys, &pb.ConsumerKeyRef{
-				Id: k.ID, ConsumerId: k.ConsumerID, KeyPreview: k.KeyPreview, KeyHash: k.KeyHash,
+				Id: k.ID, ConsumerId: k.ConsumerID, Name: k.Name, KeyPreview: k.KeyPreview, KeyHash: k.KeyHash,
 				Enabled: k.Enabled && c.Enabled, ExpiresAt: k.ExpiresAt,
 			})
 		}

--- a/go/internal/configsync/convert_test.go
+++ b/go/internal/configsync/convert_test.go
@@ -67,7 +67,7 @@ func TestSnapshotFromProto_ConsumerKeysAndGrants(t *testing.T) {
 		Consumers: []*pb.Consumer{{
 			Id: "c-1", Name: "alice", Enabled: true,
 			Keys: []*pb.ConsumerKeyRef{{
-				Id: "k-1", ConsumerId: "c-1", KeyPreview: "sk-abcd", KeyHash: "deadbeef", Enabled: true,
+				Id: "k-1", ConsumerId: "c-1", Name: "codex-key", KeyPreview: "sk-abcd", KeyHash: "deadbeef", Enabled: true,
 			}, {
 				Id: "k-2", ConsumerId: "c-1", KeyPreview: "", KeyHash: "x", // empty preview dropped
 			}},
@@ -82,6 +82,9 @@ func TestSnapshotFromProto_ConsumerKeysAndGrants(t *testing.T) {
 	entries := snap.keysByPreview["sk-abcd"]
 	if len(entries) != 1 || entries[0].ConsumerID != "c-1" || entries[0].KeyHash != "deadbeef" {
 		t.Errorf("consumer key not carried: %+v", entries)
+	}
+	if entries[0].Name != "codex-key" {
+		t.Errorf("consumer key name not carried: got %q, want codex-key", entries[0].Name)
 	}
 	if len(entries[0].Routes) != 2 {
 		t.Errorf("route grants not carried: %+v", entries[0].Routes)

--- a/go/internal/configsync/pb/configsync/v1/configsync.pb.go
+++ b/go/internal/configsync/pb/configsync/v1/configsync.pb.go
@@ -473,6 +473,7 @@ type ConsumerKeyRef struct {
 	KeyHash       string                 `protobuf:"bytes,4,opt,name=key_hash,json=keyHash,proto3" json:"key_hash,omitempty"`
 	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	ExpiresAt     string                 `protobuf:"bytes,6,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	Name          string                 `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -545,6 +546,13 @@ func (x *ConsumerKeyRef) GetEnabled() bool {
 func (x *ConsumerKeyRef) GetExpiresAt() string {
 	if x != nil {
 		return x.ExpiresAt
+	}
+	return ""
+}
+
+func (x *ConsumerKeyRef) GetName() string {
+	if x != nil {
+		return x.Name
 	}
 	return ""
 }
@@ -757,7 +765,7 @@ const file_configsync_v1_configsync_proto_rawDesc = "" +
 	"enableAuth\x12%\n" +
 	"\x0eenable_payload\x18\x05 \x01(\bR\renablePayload\x12\x18\n" +
 	"\aenabled\x18\x06 \x01(\bR\aenabled\x12;\n" +
-	"\atargets\x18\a \x03(\v2!.nyro.configsync.v1.RouteUpstreamR\atargets\"\xb6\x01\n" +
+	"\atargets\x18\a \x03(\v2!.nyro.configsync.v1.RouteUpstreamR\atargets\"\xca\x01\n" +
 	"\x0eConsumerKeyRef\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vconsumer_id\x18\x02 \x01(\tR\n" +
@@ -767,7 +775,8 @@ const file_configsync_v1_configsync_proto_rawDesc = "" +
 	"\bkey_hash\x18\x04 \x01(\tR\akeyHash\x12\x18\n" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x1d\n" +
 	"\n" +
-	"expires_at\x18\x06 \x01(\tR\texpiresAt\"\x98\x01\n" +
+	"expires_at\x18\x06 \x01(\tR\texpiresAt\x12\x12\n" +
+	"\x04name\x18\a \x01(\tR\x04name\"\x98\x01\n" +
 	"\rConsumerQuota\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vconsumer_id\x18\x02 \x01(\tR\n" +

--- a/go/internal/configsync/snapshot.go
+++ b/go/internal/configsync/snapshot.go
@@ -9,6 +9,7 @@ import "github.com/nyroway/nyro/go/internal/storage"
 type consumerKeyEntry struct {
 	KeyID      string
 	ConsumerID string
+	Name       string
 	KeyPreview string
 	KeyHash    string
 	Enabled    bool
@@ -82,6 +83,7 @@ func (s *ConfigSnapshot) FindKey(rawKey string) *storage.ConsumerKeyAccessRecord
 		return &storage.ConsumerKeyAccessRecord{
 			KeyID:      entry.KeyID,
 			ConsumerID: entry.ConsumerID,
+			Name:       entry.Name,
 			KeyPreview: entry.KeyPreview,
 			Enabled:    entry.Enabled,
 			ExpiresAt:  entry.ExpiresAt,
@@ -126,9 +128,9 @@ func (b *Snapshot) SetRoute(r storage.Route) {
 
 // AddConsumerKey registers one consumer key's gateway-facing view (preview,
 // hash, grants). Called once per key across all consumers.
-func (b *Snapshot) AddConsumerKey(keyID, consumerID, keyPreview, keyHash string, enabled bool, expiresAt string, routes []string, quotas []storage.ConsumerQuota) {
+func (b *Snapshot) AddConsumerKey(keyID, consumerID, name, keyPreview, keyHash string, enabled bool, expiresAt string, routes []string, quotas []storage.ConsumerQuota) {
 	b.keys = append(b.keys, consumerKeyEntry{
-		KeyID: keyID, ConsumerID: consumerID, KeyPreview: keyPreview, KeyHash: keyHash,
+		KeyID: keyID, ConsumerID: consumerID, Name: name, KeyPreview: keyPreview, KeyHash: keyHash,
 		Enabled: enabled, ExpiresAt: expiresAt, Routes: routes, Quotas: quotas,
 	})
 }

--- a/go/internal/observability/config.go
+++ b/go/internal/observability/config.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"fmt"
 	"strconv"
+	"time"
 )
 
 // SignalConfig is the resolved exporter configuration for a single signal
@@ -33,6 +34,16 @@ type ObsConfig struct {
 	LogsRetentionDays    int
 	MetricsRetentionDays int
 	TracesRetentionDays  int
+
+	// Per-signal flush cadence — admin-only (like DataDir and the retention
+	// fields): how often the receiver flushes that signal's buffered rows to
+	// parquet (the time trigger complementing the sink's maxRows size trigger).
+	// Resolved from obs_<signal>_flush_interval, each defaulting to
+	// DefaultFlushInterval. The gateway loads them too but never uses them — it
+	// does not persist telemetry.
+	LogsFlushInterval    time.Duration
+	MetricsFlushInterval time.Duration
+	TracesFlushInterval  time.Duration
 }
 
 // signalKeyNames maps each Signal to the key-name segment used in setting
@@ -74,11 +85,22 @@ func LoadConfig(get func(string) (string, error)) (ObsConfig, error) {
 		}
 		return def
 	}
+	dur := func(k string, def time.Duration) time.Duration {
+		if v := g(k); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				return d
+			}
+		}
+		return def
+	}
 
 	cfg := ObsConfig{
 		LogsRetentionDays:    ret("obs_logs_retention_days", 7),
 		MetricsRetentionDays: ret("obs_metrics_retention_days", 30),
 		TracesRetentionDays:  ret("obs_traces_retention_days", 3),
+		LogsFlushInterval:    dur("obs_logs_flush_interval", DefaultFlushInterval),
+		MetricsFlushInterval: dur("obs_metrics_flush_interval", DefaultFlushInterval),
+		TracesFlushInterval:  dur("obs_traces_flush_interval", DefaultFlushInterval),
 	}
 
 	var err error

--- a/go/internal/observability/flush_config_test.go
+++ b/go/internal/observability/flush_config_test.go
@@ -1,0 +1,42 @@
+package observability
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadConfig_PerSignalFlushInterval(t *testing.T) {
+	// Defaults when unset: each signal falls back to DefaultFlushInterval.
+	cfg, err := LoadConfig(func(string) (string, error) { return "", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, got := range map[string]time.Duration{
+		"logs": cfg.LogsFlushInterval, "metrics": cfg.MetricsFlushInterval, "traces": cfg.TracesFlushInterval,
+	} {
+		if got != DefaultFlushInterval {
+			t.Errorf("%s flush default = %v; want %v", name, got, DefaultFlushInterval)
+		}
+	}
+
+	// Per-signal overrides are parsed independently; an unparseable/zero value
+	// falls back to the default (not zero, which would disable the ticker).
+	store := map[string]string{
+		"obs_logs_flush_interval":    "30s",
+		"obs_metrics_flush_interval": "2s",
+		"obs_traces_flush_interval":  "bogus",
+	}
+	cfg, err = LoadConfig(func(k string) (string, error) { return store[k], nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LogsFlushInterval != 30*time.Second {
+		t.Errorf("logs = %v; want 30s", cfg.LogsFlushInterval)
+	}
+	if cfg.MetricsFlushInterval != 2*time.Second {
+		t.Errorf("metrics = %v; want 2s", cfg.MetricsFlushInterval)
+	}
+	if cfg.TracesFlushInterval != DefaultFlushInterval {
+		t.Errorf("traces (bogus) = %v; want default %v", cfg.TracesFlushInterval, DefaultFlushInterval)
+	}
+}

--- a/go/internal/observability/hooks.go
+++ b/go/internal/observability/hooks.go
@@ -30,13 +30,15 @@ const (
 )
 
 // onRequestHook starts the per-request "dispatch" span and stashes the span +
-// span-context in the bag for the OnLog hook to finish.
-type onRequestHook struct{ tracer trace.Tracer }
+// span-context in the bag for the OnLog hook to finish. It holds the swappable
+// provider rather than a concrete tracer so a config-sync hot-reload can change
+// the underlying pipeline without re-registering the hook.
+type onRequestHook struct{ sp *SwappableProvider }
 
 func (h onRequestHook) Name() string        { return "obs.on_request" }
 func (h onRequestHook) Phase() plugin.Phase { return plugin.PhaseOnRequest }
 func (h onRequestHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
-	ctx, span := h.tracer.Start(pctx.Ctx, "dispatch")
+	ctx, span := h.sp.load().tracer.Start(pctx.Ctx, "dispatch")
 	pctx.Bag.Set(BagSpanCtx, ctx)
 	pctx.Bag.Set(BagSpan, span)
 	return plugin.OutcomeContinue
@@ -44,15 +46,16 @@ func (h onRequestHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
 
 // onLogHook is terminal: it reads the per-request state the dispatcher left in
 // the bag, records the metrics, emits the structured audit LogRecord, and ends
-// the span started by onRequestHook.
+// the span started by onRequestHook. Like onRequestHook it holds the swappable
+// provider so the logger/handles it emits through follow a hot-reload.
 type onLogHook struct {
-	logger  log.Logger
-	handles *Handles
+	sp *SwappableProvider
 }
 
 func (h onLogHook) Name() string        { return "obs.on_log" }
 func (h onLogHook) Phase() plugin.Phase { return plugin.PhaseOnLog }
 func (h onLogHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
+	active := h.sp.load()
 	bag := pctx.Bag
 	span, _ := pluginGet(bag, BagSpan).(trace.Span)
 	spanCtx, _ := pluginGet(bag, BagSpanCtx).(context.Context)
@@ -79,14 +82,14 @@ func (h onLogHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
 	// variadic ...AddOption / ...RecordOption, NOT raw attribute.KeyValue. We
 	// wrap the attributes in metric.WithAttributes (which satisfies both option
 	// types via the shared attrOpt).
-	if h.handles != nil {
+	if active.handles != nil {
 		reqAttrs := metric.WithAttributes(
 			attribute.String("model", route.Model),
 			attribute.String("provider", upstream.Name),
 			attribute.String("apikey", apiKeyID),
 			attribute.String("status_class", statusClass),
 		)
-		h.handles.requests.Add(emitCtx, 1, reqAttrs)
+		active.handles.requests.Add(emitCtx, 1, reqAttrs)
 
 		tokenIn := metric.WithAttributes(
 			attribute.String("model", route.Model),
@@ -98,10 +101,10 @@ func (h onLogHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
 			attribute.String("apikey", apiKeyID),
 			attribute.String("direction", "out"),
 		)
-		h.handles.tokens.Add(emitCtx, int64(usage.PromptTokens), tokenIn)
-		h.handles.tokens.Add(emitCtx, int64(usage.CompletionTokens), tokenOut)
+		active.handles.tokens.Add(emitCtx, int64(usage.PromptTokens), tokenIn)
+		active.handles.tokens.Add(emitCtx, int64(usage.CompletionTokens), tokenOut)
 
-		h.handles.latency.Record(emitCtx, float64(latencyMs), metric.WithAttributes(
+		active.handles.latency.Record(emitCtx, float64(latencyMs), metric.WithAttributes(
 			attribute.String("model", route.Model),
 			attribute.String("provider", upstream.Name),
 		))
@@ -143,7 +146,7 @@ func (h onLogHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
 	// reached the upstream) omits the attribute entirely so the receiver leaves
 	// the parquet optional column null.
 	rec.AddAttributes(upstreamLogAttrs(lc)...)
-	h.logger.Emit(emitCtx, rec)
+	active.logger.Emit(emitCtx, rec)
 
 	// --- finish the span (status for 5xx, then End) ---
 	if span != nil {
@@ -198,9 +201,14 @@ func classify(status int) string {
 // plugin registry. It is NOT called from an init(): instrumentation stays inert
 // until the dispatcher/cmd calls it (T3.3/T3.4), so importing observability has
 // no process-wide side effects.
-func RegisterHooks(tracer trace.Tracer, logger log.Logger, handles *Handles) {
-	plugin.Register(onRequestHook{tracer: tracer})
-	plugin.Register(onLogHook{logger: logger, handles: handles})
+//
+// It must be called exactly once per process: the plugin registry appends, so a
+// second call would double-emit. Hot-reloading the underlying pipeline is done
+// by swapping sp (SwappableProvider.Swap), NOT by re-registering — the hooks
+// read the current handles from sp on every request.
+func RegisterHooks(sp *SwappableProvider) {
+	plugin.Register(onRequestHook{sp: sp})
+	plugin.Register(onLogHook{sp: sp})
 }
 
 // pluginGet is a tiny helper so the type-assertion chain reads without repeating

--- a/go/internal/observability/hooks.go
+++ b/go/internal/observability/hooks.go
@@ -132,6 +132,7 @@ func (h onLogHook) Run(pctx *plugin.PhaseContext) plugin.PhaseOutcome {
 		log.String("nyro.path", lc.Path),
 		log.String("nyro.api_key_id", apiKeyID),
 		log.String("nyro.api_key_name", lc.APIKeyName),
+		log.String("nyro.api_key_preview", lc.APIKeyPreview),
 		log.Int("nyro.client_status", status),
 		log.Int64("nyro.latency_total_ms", latencyMs),
 		log.Int64("nyro.input_tokens", int64(usage.PromptTokens)),

--- a/go/internal/observability/hooks_test.go
+++ b/go/internal/observability/hooks_test.go
@@ -53,7 +53,7 @@ func TestHooksOnRequestStoresSpan(t *testing.T) {
 	handles := NewHandles(meterProvider.Meter("nyro-test"))
 
 	cl := &captureLogger{}
-	RegisterHooks(tracer, cl, handles)
+	RegisterHooks(newSwappableFromParts(tracer, cl, handles))
 	t.Cleanup(func() {
 		_ = tracerProvider.Shutdown(context.Background())
 		_ = meterProvider.Shutdown(context.Background())
@@ -93,7 +93,7 @@ func TestHooksOnLogRecordsMetricsTokensAndSpan(t *testing.T) {
 	handles := NewHandles(meterProvider.Meter("nyro-test"))
 
 	cl := &captureLogger{}
-	RegisterHooks(tracer, cl, handles)
+	RegisterHooks(newSwappableFromParts(tracer, cl, handles))
 	t.Cleanup(func() {
 		_ = tracerProvider.Shutdown(context.Background())
 		_ = meterProvider.Shutdown(context.Background())
@@ -209,7 +209,7 @@ func TestHooksOnLogEmitsUpstreamAuditAttrs(t *testing.T) {
 	handles := NewHandles(meterProvider.Meter("nyro-test"))
 
 	cl := &captureLogger{}
-	RegisterHooks(tracer, cl, handles)
+	RegisterHooks(newSwappableFromParts(tracer, cl, handles))
 	t.Cleanup(func() {
 		_ = tracerProvider.Shutdown(context.Background())
 		_ = meterProvider.Shutdown(context.Background())
@@ -277,7 +277,7 @@ func TestHooksOnLog5xxMarksSpanError(t *testing.T) {
 	handles := NewHandles(meterProvider.Meter("nyro-test"))
 
 	cl := &captureLogger{}
-	RegisterHooks(tracer, cl, handles)
+	RegisterHooks(newSwappableFromParts(tracer, cl, handles))
 	t.Cleanup(func() {
 		_ = tracerProvider.Shutdown(context.Background())
 		_ = meterProvider.Shutdown(context.Background())

--- a/go/internal/observability/otlp_endpoint_test.go
+++ b/go/internal/observability/otlp_endpoint_test.go
@@ -1,0 +1,22 @@
+package observability
+
+import "testing"
+
+func TestOtlpSignalURL(t *testing.T) {
+	cases := []struct {
+		name, endpoint, defaultPath, want string
+	}{
+		{"base url no path (the seed case)", "http://127.0.0.1:19531", otlpLogsPath, "http://127.0.0.1:19531/v1/logs"},
+		{"base url trailing slash", "http://127.0.0.1:19531/", otlpMetricsPath, "http://127.0.0.1:19531/v1/metrics"},
+		{"https base", "https://collector.example.com:4318", otlpTracesPath, "https://collector.example.com:4318/v1/traces"},
+		{"explicit path respected", "http://host:4318/custom/logs", otlpLogsPath, "http://host:4318/custom/logs"},
+		{"scheme-less left untouched", "127.0.0.1:19531", otlpLogsPath, "127.0.0.1:19531"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := otlpSignalURL(c.endpoint, c.defaultPath); got != c.want {
+				t.Errorf("otlpSignalURL(%q, %q) = %q; want %q", c.endpoint, c.defaultPath, got, c.want)
+			}
+		})
+	}
+}

--- a/go/internal/observability/otlp_export_integration_test.go
+++ b/go/internal/observability/otlp_export_integration_test.go
@@ -1,0 +1,102 @@
+package observability
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// TestOTLPLogsExportHitsV1LogsPath is the regression test for the endpoint-path
+// bug: a base OTLP endpoint (scheme://host:port, no path — exactly what the
+// admin seeds) must make the logs exporter POST to /v1/logs, not "/". It builds
+// the real provider via NewProvider (the same path the gateway uses) pointed at
+// a recording server and asserts the path the exporter actually hits.
+func TestOTLPLogsExportHitsV1LogsPath(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK) // empty ExportLogsServiceResponse body is valid
+	}))
+	defer srv.Close()
+
+	prov, err := NewProvider(context.Background(), ObsConfig{
+		Logs: SignalConfig{Kind: ExporterKindOTLP, Params: map[string]string{"endpoint": srv.URL}},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	var rec otellog.Record
+	rec.SetTimestamp(time.Now())
+	rec.SetBody(otellog.StringValue("audit"))
+	prov.Logger.Emit(context.Background(), rec)
+
+	// Shutdown flushes the batch processor synchronously.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := prov.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) == 0 {
+		t.Fatal("exporter never POSTed to the server")
+	}
+	for _, p := range paths {
+		if p != "/v1/logs" {
+			t.Errorf("exporter POSTed to %q; want /v1/logs (base-URL endpoint must append the signal path)", p)
+		}
+	}
+}
+
+// TestOTLPLogsHonorsExportInterval proves the configured "interval" (the WebUI
+// Export Interval) is wired into the logs BatchProcessor — previously it was
+// dropped and logs always used the SDK's 1s default. With a 120ms interval and
+// NO Shutdown call, the export must arrive well before 1s; if the interval were
+// ignored, first receipt would be ~1s (the default) and this would fail.
+func TestOTLPLogsHonorsExportInterval(t *testing.T) {
+	got := make(chan time.Duration, 1)
+	start := time.Now()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case got <- time.Since(start):
+		default:
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	prov, err := NewProvider(context.Background(), ObsConfig{
+		Logs: SignalConfig{Kind: ExporterKindOTLP, Params: map[string]string{"endpoint": srv.URL, "interval": "120ms"}},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	defer prov.Shutdown(context.Background())
+
+	var rec otellog.Record
+	rec.SetTimestamp(time.Now())
+	rec.SetBody(otellog.StringValue("audit"))
+	start = time.Now()
+	prov.Logger.Emit(context.Background(), rec)
+
+	select {
+	case elapsed := <-got:
+		if elapsed > 700*time.Millisecond {
+			t.Errorf("first export took %v; expected < 700ms (interval=120ms). The configured interval appears ignored (SDK default is 1s)", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no export received within 2s")
+	}
+}

--- a/go/internal/observability/otlp_export_integration_test.go
+++ b/go/internal/observability/otlp_export_integration_test.go
@@ -83,7 +83,7 @@ func TestOTLPLogsHonorsExportInterval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
 	}
-	defer prov.Shutdown(context.Background())
+	defer func() { _ = prov.Shutdown(context.Background()) }()
 
 	var rec otellog.Record
 	rec.SetTimestamp(time.Now())

--- a/go/internal/observability/provider.go
+++ b/go/internal/observability/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -83,6 +84,41 @@ func requireOTLPEndpoint(signal Signal, params map[string]string) (string, error
 	return endpoint, nil
 }
 
+// Per-signal default OTLP/HTTP request paths, matching the OTLP spec (and the
+// paths the admin receiver mounts in internal/observability/receiver.go).
+const (
+	otlpLogsPath    = "/v1/logs"
+	otlpMetricsPath = "/v1/metrics"
+	otlpTracesPath  = "/v1/traces"
+)
+
+// otlpSignalURL normalizes a configured OTLP endpoint for a specific signal.
+// The endpoint stored in settings (and seeded by the admin — see
+// cmd/admin.seedDefaultObsEndpoint) is a BASE url like "http://127.0.0.1:19531"
+// shared across logs/metrics/traces; it carries no per-signal path.
+//
+// This matters because otlploghttp/otlpmetrichttp/otlptracehttp's
+// WithEndpointURL uses the URL's path verbatim and does NOT append the default
+// "/v1/<signal>" when it is empty — a path-less base URL makes the exporter POST
+// to "/", which the receiver 404s. (WithEndpoint, the host:port form, would
+// append the default, but our config carries a full scheme://host so
+// WithEndpointURL is the natural fit.) So we append the per-signal default path
+// ourselves here, mirroring the OTEL_EXPORTER_OTLP_ENDPOINT base-endpoint
+// convention. An endpoint that already carries an explicit path (a user pointing
+// at a custom collector route) is left untouched.
+func otlpSignalURL(endpoint, defaultPath string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		// Malformed or scheme-less: leave it for WithEndpointURL to handle/surface
+		// rather than silently rewriting into something unexpected.
+		return endpoint
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = defaultPath
+	}
+	return u.String()
+}
+
 // exporterKindValid reports whether kind is registered for signal per the
 // exporter registry (exporter.go's ExportersFor) — the actual source of
 // truth for which kinds are valid per signal. Each buildXProvider consults
@@ -114,7 +150,7 @@ func logsBuilders(ctx context.Context) map[ExporterKind]BuilderFunc {
 			if err != nil {
 				return nil, err
 			}
-			return otlploghttp.New(ctx, otlploghttp.WithEndpointURL(endpoint))
+			return otlploghttp.New(ctx, otlploghttp.WithEndpointURL(otlpSignalURL(endpoint, otlpLogsPath)))
 		},
 		ExporterKindStdout: func(params map[string]string) (any, error) {
 			return stdoutlog.New()
@@ -165,7 +201,7 @@ func metricsBuilders(ctx context.Context) map[ExporterKind]BuilderFunc {
 				return nil, err
 			}
 			return otlpmetrichttp.New(ctx,
-				otlpmetrichttp.WithEndpointURL(endpoint),
+				otlpmetrichttp.WithEndpointURL(otlpSignalURL(endpoint, otlpMetricsPath)),
 				otlpmetrichttp.WithTemporalitySelector(sdkmetric.DeltaTemporalitySelector),
 			)
 		},
@@ -200,7 +236,7 @@ func tracesBuilders(ctx context.Context) map[ExporterKind]BuilderFunc {
 			if err != nil {
 				return nil, err
 			}
-			return otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
+			return otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(otlpSignalURL(endpoint, otlpTracesPath)))
 		},
 		ExporterKindStdout: func(params map[string]string) (any, error) {
 			return stdouttrace.New()
@@ -309,9 +345,18 @@ func buildLoggerProvider(ctx context.Context, res *resource.Resource, sc SignalC
 		return nil, fmt.Errorf("observability: logs builder for %q returned unexpected type %T", sc.Kind, raw)
 	}
 
+	// Honor the configured "interval" (the WebUI's Export Interval) as the batch
+	// processor's export cadence, matching how metrics (PeriodicReader interval)
+	// and traces (BatchSpanProcessor timeout) consume the same field. stdout has
+	// no interval field, so it keeps the SDK's own default.
+	var procOpts []sdklog.BatchProcessorOption
+	if d, ok := parseDuration(sc.Params["interval"]); ok {
+		procOpts = append(procOpts, sdklog.WithExportInterval(d))
+	}
+
 	return sdklog.NewLoggerProvider(
 		sdklog.WithResource(res),
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(exp)),
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exp, procOpts...)),
 	), nil
 }
 

--- a/go/internal/observability/receiver.go
+++ b/go/internal/observability/receiver.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	collectlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
@@ -50,6 +52,55 @@ func (rcv *Receiver) Flush(ctx context.Context) {
 	_ = rcv.logs.Flush()
 	_ = rcv.metrics.Flush()
 	_ = rcv.traces.Flush()
+}
+
+// DefaultFlushInterval is the fallback time-trigger cadence for StartFlusher.
+// It is the "time" half of the sink's size-or-time flush policy: the sinks
+// otherwise flush only when a buffer reaches maxRows (the "size" half) or on the
+// shutdown Flush, so a low-traffic deployment that never fills a buffer would
+// leave every row invisible to /logs and /stats until the admin restarts.
+const DefaultFlushInterval = 5 * time.Second
+
+// SignalFlush carries the per-signal flush cadence for StartFlusher, mirroring
+// SignalRetention. A zero (or negative) interval for a signal falls back to
+// DefaultFlushInterval.
+type SignalFlush struct {
+	Logs, Metrics, Traces time.Duration
+}
+
+// StartFlusher runs one background ticker per signal, each flushing its own sink
+// on its own interval until ctx is cancelled — the time trigger complementing
+// the sinks' size trigger (maxRows). Whichever fires first flushes; a flush on
+// an empty buffer is a no-op (flushLocked returns early), so idle periods create
+// no files. This bounds each signal's /logs+/stats staleness to at most its
+// interval. Per-signal so, e.g., metrics can persist quickly for dashboards
+// while logs persist less often to reduce file churn.
+//
+// Tuning note: each flush that has buffered rows writes one new parquet file, so
+// a signal's interval trades query freshness against file count — smaller makes
+// data appear sooner but produces more (smaller) files for ReadSince to scan.
+func (rcv *Receiver) StartFlusher(ctx context.Context, f SignalFlush) {
+	tick := func(interval time.Duration, flush func() error, signal string) {
+		if interval <= 0 {
+			interval = DefaultFlushInterval
+		}
+		go func() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					_ = flush()
+				}
+			}
+		}()
+		slog.Info("observability sink flusher started", "signal", signal, "interval", interval)
+	}
+	tick(f.Logs, rcv.logs.Flush, "logs")
+	tick(f.Metrics, rcv.metrics.Flush, "metrics")
+	tick(f.Traces, rcv.traces.Flush, "traces")
 }
 
 func (rcv *Receiver) handleLogs(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/observability/receiver.go
+++ b/go/internal/observability/receiver.go
@@ -148,7 +148,7 @@ func logRecordFromOTLP(lr *logsv1.LogRecord) LogRecord {
 		ModelID: m.str("nyro.model_id"), ModelName: m.str("nyro.model_name"),
 		ClientModel: m.str("nyro.client_model"), UpstreamModel: m.str("nyro.upstream_model"),
 		Method: m.str("nyro.method"), Path: m.str("nyro.path"),
-		APIKeyID: m.str("nyro.api_key_id"), APIKeyName: m.str("nyro.api_key_name"),
+		APIKeyID: m.str("nyro.api_key_id"), APIKeyName: m.str("nyro.api_key_name"), APIKeyPreview: m.str("nyro.api_key_preview"),
 		InputTokens: int32(m.i("nyro.input_tokens")), OutputTokens: int32(m.i("nyro.output_tokens")),
 		CacheReadTokens: int32(m.i("nyro.cache_read_tokens")),
 	}

--- a/go/internal/observability/receiver_flush_test.go
+++ b/go/internal/observability/receiver_flush_test.go
@@ -1,0 +1,49 @@
+package observability
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nyroway/nyro/go/internal/observability/parquet"
+)
+
+// TestStartFlusher_TimeTriggerFlushesBufferedRows proves the time trigger: a row
+// written to a sink stays buffered (invisible to a file-based read) until either
+// the size trigger (maxRows) or StartFlusher's periodic flush fires. With a large
+// maxRows the size trigger never fires, so only the flusher can make the row
+// queryable — reproducing and then fixing the "WebUI empty on low traffic" bug.
+func TestStartFlusher_TimeTriggerFlushesBufferedRows(t *testing.T) {
+	dir := t.TempDir()
+	logSink, err := parquet.NewSink[LogRecord](dir, "logs", 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mSink, _ := parquet.NewSink[MetricSample](dir, "metrics", 50000)
+	tSink, _ := parquet.NewSink[SpanSnapshot](dir, "traces", 50000)
+	rcv := NewReceiver(logSink, mSink, tSink)
+
+	if err := logSink.Write([]LogRecord{{ID: "req_x", CreatedAt: time.Now().UnixMilli()}}); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := NewLogs(dir)
+	// Before any flush: the row is buffered in memory, so a file-based read sees
+	// nothing (this is exactly why the WebUI was empty).
+	if p, _ := logs.Query(LogQuery{}); p.Total != 0 {
+		t.Fatalf("expected 0 rows before flush (buffered), got %d", p.Total)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rcv.StartFlusher(ctx, SignalFlush{Logs: 30 * time.Millisecond})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p, _ := logs.Query(LogQuery{}); p.Total == 1 {
+			return // flusher made the buffered row queryable — success
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("row never became queryable: StartFlusher did not flush the buffered log within 2s")
+}

--- a/go/internal/observability/signals.go
+++ b/go/internal/observability/signals.go
@@ -16,6 +16,7 @@ import (
 // proxy original, keeping T3.2 and T3.3 independently green).
 type LogCtx struct {
 	APIKeyName        string
+	APIKeyPreview     string
 	ClientProtocol    string
 	UpstreamProtocol  string
 	ClientModel       string
@@ -45,6 +46,7 @@ type LogRecord struct {
 	CreatedAt          int64  `json:"created_at" parquet:"created_at"`
 	APIKeyID           string `json:"api_key_id,omitempty" parquet:"api_key_id,dict"`
 	APIKeyName         string `json:"api_key_name,omitempty" parquet:"api_key_name"`
+	APIKeyPreview      string `json:"api_key_preview,omitempty" parquet:"api_key_preview"`
 	ClientProtocol     string `json:"client_protocol,omitempty" parquet:"client_protocol,dict"`
 	UpstreamProtocol   string `json:"upstream_protocol,omitempty" parquet:"upstream_protocol,dict"`
 	ProviderID         string `json:"provider_id,omitempty" parquet:"provider_id,dict"`

--- a/go/internal/observability/swappable.go
+++ b/go/internal/observability/swappable.go
@@ -1,0 +1,80 @@
+package observability
+
+import (
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// activeSet is the immutable bundle of signal handles the phase hooks read on
+// every request: the tracer that starts the per-request span, the logger that
+// emits the audit record, and the metric instruments. prov is the ObsProvider
+// these were derived from (nil when the set was assembled from raw parts, e.g.
+// in tests) — retained so a Swap can hand the displaced provider back to the
+// caller for a graceful Shutdown.
+type activeSet struct {
+	tracer  trace.Tracer
+	logger  log.Logger
+	handles *Handles
+	prov    *ObsProvider
+}
+
+// SwappableProvider is the indirection that makes observability hot-reloadable.
+// The phase hooks are registered into the process-wide plugin registry exactly
+// once (RegisterHooks) and hold a *SwappableProvider rather than a concrete
+// tracer/logger/handles; each request reads the current activeSet via load().
+// A config-sync push that changes the resolved ObsConfig calls Swap to install
+// a freshly built ObsProvider atomically, so in-flight requests keep using the
+// set they already loaded while new requests pick up the new pipeline — no
+// re-registration (which would double-emit) and no lock on the hot path.
+type SwappableProvider struct {
+	cur atomic.Pointer[activeSet]
+}
+
+// activeSetFromProvider derives the hook-facing handle bundle from p. The metric
+// instruments are (re)created from p.Meter so they bind to the new provider's
+// MeterProvider — reusing an old Handles would keep emitting into the previous,
+// possibly shut-down, meter.
+func activeSetFromProvider(p *ObsProvider) *activeSet {
+	return &activeSet{
+		tracer:  p.Tracer,
+		logger:  p.Logger,
+		handles: NewHandles(p.Meter),
+		prov:    p,
+	}
+}
+
+// NewSwappableProvider builds a SwappableProvider whose initial active set is
+// derived from p (its tracer/logger and a fresh Handles from p.Meter).
+func NewSwappableProvider(p *ObsProvider) *SwappableProvider {
+	s := &SwappableProvider{}
+	s.cur.Store(activeSetFromProvider(p))
+	return s
+}
+
+// newSwappableFromParts builds a SwappableProvider directly from raw handles,
+// bypassing an ObsProvider. Used by tests that assemble a tracer/logger/handles
+// harness without a full provider; its active set carries no prov, so Swap
+// against a real provider later returns nil for the displaced one.
+func newSwappableFromParts(tracer trace.Tracer, logger log.Logger, handles *Handles) *SwappableProvider {
+	s := &SwappableProvider{}
+	s.cur.Store(&activeSet{tracer: tracer, logger: logger, handles: handles})
+	return s
+}
+
+// load returns the current active set (never nil once constructed).
+func (s *SwappableProvider) load() *activeSet { return s.cur.Load() }
+
+// Swap atomically installs a new active set derived from p and returns the
+// ObsProvider that was previously active, or nil if there was none (or the
+// previous set was assembled from raw parts). The caller owns Shutdown of the
+// returned provider and should defer it past in-flight requests that may still
+// hold the displaced set.
+func (s *SwappableProvider) Swap(p *ObsProvider) *ObsProvider {
+	old := s.cur.Swap(activeSetFromProvider(p))
+	if old == nil {
+		return nil
+	}
+	return old.prov
+}

--- a/go/internal/protocol/codec/anthropic/stream.go
+++ b/go/internal/protocol/codec/anthropic/stream.go
@@ -67,6 +67,20 @@ func (d *streamResponseDecoder) ParseChunk(payload string) ([]ir.StreamDelta, er
 			}
 			if p.Usage != nil {
 				d.outputTokens = p.Usage.OutputTokens
+				// Providers that report the full usage only in message_delta
+				// (e.g. Zhipu/GLM, whose message_start usage is all-zero) carry
+				// the real input/cache counts here. Adopt them when present;
+				// real Anthropic omits these fields (decode to 0 / nil), so the
+				// message_start values captured above are preserved.
+				if p.Usage.InputTokens != 0 {
+					d.inputTokens = p.Usage.InputTokens
+				}
+				if p.Usage.CacheReadTokens != nil {
+					d.cacheReadTokens = p.Usage.CacheReadTokens
+				}
+				if p.Usage.CacheCreationTokens != nil {
+					d.cacheCreationTokens = p.Usage.CacheCreationTokens
+				}
 			}
 		}
 	case "message_stop":

--- a/go/internal/protocol/codec/anthropic/usage_delta_test.go
+++ b/go/internal/protocol/codec/anthropic/usage_delta_test.go
@@ -1,0 +1,68 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/nyroway/nyro/go/internal/protocol/ir"
+)
+
+// feed runs the decoder over a sequence of SSE data payloads and returns the
+// final aggregated UsageDelta (the one emitted at message_stop).
+func feed(t *testing.T, payloads []string) ir.Usage {
+	t.Helper()
+	d := &streamResponseDecoder{}
+	var last ir.Usage
+	seen := false
+	for _, p := range payloads {
+		deltas, err := d.ParseChunk(p)
+		if err != nil {
+			t.Fatalf("ParseChunk(%q): %v", p, err)
+		}
+		for _, dl := range deltas {
+			if u, ok := dl.(*ir.UsageDelta); ok {
+				last = u.Usage
+				seen = true
+			}
+		}
+	}
+	if !seen {
+		t.Fatal("no UsageDelta emitted")
+	}
+	return last
+}
+
+// TestUsageFromMessageDelta_Zhipu reproduces the exact GLM/Zhipu wire shape:
+// message_start reports usage all-zero and the real input/output counts arrive
+// only in the final message_delta. The decoder must surface input_tokens=11.
+func TestUsageFromMessageDelta_Zhipu(t *testing.T) {
+	u := feed(t, []string{
+		`{"type":"message_start","message":{"id":"msg_1","model":"glm-5.2","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":11,"output_tokens":81,"cache_read_input_tokens":0}}`,
+		`{"type":"message_stop"}`,
+	})
+	if u.PromptTokens != 11 {
+		t.Errorf("PromptTokens = %d; want 11 (input_tokens from message_delta)", u.PromptTokens)
+	}
+	if u.CompletionTokens != 81 {
+		t.Errorf("CompletionTokens = %d; want 81", u.CompletionTokens)
+	}
+}
+
+// TestUsageFromMessageStart_Anthropic guards the real-Anthropic shape: input in
+// message_start, message_delta carries only output_tokens. The message_start
+// value must be preserved (not clobbered to 0 by the absent delta field).
+func TestUsageFromMessageStart_Anthropic(t *testing.T) {
+	u := feed(t, []string{
+		`{"type":"message_start","message":{"id":"msg_1","model":"claude","usage":{"input_tokens":50}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}`,
+		`{"type":"message_stop"}`,
+	})
+	if u.PromptTokens != 50 {
+		t.Errorf("PromptTokens = %d; want 50 (preserved from message_start)", u.PromptTokens)
+	}
+	if u.CompletionTokens != 10 {
+		t.Errorf("CompletionTokens = %d; want 10", u.CompletionTokens)
+	}
+}

--- a/go/internal/protocol/codec/anthropic/wire.go
+++ b/go/internal/protocol/codec/anthropic/wire.go
@@ -136,7 +136,16 @@ type messageDeltaPayload struct {
 		StopReason string `json:"stop_reason,omitempty"`
 	} `json:"delta"`
 	Usage *struct {
-		OutputTokens uint32 `json:"output_tokens"`
+		// InputTokens (and the cache counters) are included in message_delta by
+		// some Anthropic-compatible providers (e.g. Zhipu/GLM), which report the
+		// full usage only in the final message_delta and leave message_start's
+		// usage all-zero. Real Anthropic omits input_tokens here (it lives in
+		// message_start), so an absent field decodes to 0 and the decoder keeps
+		// the message_start value. See streamResponseDecoder.ParseChunk.
+		InputTokens         uint32  `json:"input_tokens"`
+		OutputTokens        uint32  `json:"output_tokens"`
+		CacheReadTokens     *uint32 `json:"cache_read_input_tokens,omitempty"`
+		CacheCreationTokens *uint32 `json:"cache_creation_input_tokens,omitempty"`
 	} `json:"usage,omitempty"`
 }
 

--- a/go/internal/protocoltest/testdata/golden/anthropic-messages__anthropic-messages/text_stream.stream.golden
+++ b/go/internal/protocoltest/testdata/golden/anthropic-messages__anthropic-messages/text_stream.stream.golden
@@ -950,6 +950,7 @@
   },
   "type": "message_delta",
   "usage": {
+    "cache_read_input_tokens": 0,
     "output_tokens": 100
   }
 }

--- a/go/internal/protocoltest/testdata/golden/google-gemini__anthropic-messages/text_stream.stream.golden
+++ b/go/internal/protocoltest/testdata/golden/google-gemini__anthropic-messages/text_stream.stream.golden
@@ -1498,7 +1498,7 @@
   "candidates": null,
   "usageMetadata": {
     "candidatesTokenCount": 100,
-    "promptTokenCount": 0,
-    "totalTokenCount": 100
+    "promptTokenCount": 15,
+    "totalTokenCount": 115
   }
 }

--- a/go/internal/protocoltest/testdata/golden/openai-chat__anthropic-messages/text_stream.stream.golden
+++ b/go/internal/protocoltest/testdata/golden/openai-chat__anthropic-messages/text_stream.stream.golden
@@ -1316,7 +1316,7 @@
   "object": "chat.completion.chunk",
   "usage": {
     "completion_tokens": 100,
-    "prompt_tokens": 0,
-    "total_tokens": 100
+    "prompt_tokens": 15,
+    "total_tokens": 115
   }
 }

--- a/go/internal/protocoltest/testdata/golden/openai-responses__anthropic-messages/text_stream.stream.golden
+++ b/go/internal/protocoltest/testdata/golden/openai-responses__anthropic-messages/text_stream.stream.golden
@@ -187,9 +187,9 @@
     "model": "poolside/laguna-m.1:free",
     "status": "completed",
     "usage": {
-      "input_tokens": 0,
+      "input_tokens": 15,
       "output_tokens": 100,
-      "total_tokens": 100
+      "total_tokens": 115
     }
   },
   "type": "response.completed"

--- a/go/internal/proxy/dispatcher.go
+++ b/go/internal/proxy/dispatcher.go
@@ -41,7 +41,7 @@ func (g *Gateway) Dispatch(w http.ResponseWriter, r *http.Request, req *ir.AiReq
 	lc := observability.LogCtx{
 		Method:         r.Method,
 		Path:           r.URL.Path,
-		ClientProtocol: ingress.Endpoint().String(),
+		ClientProtocol: string(ingress.Endpoint().Protocol),
 		ClientModel:    req.Model,
 		IsStream:       req.Stream.Enabled,
 	}
@@ -92,7 +92,7 @@ func (g *Gateway) Dispatch(w http.ResponseWriter, r *http.Request, req *ir.AiReq
 
 	// inbound auth + OnAccess
 	plugin.RunPhaseHooks(plugin.PhaseOnAccess, &plugin.PhaseContext{Ctx: r.Context(), Request: req, Bag: bag})
-	status, msg, release := checkAccess(g.snapshot(), g.Quota, route, r, &consumerID, &lc.APIKeyName)
+	status, msg, release := checkAccess(g.snapshot(), g.Quota, route, r, &consumerID, &lc.APIKeyName, &lc.APIKeyPreview)
 	if status != 0 {
 		writeJSONError(rec, status, msg)
 		return
@@ -195,7 +195,7 @@ func (g *Gateway) Dispatch(w http.ResponseWriter, r *http.Request, req *ir.AiReq
 		// Populate upstream logCtx fields + bag now that they're known.
 		upstream = *p
 		lc.UpstreamModel = actualModel
-		lc.UpstreamProtocol = egressHandler.Endpoint().String()
+		lc.UpstreamProtocol = string(egressHandler.Endpoint().Protocol)
 		us := int32(resp.StatusCode)
 		lc.UpstreamStatus = &us
 		um := int64(latencyMs)

--- a/go/internal/proxy/dispatcher.go
+++ b/go/internal/proxy/dispatcher.go
@@ -376,7 +376,7 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	body, _ := json.Marshal(map[string]any{
-		"error": map[string]any{"message": message, "type": "gateway_error"},
+		"error": map[string]any{"message": message, "type": "GATEWAY_ERROR"},
 	})
 	_, _ = w.Write(body)
 }

--- a/go/internal/proxy/inbound.go
+++ b/go/internal/proxy/inbound.go
@@ -19,7 +19,7 @@ import (
 // (0, "", nil) to allow, or (statusCode, message, nil) to deny. When a
 // concurrency quota slot was acquired, the third return is a non-nil release
 // func that MUST be called exactly once when the request finishes.
-func checkAccess(snap *configsync.ConfigSnapshot, qc *quota.Counter, route storage.Route, r *http.Request, consumerID *string, keyName *string) (int, string, func()) {
+func checkAccess(snap *configsync.ConfigSnapshot, qc *quota.Counter, route storage.Route, r *http.Request, consumerID *string, keyName *string, keyPreview *string) (int, string, func()) {
 	if !route.EnableAuth {
 		return 0, "", nil
 	}
@@ -32,7 +32,15 @@ func checkAccess(snap *configsync.ConfigSnapshot, qc *quota.Counter, route stora
 		return http.StatusUnauthorized, "invalid API key", nil
 	}
 	*consumerID = rec.ConsumerID
-	*keyName = rec.KeyPreview
+	// Prefer the human-readable key name; fall back to the preview so an unnamed
+	// key still identifies itself in the logs. The preview is kept separately so
+	// the UI can show it alongside the name.
+	if rec.Name != "" {
+		*keyName = rec.Name
+	} else {
+		*keyName = rec.KeyPreview
+	}
+	*keyPreview = rec.KeyPreview
 	if !rec.Enabled {
 		return http.StatusForbidden, "API key is disabled", nil
 	}

--- a/go/internal/proxy/server.go
+++ b/go/internal/proxy/server.go
@@ -65,7 +65,7 @@ func NewRouter(gw *Gateway) chi.Router {
 	r.Post("/v1beta/models/{resource}", func(w http.ResponseWriter, r *http.Request) {
 		model, action, ok := strings.Cut(chi.URLParam(r, "resource"), ":")
 		if !ok {
-			webutil.Error(w, http.StatusNotFound, "malformed Gemini path, expected models/{model}:{action}", "gateway_error")
+			webutil.Error(w, http.StatusNotFound, "malformed Gemini path, expected models/{model}:{action}", "GATEWAY_ERROR")
 			return
 		}
 		handleProxy(w, r, gw, ids.GeminiGenerateContentV1Beta, model, action == "streamGenerateContent")
@@ -78,7 +78,7 @@ func NewRouter(gw *Gateway) chi.Router {
 func handleProxy(w http.ResponseWriter, r *http.Request, gw *Gateway, ep ids.ProtocolEndpoint, pathModel string, pathStream bool) {
 	h, ok := codec.Get(ep)
 	if !ok {
-		webutil.Error(w, http.StatusNotImplemented, "no codec registered for endpoint", "gateway_error")
+		webutil.Error(w, http.StatusNotImplemented, "no codec registered for endpoint", "GATEWAY_ERROR")
 		return
 	}
 	limit := resolveProxySettings(gw.snapshot()).MaxBodyBytes
@@ -87,10 +87,10 @@ func handleProxy(w http.ResponseWriter, r *http.Request, gw *Gateway, ep ids.Pro
 	if err != nil {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {
-			webutil.Error(w, http.StatusRequestEntityTooLarge, "request body too large", "gateway_error")
+			webutil.Error(w, http.StatusRequestEntityTooLarge, "request body too large", "GATEWAY_ERROR")
 			return
 		}
-		webutil.Error(w, http.StatusBadRequest, "read body: "+err.Error(), "gateway_error")
+		webutil.Error(w, http.StatusBadRequest, "read body: "+err.Error(), "GATEWAY_ERROR")
 		return
 	}
 
@@ -98,7 +98,7 @@ func handleProxy(w http.ResponseWriter, r *http.Request, gw *Gateway, ep ids.Pro
 	if pathModel != "" {
 		md, ok := h.MakeRequestDecoder().(codec.PathModelDecoder)
 		if !ok {
-			webutil.Error(w, http.StatusInternalServerError, "codec does not support path-model decode", "gateway_error")
+			webutil.Error(w, http.StatusInternalServerError, "codec does not support path-model decode", "GATEWAY_ERROR")
 			return
 		}
 		req, err = md.DecodeWithModel(body, pathModel, pathStream)
@@ -106,7 +106,7 @@ func handleProxy(w http.ResponseWriter, r *http.Request, gw *Gateway, ep ids.Pro
 		req, err = h.MakeRequestDecoder().Decode(body)
 	}
 	if err != nil {
-		webutil.Error(w, http.StatusBadRequest, "decode request: "+err.Error(), "gateway_error")
+		webutil.Error(w, http.StatusBadRequest, "decode request: "+err.Error(), "GATEWAY_ERROR")
 		return
 	}
 

--- a/go/internal/storage/consumer.go
+++ b/go/internal/storage/consumer.go
@@ -183,6 +183,7 @@ func ValidateConsumerQuota(q CreateConsumerQuota) error {
 type ConsumerKeyAccessRecord struct {
 	KeyID      string          `json:"key_id"`
 	ConsumerID string          `json:"consumer_id"`
+	Name       string          `json:"name,omitempty"`
 	KeyPreview string          `json:"key_preview"`
 	Enabled    bool            `json:"enabled"`
 	ExpiresAt  string          `json:"expires_at,omitempty"`

--- a/go/internal/webui/webui.go
+++ b/go/internal/webui/webui.go
@@ -34,11 +34,11 @@ func mount(r chi.Router, fsys fs.FS) {
 	r.NotFound(func(w http.ResponseWriter, req *http.Request) {
 		p := req.URL.Path
 		if isReservedPath(p) {
-			webutil.Error(w, http.StatusNotFound, "not found", "gateway_error")
+			webutil.Error(w, http.StatusNotFound, "not found", "GATEWAY_ERROR")
 			return
 		}
 		if req.Method != http.MethodGet {
-			webutil.Error(w, http.StatusNotFound, "not found", "gateway_error")
+			webutil.Error(w, http.StatusNotFound, "not found", "GATEWAY_ERROR")
 			return
 		}
 
@@ -77,7 +77,7 @@ func servePath(fileServer http.Handler, targetPath string, w http.ResponseWriter
 func serveIndex(fsys fs.FS, w http.ResponseWriter) {
 	body, err := fs.ReadFile(fsys, "index.html")
 	if err != nil {
-		webutil.Error(w, http.StatusNotFound, "not found", "gateway_error")
+		webutil.Error(w, http.StatusNotFound, "not found", "GATEWAY_ERROR")
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/go/internal/webui/webui_test.go
+++ b/go/internal/webui/webui_test.go
@@ -49,7 +49,7 @@ func TestMountServesDirectorySpaAndKeepsAPIsJSON404(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("api status = %d, want 404", rec.Code)
 	}
-	if got := rec.Body.String(); !strings.Contains(got, "gateway_error") {
+	if got := rec.Body.String(); !strings.Contains(got, "GATEWAY_ERROR") {
 		t.Fatalf("api body = %q, want gateway_error JSON", got)
 	}
 }
@@ -71,7 +71,7 @@ func TestMountDisabledLeavesDefaultNotFound(t *testing.T) {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, "gateway_error") {
+	if strings.Contains(body, "GATEWAY_ERROR") {
 		t.Fatalf("body = %q, want chi's default 404 body, not the webui package's custom NotFound handler", body)
 	}
 	if !strings.Contains(body, "404 page not found") {

--- a/go/proto/configsync/v1/configsync.proto
+++ b/go/proto/configsync/v1/configsync.proto
@@ -78,6 +78,7 @@ message ConsumerKeyRef {
   string key_hash = 4;
   bool enabled = 5;
   string expires_at = 6;
+  string name = 7;
 }
 
 message ConsumerQuota {

--- a/go/webui/src/lib/format.ts
+++ b/go/webui/src/lib/format.ts
@@ -114,3 +114,22 @@ export function tryPrettyJson(raw: string | null | undefined): string {
     return raw;
   }
 }
+
+/** Backend only ever returns a masked key_preview (leading 12 + trailing 6
+ *  characters of the raw key, concatenated — never the full plaintext, except
+ *  the one-time reveal right after create/add/regenerate). This renders it as
+ *  "sk-abc123************************abc123": a fixed-length mask so the
+ *  asterisk run never hints at the real key's length. Shared by the API-keys
+ *  page and the request-log table so a preview looks the same everywhere. */
+const KEY_PREVIEW_LEAD_VISIBLE = 9;
+const KEY_PREVIEW_TRAIL_VISIBLE = 6;
+const KEY_PREVIEW_MASK_LEN = 28;
+
+export function formatKeyPreview(preview: string | undefined | null): string {
+  const trimmed = (preview ?? "").trim();
+  if (!trimmed) return "sk-";
+  if (trimmed.length <= KEY_PREVIEW_LEAD_VISIBLE + KEY_PREVIEW_TRAIL_VISIBLE) return trimmed;
+  const lead = trimmed.slice(0, KEY_PREVIEW_LEAD_VISIBLE);
+  const trail = trimmed.slice(-KEY_PREVIEW_TRAIL_VISIBLE);
+  return `${lead}${"*".repeat(KEY_PREVIEW_MASK_LEN)}${trail}`;
+}

--- a/go/webui/src/lib/observability-schema.ts
+++ b/go/webui/src/lib/observability-schema.ts
@@ -102,3 +102,7 @@ export function exporterSettingKey(signal: Signal): string {
 export function retentionSettingKey(signal: Signal): string {
   return `obs_${signal}_retention_days`;
 }
+
+export function flushIntervalSettingKey(signal: Signal): string {
+  return `obs_${signal}_flush_interval`;
+}

--- a/go/webui/src/lib/types.ts
+++ b/go/webui/src/lib/types.ts
@@ -204,6 +204,7 @@ export interface RequestLog {
   created_at: number;
   api_key_id?: string;
   api_key_name?: string;
+  api_key_preview?: string;
 
   client_protocol?: string;
   upstream_protocol?: string;

--- a/go/webui/src/pages/api-keys.test.ts
+++ b/go/webui/src/pages/api-keys.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { formatKeyPreview } from "@/lib/format";
 
 const source = readFileSync(resolve(__dirname, "api-keys.tsx"), "utf8");
 
@@ -204,13 +205,13 @@ describe("multi-key management", () => {
   });
 
   it("masks the key preview to a fixed length regardless of the real key's length", () => {
-    const start = source.indexOf("function formatKeyPreview(");
-    const end = source.indexOf("\nfunction formatExpiresText", start);
-    if (start < 0 || end < 0) {
-      throw new Error("Could not locate formatKeyPreview");
-    }
-    const body = source.slice(start, end);
-
-    expect(body).toContain('"*".repeat(KEY_PREVIEW_MASK_LEN)');
+    // formatKeyPreview is shared from @/lib/format; the mask run must be a fixed
+    // length so it never hints at the real key's length.
+    const maskOf = (s: string) => (formatKeyPreview(s).match(/\*+/) ?? [""])[0];
+    const shortMask = maskOf("sk-abcdefghijklmnop"); // 19 chars
+    const longMask = maskOf("sk-abcdefghijklmnopqrstuvwxyz0123456789"); // longer
+    expect(shortMask.length).toBe(28);
+    expect(longMask.length).toBe(28);
+    expect(formatKeyPreview("sk-abcdefghijklmnop")).toBe(`sk-abcdef${"*".repeat(28)}klmnop`);
   });
 });

--- a/go/webui/src/pages/api-keys.tsx
+++ b/go/webui/src/pages/api-keys.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatKeyPreview } from "@/lib/format";
 import {
   ChevronLeft,
   ChevronRight,
@@ -129,23 +130,6 @@ function SectionTitle({ children, info }: { children: string; info?: string }) {
   );
 }
 
-/** Backend only ever returns a masked key_preview (leading 12 + trailing 6
- *  characters of the raw key, concatenated — never the full plaintext, except
- *  the one-time reveal right after create/add/regenerate). This renders it as
- *  "sk-abc123************************abc123": a fixed-length mask so the
- *  asterisk run never hints at the real key's length. */
-const KEY_PREVIEW_LEAD_VISIBLE = 9;
-const KEY_PREVIEW_TRAIL_VISIBLE = 6;
-const KEY_PREVIEW_MASK_LEN = 28;
-
-function formatKeyPreview(preview: string | undefined | null) {
-  const trimmed = (preview ?? "").trim();
-  if (!trimmed) return "sk-";
-  if (trimmed.length <= KEY_PREVIEW_LEAD_VISIBLE + KEY_PREVIEW_TRAIL_VISIBLE) return trimmed;
-  const lead = trimmed.slice(0, KEY_PREVIEW_LEAD_VISIBLE);
-  const trail = trimmed.slice(-KEY_PREVIEW_TRAIL_VISIBLE);
-  return `${lead}${"*".repeat(KEY_PREVIEW_MASK_LEN)}${trail}`;
-}
 
 function formatExpiresText(value: string | null | undefined, isZh: boolean) {
   if (!value) return isZh ? "永不过期" : "Never";

--- a/go/webui/src/pages/logs.tsx
+++ b/go/webui/src/pages/logs.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import { useLocale } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Select,
   SelectContent,
@@ -274,17 +275,28 @@ export default function LogsPage() {
                           {log.client_status_code ?? "–"}
                         </span>
                       </td>
-                      <td className="px-3 py-2 whitespace-nowrap">
-                        <div className="flex flex-col leading-tight">
-                          <span className="text-xs font-medium text-slate-700">
-                            {log.api_key_name ?? "–"}
+                      <td className="px-3 py-2 text-xs whitespace-nowrap">
+                        {log.api_key_preview && log.api_key_preview !== log.api_key_name ? (
+                          // Named key: show the name, reveal the masked preview on hover
+                          // (same affordance as the nodes list' connection-time tooltip).
+                          <TooltipProvider delayDuration={120}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="cursor-help font-medium text-slate-700">
+                                  {log.api_key_name}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent className="font-mono">
+                                {formatKeyPreview(log.api_key_preview)}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : (
+                          // Unnamed key (name falls back to the preview) or no key.
+                          <span className="font-medium text-slate-700">
+                            {log.api_key_name ? formatKeyPreview(log.api_key_name) : "–"}
                           </span>
-                          {log.api_key_preview && log.api_key_preview !== log.api_key_name ? (
-                            <span className="text-[11px] text-slate-400">
-                              {formatKeyPreview(log.api_key_preview)}
-                            </span>
-                          ) : null}
-                        </div>
+                        )}
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-col leading-tight">

--- a/go/webui/src/pages/logs.tsx
+++ b/go/webui/src/pages/logs.tsx
@@ -274,8 +274,17 @@ export default function LogsPage() {
                           {log.client_status_code ?? "–"}
                         </span>
                       </td>
-                      <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">
-                        {log.api_key_name ?? "–"}
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <div className="flex flex-col leading-tight">
+                          <span className="text-xs font-medium text-slate-700">
+                            {log.api_key_name ?? "–"}
+                          </span>
+                          {log.api_key_preview && log.api_key_preview !== log.api_key_name ? (
+                            <span className="text-[11px] text-slate-400">
+                              {log.api_key_preview}
+                            </span>
+                          ) : null}
+                        </div>
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-col leading-tight">

--- a/go/webui/src/pages/logs.tsx
+++ b/go/webui/src/pages/logs.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight, ScrollText, Trash2 } from "lucide-react";
 import { backend } from "@/lib/backend";
 import type { Consumer, LogPage, LogQuery, ModelStats, Upstream, RequestLog } from "@/lib/types";
 import { getRouteType } from "@/lib/types";
-import { computeTps, formatDuration, formatLogTime, formatTokenCount, formatTps } from "@/lib/format";
+import { computeTps, formatDuration, formatKeyPreview, formatLogTime, formatTokenCount, formatTps } from "@/lib/format";
 import { prettyName } from "@/lib/protocol";
 import { cn } from "@/lib/utils";
 import { useLocale } from "@/lib/i18n";
@@ -281,7 +281,7 @@ export default function LogsPage() {
                           </span>
                           {log.api_key_preview && log.api_key_preview !== log.api_key_name ? (
                             <span className="text-[11px] text-slate-400">
-                              {log.api_key_preview}
+                              {formatKeyPreview(log.api_key_preview)}
                             </span>
                           ) : null}
                         </div>

--- a/go/webui/src/pages/settings.tsx
+++ b/go/webui/src/pages/settings.tsx
@@ -34,6 +34,7 @@ import {
   exporterKindLabel,
   exporterSettingKey,
   retentionSettingKey,
+  flushIntervalSettingKey,
   settingKey,
   SIGNALS,
   type ExporterDef,
@@ -58,6 +59,12 @@ const OBS_RETENTION_DEFAULT: Record<Signal, string> = {
   metrics: "30",
   traces: "3",
 };
+
+// Admin-local flush cadence (per signal): how often the receiver persists that
+// signal's buffered rows to parquet — the time trigger complementing the sink's
+// size trigger. A sibling of the per-signal retention settings, same admin-local
+// storage tier, applied at boot.
+const OBS_FLUSH_DEFAULT = "5s";
 
 const OBS_SIGNAL_LABEL: Record<Signal, { zh: string; en: string }> = {
   logs: { zh: "日志", en: "Logs" },
@@ -454,51 +461,84 @@ function PublicGatewayURLForm({
 
 function RetentionSettingsCard({ isZh, showErrorDialog }: { isZh: boolean; showErrorDialog: (titleZh: string, titleEn: string, error: unknown) => void }) {
   const qc = useQueryClient();
-  const keys = useMemo(() => SIGNALS.map(retentionSettingKey), []);
-  const queries = useQueries({
-    queries: keys.map((key) => ({ queryKey: ["setting", key], queryFn: () => backend<string | null>("get_setting", { key }) })),
+  const retentionKeys = useMemo(() => SIGNALS.map(retentionSettingKey), []);
+  const flushKeys = useMemo(() => SIGNALS.map(flushIntervalSettingKey), []);
+  const retentionQueries = useQueries({
+    queries: retentionKeys.map((key) => ({ queryKey: ["setting", key], queryFn: () => backend<string | null>("get_setting", { key }) })),
   });
-  const settings = queries.map((query) => query.data ?? null);
-  const baseline = useMemo(() => {
+  const flushQueries = useQueries({
+    queries: flushKeys.map((key) => ({ queryKey: ["setting", key], queryFn: () => backend<string | null>("get_setting", { key }) })),
+  });
+  const retentionSettings = retentionQueries.map((query) => query.data ?? null);
+  const flushSettings = flushQueries.map((query) => query.data ?? null);
+
+  const retentionBaseline = useMemo(() => {
     const values = {} as Record<Signal, string>;
-    SIGNALS.forEach((signal, index) => { values[signal] = settings[index]?.trim() || OBS_RETENTION_DEFAULT[signal]; });
+    SIGNALS.forEach((signal, index) => { values[signal] = retentionSettings[index]?.trim() || OBS_RETENTION_DEFAULT[signal]; });
     return values;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(settings)]);
-  const [values, setValues] = useState<Record<Signal, string>>(baseline);
-  useEffect(() => setValues(baseline), [baseline]);
-  const dirty = SIGNALS.some((signal) => values[signal].trim() !== baseline[signal]);
+  }, [JSON.stringify(retentionSettings)]);
+  const flushBaseline = useMemo(() => {
+    const values = {} as Record<Signal, string>;
+    SIGNALS.forEach((signal, index) => { values[signal] = flushSettings[index]?.trim() || OBS_FLUSH_DEFAULT; });
+    return values;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(flushSettings)]);
+
+  const [retention, setRetention] = useState<Record<Signal, string>>(retentionBaseline);
+  const [flush, setFlush] = useState<Record<Signal, string>>(flushBaseline);
+  useEffect(() => setRetention(retentionBaseline), [retentionBaseline]);
+  useEffect(() => setFlush(flushBaseline), [flushBaseline]);
+
+  const dirty = SIGNALS.some((signal) => retention[signal].trim() !== retentionBaseline[signal] || flush[signal].trim() !== flushBaseline[signal]);
+  const flushInvalid = SIGNALS.some((signal) => !GO_DURATION_RE.test(flush[signal].trim() || OBS_FLUSH_DEFAULT));
+
   const saveMut = useMutation({
     mutationFn: async () => {
-      await Promise.all(SIGNALS.map((signal) => backend("set_setting", {
-        key: retentionSettingKey(signal),
-        value: values[signal].trim() || OBS_RETENTION_DEFAULT[signal],
-      })));
+      await Promise.all(SIGNALS.flatMap((signal) => [
+        backend("set_setting", { key: retentionSettingKey(signal), value: retention[signal].trim() || OBS_RETENTION_DEFAULT[signal] }),
+        backend("set_setting", { key: flushIntervalSettingKey(signal), value: flush[signal].trim() || OBS_FLUSH_DEFAULT }),
+      ]));
     },
-    onSuccess: () => { for (const key of keys) qc.invalidateQueries({ queryKey: ["setting", key] }); },
-    onError: (error: unknown) => showErrorDialog("保存遥测保留策略失败", "Failed to save telemetry retention", error),
+    onSuccess: () => { for (const key of [...retentionKeys, ...flushKeys]) qc.invalidateQueries({ queryKey: ["setting", key] }); },
+    onError: (error: unknown) => showErrorDialog("保存遥测存储策略失败", "Failed to save telemetry storage settings", error),
   });
 
   return (
     <div className="glass rounded-2xl p-6 space-y-4">
       <div>
         <h3 className="text-lg font-semibold text-slate-900">{isZh ? "本地遥测保留" : "Local Telemetry Retention"}</h3>
-        <p className="mt-1 text-sm text-slate-500">{isZh ? "Admin 本地 parquet 存储的保留天数，不配置外部导出器的生命周期。" : "Retention days for Admin-local parquet storage, not an external exporter's lifecycle."}</p>
+        <p className="mt-1 text-sm text-slate-500">{isZh ? "Admin 本地 parquet 存储的保留天数与落盘间隔，不配置外部导出器的生命周期。" : "Retention days and flush interval for Admin-local parquet storage, not an external exporter's lifecycle."}</p>
       </div>
-      <div className="grid grid-cols-3 gap-3">
-        {SIGNALS.map((signal) => (
-          <div key={signal} className="space-y-1.5">
-            <label className="ml-1 text-xs text-slate-700">{isZh ? OBS_SIGNAL_LABEL[signal].zh : OBS_SIGNAL_LABEL[signal].en}</label>
-            <Input type="number" min={1} max={365} placeholder={OBS_RETENTION_DEFAULT[signal]} value={values[signal]} onChange={(e) => setValues((prev) => ({ ...prev, [signal]: e.target.value }))} />
-          </div>
-        ))}
+      <div className="space-y-1.5">
+        <p className="ml-1 text-xs font-medium text-slate-600">{isZh ? "保留天数" : "Retention (days)"}</p>
+        <div className="grid grid-cols-3 gap-3">
+          {SIGNALS.map((signal) => (
+            <div key={signal} className="space-y-1.5">
+              <label className="ml-1 text-xs text-slate-700">{isZh ? OBS_SIGNAL_LABEL[signal].zh : OBS_SIGNAL_LABEL[signal].en}</label>
+              <Input type="number" min={1} max={365} placeholder={OBS_RETENTION_DEFAULT[signal]} value={retention[signal]} onChange={(e) => setRetention((prev) => ({ ...prev, [signal]: e.target.value }))} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <p className="ml-1 text-xs font-medium text-slate-600">{isZh ? "落盘间隔（如 5s）" : "Flush interval (e.g. 5s)"}</p>
+        <div className="grid grid-cols-3 gap-3">
+          {SIGNALS.map((signal) => (
+            <div key={signal} className="space-y-1.5">
+              <label className="ml-1 text-xs text-slate-700">{isZh ? OBS_SIGNAL_LABEL[signal].zh : OBS_SIGNAL_LABEL[signal].en}</label>
+              <Input placeholder={OBS_FLUSH_DEFAULT} value={flush[signal]} onChange={(e) => setFlush((prev) => ({ ...prev, [signal]: e.target.value }))} />
+            </div>
+          ))}
+        </div>
       </div>
       <div className="flex items-center gap-2">
-        <Button onClick={() => saveMut.mutate()} disabled={saveMut.isPending || !dirty} size="sm" className="flex items-center gap-1.5">
+        <Button onClick={() => saveMut.mutate()} disabled={saveMut.isPending || !dirty || flushInvalid} size="sm" className="flex items-center gap-1.5">
           {saveMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
           {isZh ? "保存" : "Save"}
         </Button>
-        {dirty && <p className="text-xs text-amber-600">{isZh ? "重启 Admin 后生效" : "Restart Admin to apply"}</p>}
+        {flushInvalid && <p className="text-xs text-rose-600">{isZh ? "落盘间隔格式无效（示例：5s、30s、1m）" : "Invalid flush interval (e.g. 5s, 30s, 1m)"}</p>}
+        {dirty && !flushInvalid && <p className="text-xs text-amber-600">{isZh ? "重启 Admin 后生效" : "Restart Admin to apply"}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes a chain of issues found while bringing up the default data-plane + control-plane telemetry flow (OpenAI Responses client → Nyro → Anthropic Messages/Zhipu). Each is a separate commit.

## What was broken

1. **Gateway never applied control-plane obs config** (`--config-server` mode). The OTel provider was built once at startup from the still-empty config cache → resolved to the stdout default and was never rebuilt when the first config-sync snapshot arrived. Result: request logs went to the gateway's stdout; nothing reached the control plane.
2. **OTLP exports 404'd.** The seeded endpoint is a base URL (`http://host:port`) shared by all three signals; `WithEndpointURL` does not append the default `/v1/<signal>` path when it is empty, so exports POSTed to `/` → admin `NotFound`.
3. **WebUI logs/metrics/traces empty.** The admin's parquet sinks only flushed on their size trigger (`maxRows=50000`) or at shutdown — no time trigger — so low-traffic data never became queryable until restart.
4. **Input tokens always 0.** Zhipu/GLM reports the real usage only in the final `message_delta`; the Anthropic decoder read `input_tokens` only from `message_start` (which GLM sends as 0).
5. **Logs Export Interval ignored.** The configured interval was wired for metrics (PeriodicReader) and traces (batch timeout) but dropped for logs (fixed 1s SDK default).
6. **Error `type` casing.** Framework error envelope types lowercased.

## Changes (per commit)

- `fix(go/anthropic)`: adopt input/cache token counts from `message_delta` when present (real Anthropic unchanged); goldens updated (they had codified the bug).
- `refactor(go)`: `gateway_error`→`GATEWAY_ERROR`, `auth_error`→`AUTH_ERROR`. `AiErrorKind` protocol values stay snake_case (OpenAI/Anthropic wire contract).
- `fix(go/observability)`: hot-reload — `SwappableProvider` behind the once-registered hooks + `ConfigCache` OnSwap callback + `obsManager` that rebuilds the provider (and prometheus server) on obs-config change.
- `fix(go/observability)`: append per-signal `/v1/<signal>` path to base OTLP endpoints; honor the logs export interval.
- `feat(go/observability)`: per-signal time-triggered parquet flush via `obs_<signal>_flush_interval` (admin-local settings, sibling of retention, default 5s, editable in the WebUI Local Telemetry card).

## Verification

- Full `go build ./... && go vet ./... && go test ./...` green (protocoltest goldens regenerated).
- WebUI `npm run lint` + `npm run build` + settings-layout tests green.
- End-to-end reproduced with a mock Anthropic/Zhipu SSE upstream: after the fixes, `/logs` and `/stats` populate and show `input_tokens=11, output_tokens=81`.

## Notes for reviewers

- `obs_<signal>_flush_interval` and retention are admin-local (not pushed to the data plane) and applied at admin boot — the WebUI card notes "Restart Admin to apply".
- Flush interval trades query freshness against parquet file count (one file per non-empty flush); default 5s, configurable per signal.