### PR TITLE
feat(go/configsync): drain streams on admin shutdown + jitter reconnect backoff

### DIFF
--- a/go/internal/configsync/client.go
+++ b/go/internal/configsync/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log"
 	"math"
+	mrand "math/rand"
 	"net"
 	"os"
 	"strings"
@@ -45,6 +46,11 @@ type ConfigClient struct {
 	// Backoff config. Overridable for tests.
 	initialBackoff time.Duration
 	maxBackoff     time.Duration
+
+	// rng sources the reconnect jitter. Seeded per-process so multiple
+	// gateways that drop together don't reconnect in lockstep. Overridable
+	// for tests to make jitter deterministic.
+	rng *mrand.Rand
 }
 
 // NewConfigClient builds a client that connects to target (host:port) and
@@ -71,6 +77,7 @@ func NewConfigClient(target string, cache *ConfigCache, servicePort string, tlsC
 		servicePort:    servicePort,
 		initialBackoff: 500 * time.Millisecond,
 		maxBackoff:     30 * time.Second,
+		rng:            mrand.New(mrand.NewSource(time.Now().UnixNano())),
 		dialOpts: []grpc.DialOption{
 			grpc.WithTransportCredentials(creds),
 		},
@@ -177,8 +184,11 @@ func (c *ConfigClient) runOnce(ctx context.Context) (connected bool, err error) 
 	}
 }
 
