### PR TITLE
fix(go/migrations): use utf8mb4_general_ci for broader MySQL compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       # have docker, nothing extra to install.
       - name: Create atlas dev-database scratch schemas
         run: |
-          mysql -h127.0.0.1 -P13306 -uroot -ppass -e "CREATE DATABASE IF NOT EXISTS dev;"
+          mysql -h127.0.0.1 -P13306 -uroot -ppass -e "CREATE DATABASE IF NOT EXISTS dev CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
           PGPASSWORD=pass psql -h127.0.0.1 -p15432 -Upostgres -c "CREATE DATABASE dev;" || true
 
       # Two different checks, see go/docs/schema/migrations.md: lint

--- a/go/docs/schema/migrations.md
+++ b/go/docs/schema/migrations.md
@@ -71,12 +71,21 @@ in `go/atlas.hcl` (`localhost:13306`/`:15432`). Spin them up once with:
 docker run -d --name nyro-atlas-mysql-dev -e MYSQL_ROOT_PASSWORD=pass -p 13306:3306 mysql:8
 docker run -d --name nyro-atlas-postgres-dev -e POSTGRES_PASSWORD=pass -p 15432:5432 postgres:16
 # once both are up (mysqladmin ping / pg_isready):
-docker exec nyro-atlas-mysql-dev mysql -ppass -e "CREATE DATABASE IF NOT EXISTS dev;"
+docker exec nyro-atlas-mysql-dev mysql -ppass -e "CREATE DATABASE IF NOT EXISTS dev CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
 docker exec nyro-atlas-postgres-dev psql -U postgres -c "CREATE DATABASE dev;"
 ```
 
 They're scratch space atlas uses to compute diffs — never a real target,
 safe to leave running or throw away and recreate at any time.
+
+The `dev` mysql database's charset/collation must be set explicitly to
+`utf8mb4`/`utf8mb4_general_ci` (matching CI's setup step): tables with no
+explicit charset inherit whatever the connected database defaults to, and
+Atlas bakes that into the generated `CREATE TABLE` statements. Left
+unset, MySQL 8 defaults to `utf8mb4_0900_ai_ci`, a collation unsupported
+by MySQL 5.7 and most MariaDB versions — the broadly-compatible
+`utf8mb4_general_ci` needs to come from the dev database, not the
+generator.
 
 ## Makefile targets
 

--- a/go/migrations/mysql/20260713135351_baseline.sql
+++ b/go/migrations/mysql/20260713135351_baseline.sql
@@ -13,7 +13,7 @@ CREATE TABLE `consumer_keys` (
   PRIMARY KEY (`id`),
   UNIQUE INDEX `idx_consumer_key_name` (`consumer_id`, `name`),
   INDEX `idx_consumer_keys_key_preview` (`key_preview`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "consumer_quotas" table
 CREATE TABLE `consumer_quotas` (
   `id` varchar(191) NOT NULL,
@@ -25,13 +25,13 @@ CREATE TABLE `consumer_quotas` (
   `created_at` longtext NOT NULL,
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`id`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "consumer_routes" table
 CREATE TABLE `consumer_routes` (
   `consumer_id` varchar(191) NOT NULL,
   `route_id` varchar(191) NOT NULL,
   PRIMARY KEY (`consumer_id`, `route_id`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "consumers" table
 CREATE TABLE `consumers` (
   `id` varchar(191) NOT NULL,
@@ -47,7 +47,7 @@ CREATE TABLE `consumers` (
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `idx_consumers_name` (`name`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "route_upstreams" table
 CREATE TABLE `route_upstreams` (
   `id` varchar(191) NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE `route_upstreams` (
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `idx_route_upstream_model` (`route_id`, `upstream_id`, `model`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "routes" table
 CREATE TABLE `routes` (
   `id` varchar(191) NOT NULL,
@@ -74,14 +74,14 @@ CREATE TABLE `routes` (
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `idx_routes_model` (`model`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "settings" table
 CREATE TABLE `settings` (
   `key` varchar(191) NOT NULL,
   `value` longtext NOT NULL,
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`key`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
 -- Create "upstreams" table
 CREATE TABLE `upstreams` (
   `id` varchar(191) NOT NULL,
@@ -98,4 +98,4 @@ CREATE TABLE `upstreams` (
   `updated_at` longtext NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `idx_upstreams_name` (`name`)
-) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/go/migrations/mysql/atlas.sum
+++ b/go/migrations/mysql/atlas.sum
@@ -1,2 +1,2 @@
-h1:EcQrV/UOUGblVikGyCk54HK+gQF3PTqwvCec9PEDBQM=
-20260713135351_baseline.sql h1:85iH4vCdjj2vtqD6lIgEi3vS+DhMEFctFfTpQXnbZZs=
+h1:VBpzfxJ3Rz5bhLBTcnZX5/cxH5iSUEzeYTO9yBdUIag=
+20260713135351_baseline.sql h1:RzYXlQg/edVFYW27FS3a6nKKivP2YZgYMmoqnUl60rk=


### PR DESCRIPTION
## Summary
- The generated MySQL baseline migration used `utf8mb4_0900_ai_ci`, a MySQL 8.0+-only collation that fails to import on MySQL 5.7 and most MariaDB versions.
- The collation isn't set explicitly anywhere in the GORM models — it leaked in from whatever the scratch "dev" database Atlas diffs against defaults to (MySQL 8's own default).
- Changed the baseline migration to `utf8mb4_general_ci` (MySQL 5.5+ / MariaDB compatible) and fixed the root cause: CI and local dev docs now explicitly set the scratch database's collation, so future `go-migrate-diff` runs won't drift back to the MySQL 8 default.

## Test plan
- [x] `make go-migrate-lint` — no diagnostics on the baseline migration
- [x] `make go-migrate-verify` — Atlas confirms "synced with the desired state, no changes to be made" for both mysql/postgres against a fresh scratch dev database created with the updated collation