-// backoff returns a growing delay for attempt (1-based), capped at maxBackoff.
-func (c *ConfigClient) backoff(attempt int) time.Duration {
+// baseBackoff returns the deterministic exponential delay for attempt
+// (1-based), capped at maxBackoff — base * 2^(attempt-1). It carries no
+// randomness so the growth schedule stays easy to reason about and test;
+// backoff layers jitter on top.
+func (c *ConfigClient) baseBackoff(attempt int) time.Duration {
 	if attempt <= 1 {
 		return c.initialBackoff
 	}
@@ -189,6 +199,20 @@ func (c *ConfigClient) backoff(attempt int) time.Duration {
 		d = c.maxBackoff
 	}
 	return d
+}
+
+// backoff returns the actual reconnect delay: the exponential baseBackoff with
+// equal jitter applied — base/2 + rand[0, base/2). The jitter spreads the
+// reconnect instants of gateways that dropped together (e.g. on an admin
+// restart) so they don't stampede the admin in lockstep. The result stays in
+// [base/2, base), so it never exceeds maxBackoff.
+func (c *ConfigClient) backoff(attempt int) time.Duration {
+	base := c.baseBackoff(attempt)
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(c.rng.Int63n(int64(half)))
 }
 
 // ServeGRPC starts a gRPC server listening on addr serving srv. It blocks until
@@ -218,6 +242,12 @@ func ServeGRPC(ctx context.Context, addr string, srv pb.ConfigServiceServer, tls
 	pb.RegisterConfigServiceServer(gs, srv)
 	go func() {
 		<-ctx.Done()
+		// Drain active gateway streams first so GracefulStop is not blocked
+		// waiting on the long-lived StreamConfig RPCs. The 5s hard-stop below
+		// remains as a safety net.
+		if d, ok := srv.(interface{ Drain() }); ok {
+			d.Drain()
+		}
 		stopped := make(chan struct{})
 		go func() { gs.GracefulStop(); close(stopped) }()
 		select {

--- a/go/internal/configsync/client_test.go
+++ b/go/internal/configsync/client_test.go
@@ -2,6 +2,7 @@ package configsync
 
 import (
 	"context"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -76,20 +77,42 @@ func TestConfigClient_StopsOnContextCancel(t *testing.T) {
 	}
 }
 
-// TestConfigClient_BackoffGrows verifies the reconnect backoff schedule grows
-// exponentially and is capped at maxBackoff.
-func TestConfigClient_BackoffGrows(t *testing.T) {
+// TestConfigClient_BaseBackoffGrows verifies the deterministic backoff schedule
+// grows exponentially and is capped at maxBackoff.
+func TestConfigClient_BaseBackoffGrows(t *testing.T) {
 	c := &ConfigClient{initialBackoff: 10 * time.Millisecond, maxBackoff: 100 * time.Millisecond}
-	if d := c.backoff(1); d != 10*time.Millisecond {
-		t.Errorf("backoff(1) = %v; want 10ms", d)
+	if d := c.baseBackoff(1); d != 10*time.Millisecond {
+		t.Errorf("baseBackoff(1) = %v; want 10ms", d)
 	}
-	if d := c.backoff(2); d != 20*time.Millisecond {
-		t.Errorf("backoff(2) = %v; want 20ms", d)
+	if d := c.baseBackoff(2); d != 20*time.Millisecond {
+		t.Errorf("baseBackoff(2) = %v; want 20ms", d)
 	}
-	if d := c.backoff(3); d != 40*time.Millisecond {
-		t.Errorf("backoff(3) = %v; want 40ms", d)
+	if d := c.baseBackoff(3); d != 40*time.Millisecond {
+		t.Errorf("baseBackoff(3) = %v; want 40ms", d)
 	}
-	if d := c.backoff(10); d != 100*time.Millisecond {
-		t.Errorf("backoff(10) = %v; want capped 100ms", d)
+	if d := c.baseBackoff(10); d != 100*time.Millisecond {
+		t.Errorf("baseBackoff(10) = %v; want capped 100ms", d)
+	}
+}
+
+// TestConfigClient_BackoffJitter verifies backoff applies equal jitter: the
+// result stays in [base/2, base) and varies across calls (not lockstep).
+func TestConfigClient_BackoffJitter(t *testing.T) {
+	c := &ConfigClient{
+		initialBackoff: 10 * time.Millisecond,
+		maxBackoff:     100 * time.Millisecond,
+		rng:            mrand.New(mrand.NewSource(1)),
+	}
+	base := c.baseBackoff(4) // 80ms, below the cap
+	seen := map[time.Duration]struct{}{}
+	for range 50 {
+		d := c.backoff(4)
+		if d < base/2 || d >= base {
+			t.Fatalf("backoff(4) = %v; want in [%v, %v)", d, base/2, base)
+		}
+		seen[d] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Errorf("jitter produced no variation across 50 calls: %v", seen)
 	}
 }

--- a/go/internal/configsync/server.go
+++ b/go/internal/configsync/server.go
@@ -33,6 +33,14 @@ type ConfigServer struct {
 	current  *pb.ConfigSnapshot // last snapshot handed to Notify (nil until first push)
 	clients  map[*streamClient]struct{}
 	buildCnt int // diagnostics: number of snapshot rebuilds
+
+	// done is closed by Drain to signal a server shutdown to every active
+	// StreamConfig loop so they return immediately instead of blocking until
+	// the gateway disconnects. Without this, GracefulStop would wait on the
+	// long-lived streams until its hard-stop timeout. drainOnce guards the
+	// close so Drain is idempotent.
+	done      chan struct{}
+	drainOnce sync.Once
 }
 
 type streamClient struct {
@@ -74,7 +82,16 @@ func NewConfigServer(store storage.Storage) *ConfigServer {
 	return &ConfigServer{
 		store:   store,
 		clients: map[*streamClient]struct{}{},
+		done:    make(chan struct{}),
 	}
+}
+
+// Drain signals every active StreamConfig loop to return so a graceful
+// shutdown completes promptly instead of waiting for gateways to disconnect.
+// It is idempotent and safe to call concurrently. Call it before the gRPC
+// server's GracefulStop (see ServeGRPC).
+func (s *ConfigServer) Drain() {
+	s.drainOnce.Do(func() { close(s.done) })
 }
 
 // StreamConfig implements the long-lived gateway subscription. The gateway
@@ -152,6 +169,11 @@ func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreami
 			c.setLastVersion(snap.GetVersion())
 		case <-ctx.Done():
 			return nil
+		case <-s.done:
+			// Server is shutting down: end the stream so GracefulStop can
+			// complete. Unavailable tells the gateway this is a server-side
+			// close, and it reconnects with backoff as usual.
+			return status.Error(codes.Unavailable, "server shutting down")
 		}
 	}
 }

--- a/go/internal/configsync/server_test.go
+++ b/go/internal/configsync/server_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
 	pb "github.com/nyroway/nyro/go/internal/configsync/pb/configsync/v1"
@@ -129,6 +131,44 @@ func TestNodes_RemovedOnDisconnect(t *testing.T) {
 
 	cancel()
 	waitFor(t, time.Second, func() bool { return len(srv.Nodes()) == 0 })
+}
+
+// TestDrain_EndsActiveStream verifies Drain returns every active StreamConfig
+// with Unavailable so a graceful shutdown does not block on long-lived streams.
+func TestDrain_EndsActiveStream(t *testing.T) {
+	st, _, _, _, _, _ := newPopulatedStorage(t)
+	srv, dialOpt, stop := bufconnEnv(t, st)
+	defer stop()
+
+	stream, closeFn := dialClient(t, dialOpt)
+	defer closeFn()
+
+	// Consume the initial snapshot so the stream is parked in its push loop.
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("initial Recv: %v", err)
+	}
+	waitFor(t, time.Second, func() bool { return srv.ClientCount() == 1 })
+
+	srv.Drain()
+
+	// The stream must end promptly with Unavailable.
+	done := make(chan error, 1)
+	go func() {
+		_, err := stream.Recv()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if status.Code(err) != codes.Unavailable {
+			t.Fatalf("Recv after Drain = %v; want Unavailable", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not end after Drain")
+	}
+	waitFor(t, time.Second, func() bool { return srv.ClientCount() == 0 })
+
+	// Drain is idempotent.
+	srv.Drain()
 }
 
 func TestNotify_PushesToConnectedGateway(t *testing.T) {


### PR DESCRIPTION
## 背景

调研 admin/gateway 高可用时发现两个问题:

1. **admin 关闭时卡约 5 秒**:gateway↔admin 是一条 gRPC 服务端长流(`StreamConfig`)。admin 关闭走 `GracefulStop()`,但它不会主动取消长流的 context——只要 gateway 不断,流的 for 循环就一直阻塞,GracefulStop 被迫等到 `ServeGRPC` 里的 5 秒兜底超时才硬停。
2. **重连退避无 jitter**:`ConfigClient.backoff()` 是纯指数退避,多个 gateway 同时断线(如 admin 重启)会同步重连,存在惊群风险。

## 改动

**admin 优雅关闭主动断流** (`server.go` / `client.go`)
- `ConfigServer` 新增 `done` channel + 幂等的 `Drain()` 方法。
- `StreamConfig` 推送 select 增加 `case <-s.done`,返回 `codes.Unavailable` 让活跃长流立即结束。
- `ServeGRPC` 在 `GracefulStop` 之前先 `Drain()`,5 秒硬停兜底保留作安全网。
- 效果:有 gateway 连接时 admin 收到 SIGINT/SIGTERM 也能秒退;gateway 收到 `Unavailable` 后照常退避重连。

**重连退避加 jitter** (`client.go`)
- 纯指数逻辑拆为可测的 `baseBackoff(attempt)`;新 `backoff(attempt)` 叠加 equal jitter:`base/2 + rand[0, base/2)`,结果落在 `[base/2, base)`,不超过 `maxBackoff`。
- `ConfigClient` 加可注入的 `rng`,测试可用固定 seed 断言。

## 测试

- 新增 `TestDrain_EndsActiveStream`:验证 `Drain()` 后活跃流秒级返回 `Unavailable`、客户端计数归零、`Drain` 幂等。
- `TestConfigClient_BackoffGrows` → `TestConfigClient_BaseBackoffGrows`(测确定性指数值);新增 `TestConfigClient_BackoffJitter`(测区间与抖动)。
- `go build ./...`、`go vet`、全量 `go test ./...` 均通过。