### PR TITLE
feat(go): Connect page in webui + recoverable (plaintext) API keys

### DIFF
--- a/go/cmd/admin/admin.go
+++ b/go/cmd/admin/admin.go
@@ -69,6 +69,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().String("webui-dir", "", "path to the built WebUI (serves the SPA at /)")
 	cmd.Flags().String("dsn", "", fmt.Sprintf("database DSN: sqlite://<path> (default %s), postgres://..., or mysql://...", defaultDSN()))
 	cmd.Flags().Bool("auto-migrate", false, "let nyro create/alter the schema itself via GORM AutoMigrate (requires DDL rights on --dsn); default false regardless of backend — without it, nyro only verifies the canonical tables exist, and a DBA applies the DDL from `nyro migrate dump`/`diff` (see go/docs/schema/migrations.md)")
+	cmd.Flags().Bool("plaintext-keys", false, "store the recoverable raw API key alongside its hash so full keys can be retrieved/copied after creation; default false (hash-only, keys shown once at creation). Never affects inbound auth (always hash-compared) and is never sent to gateways over config-sync")
 	cmd.Flags().String("obs-data-dir", filepath.Join(nyroHomeDir(), "obs"), "directory for admin-local observability parquet data (logs/metrics/traces)")
 	cmd.Flags().Duration("config-poll-interval", 0, "how often to poll the shared config_epoch setting for changes made by other admin replicas (0 disables polling)")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
@@ -81,6 +82,7 @@ func NewCmd() *cobra.Command {
 		webuiDir, _ := cmd.Flags().GetString("webui-dir")
 		dsn, _ := cmd.Flags().GetString("dsn")
 		autoMigrate, _ := cmd.Flags().GetBool("auto-migrate")
+		plaintextKeys, _ := cmd.Flags().GetBool("plaintext-keys")
 		obsDataDir, _ := cmd.Flags().GetString("obs-data-dir")
 		configPollInterval, _ := cmd.Flags().GetDuration("config-poll-interval")
 		if configPollInterval < 0 {
@@ -148,7 +150,7 @@ func NewCmd() *cobra.Command {
 			}
 		}
 
-		st, err := bootstrap.OpenStorageFromDSN(dsn, autoMigrate)
+		st, err := bootstrap.OpenStorageFromDSN(dsn, autoMigrate, plaintextKeys)
 		if err != nil {
 			return err
 		}

--- a/go/docs/schema/database.md
+++ b/go/docs/schema/database.md
@@ -81,6 +81,7 @@ CREATE TABLE consumer_keys (
   name TEXT NOT NULL,
   key_preview TEXT NOT NULL,
   key_hash TEXT NOT NULL,
+  key_plaintext TEXT,            -- recoverable raw key; set only under admin --plaintext-keys, else empty
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   expires_at TEXT,
   last_used_at TEXT,

--- a/go/internal/bootstrap/bootstrap.go
+++ b/go/internal/bootstrap/bootstrap.go
@@ -88,7 +88,12 @@ func mysqlURLToGormDSN(dsn string) (string, error) {
 // database engine. When false, the backend instead gets a read-only schema
 // check (Backend.CheckSchema): it confirms the canonical tables already exist
 // (all backends), without doing any DDL.
-func OpenStorageFromDSN(dsn string, autoMigrate bool) (storage.Storage, error) {
+//
+// plaintextKeys, when true, makes the backend store the recoverable raw API
+// key alongside its hash on creation, so keys can be retrieved after creation
+// (e.g. to display/copy a full key in the UI). Default false (hash-only); it
+// never affects the inbound auth path, which always compares hashes.
+func OpenStorageFromDSN(dsn string, autoMigrate, plaintextKeys bool) (storage.Storage, error) {
 	backend, driverDSN, err := ParseDSN(dsn)
 	if err != nil {
 		return nil, err
@@ -99,18 +104,21 @@ func OpenStorageFromDSN(dsn string, autoMigrate bool) (storage.Storage, error) {
 		if err != nil {
 			return nil, fmt.Errorf("open sqlite: %w", err)
 		}
+		b.SetPlaintextKeys(plaintextKeys)
 		return bootstrapSQL(b, autoMigrate)
 	case "postgres":
 		b, err := database.NewPostgres(driverDSN)
 		if err != nil {
 			return nil, fmt.Errorf("open postgres: %w", err)
 		}
+		b.SetPlaintextKeys(plaintextKeys)
 		return bootstrapSQL(b, autoMigrate)
 	case "mysql":
 		b, err := database.NewMySQL(driverDSN)
 		if err != nil {
 			return nil, fmt.Errorf("open mysql: %w", err)
 		}
+		b.SetPlaintextKeys(plaintextKeys)
 		return bootstrapSQL(b, autoMigrate)
 	default:
 		return nil, fmt.Errorf("unknown storage backend %q", backend)

--- a/go/internal/bootstrap/bootstrap_test.go
+++ b/go/internal/bootstrap/bootstrap_test.go
@@ -45,7 +45,7 @@ func TestParseDSN(t *testing.T) {
 
 func TestOpenStorageFromDSN(t *testing.T) {
 	t.Run("sqlite in-memory with auto-migrate migrates and serves", func(t *testing.T) {
-		st, err := OpenStorageFromDSN("sqlite://:memory:", true)
+		st, err := OpenStorageFromDSN("sqlite://:memory:", true, false)
 		if err != nil {
 			t.Fatalf("sqlite: %v", err)
 		}
@@ -58,12 +58,12 @@ func TestOpenStorageFromDSN(t *testing.T) {
 		}
 	})
 	t.Run("sqlite in-memory without auto-migrate fails schema check", func(t *testing.T) {
-		if _, err := OpenStorageFromDSN("sqlite://:memory:", false); err == nil {
+		if _, err := OpenStorageFromDSN("sqlite://:memory:", false, false); err == nil {
 			t.Error("expected schema-check error on an unmigrated in-memory db")
 		}
 	})
 	t.Run("bad scheme errors", func(t *testing.T) {
-		if _, err := OpenStorageFromDSN("bogus://x", false); err == nil {
+		if _, err := OpenStorageFromDSN("bogus://x", false, false); err == nil {
 			t.Error("expected error for bogus scheme")
 		}
 	})

--- a/go/internal/storage/consumer.go
+++ b/go/internal/storage/consumer.go
@@ -46,9 +46,15 @@ type ConsumerKey struct {
 	Name       string `json:"name"`
 	KeyPreview string `json:"key_preview"`
 	KeyHash    string `json:"-"` // never serialized
-	// Token carries the raw key exactly once, in the response to the create
-	// call that generated it. It is never populated on read paths (List/Get)
-	// and never persisted.
+	// KeyPlaintext holds the recoverable raw key, populated on read paths only
+	// when the admin was started with --plaintext-keys (which stores the
+	// plaintext alongside the hash). It is empty for hash-only keys (the
+	// default) and never serialized directly; when non-empty a store copies it
+	// into Token so callers can retrieve the full key after creation.
+	KeyPlaintext string `json:"-"`
+	// Token carries the raw key: exactly once in the create response, and — for
+	// keys stored with --plaintext-keys — also on read paths (List/Get), copied
+	// from KeyPlaintext. It is empty for hash-only keys on read.
 	Token      string `json:"token,omitempty"`
 	Enabled    bool   `json:"enabled"`
 	ExpiresAt  string `json:"expires_at,omitempty"`

--- a/go/internal/storage/database/backend.go
+++ b/go/internal/storage/database/backend.go
@@ -20,7 +20,16 @@ type Backend struct {
 	backend string
 	db      *gorm.DB
 	q       *query.Query
+	// plaintextKeys, when true, stores the recoverable raw key alongside the
+	// hash on creation so it can be retrieved later. Set once at startup via
+	// SetPlaintextKeys; default false (hash-only).
+	plaintextKeys bool
 }
+
+// SetPlaintextKeys toggles recoverable plaintext key storage. It is set once
+// at startup (from the admin's --plaintext-keys flag) before the backend
+// serves any request.
+func (b *Backend) SetPlaintextKeys(v bool) { b.plaintextKeys = v }
 
 // NewSQLite opens a SQLite database and returns a shared SQL backend.
 func NewSQLite(path string) (*Backend, error) {
@@ -106,7 +115,9 @@ func (b *Backend) Upstreams() storage.UpstreamStore { return upstreamStore{q: b.
 func (b *Backend) Routes() storage.RouteStore { return routeStore{q: b.q} }
 
 // Consumers returns the config-schema consumer store.
-func (b *Backend) Consumers() storage.ConsumerStore { return consumerStore{q: b.q} }
+func (b *Backend) Consumers() storage.ConsumerStore {
+	return consumerStore{q: b.q, plaintextKeys: b.plaintextKeys}
+}
 
 // Auth returns the config-schema inbound key-auth read path.
 func (b *Backend) Auth() storage.KeyAuthStore { return keyAuthStore{q: b.q} }

--- a/go/internal/storage/database/consumers.go
+++ b/go/internal/storage/database/consumers.go
@@ -12,7 +12,12 @@ import (
 	"github.com/nyroway/nyro/go/internal/storage/query"
 )
 
-type consumerStore struct{ q *query.Query }
+type consumerStore struct {
+	q *query.Query
+	// plaintextKeys mirrors Backend.plaintextKeys: store the recoverable raw
+	// key alongside the hash when creating keys.
+	plaintextKeys bool
+}
 
 func (s consumerStore) loadDetails(ctx context.Context, tx *query.Query, c *model.Consumer) (storage.Consumer, error) {
 	out := consumerFromModel(c)
@@ -133,7 +138,7 @@ func (s consumerStore) Create(in storage.CreateConsumer) (storage.Consumer, erro
 		// since raw tokens are never persisted.
 		createdKeys := make([]storage.ConsumerKey, 0, len(in.Keys))
 		for _, k := range in.Keys {
-			ck, err := createConsumerKey(ctx, tx, c.ID, k)
+			ck, err := createConsumerKey(ctx, tx, c.ID, k, s.plaintextKeys)
 			if err != nil {
 				return err
 			}
@@ -170,10 +175,11 @@ func (s consumerStore) Create(in storage.CreateConsumer) (storage.Consumer, erro
 	return out, err
 }
 
-// createConsumerKey generates (or accepts) a raw token, persists only its
-// prefix+hash, and returns the DTO with Token populated (the one-time plaintext
-// exposure at creation).
-func createConsumerKey(ctx context.Context, tx *query.Query, consumerID string, in storage.CreateConsumerKey) (storage.ConsumerKey, error) {
+// createConsumerKey generates (or accepts) a raw token, persists its
+// prefix+hash (and, when plaintextKeys is set, the recoverable raw key), and
+// returns the DTO with Token populated (the one-time plaintext exposure at
+// creation).
+func createConsumerKey(ctx context.Context, tx *query.Query, consumerID string, in storage.CreateConsumerKey, plaintextKeys bool) (storage.ConsumerKey, error) {
 	now := nowISO()
 	raw := in.Token
 	var preview, hash string
@@ -201,6 +207,9 @@ func createConsumerKey(ctx context.Context, tx *query.Query, consumerID string, 
 		ExpiresAt:  in.ExpiresAt,
 		CreatedAt:  now,
 		UpdatedAt:  now,
+	}
+	if plaintextKeys {
+		k.KeyPlaintext = raw
 	}
 	if err := tx.ConsumerKey.WithContext(ctx).Create(k); err != nil {
 		return storage.ConsumerKey{}, err
@@ -384,7 +393,7 @@ func (s consumerStore) AddKey(consumerID string, in storage.CreateConsumerKey) (
 		if _, err := tx.Consumer.WithContext(ctx).Where(tx.Consumer.ID.Eq(consumerID)).First(); err != nil {
 			return err
 		}
-		ck, err := createConsumerKey(ctx, tx, consumerID, in)
+		ck, err := createConsumerKey(ctx, tx, consumerID, in, s.plaintextKeys)
 		if err != nil {
 			return err
 		}

--- a/go/internal/storage/database/convert.go
+++ b/go/internal/storage/database/convert.go
@@ -158,18 +158,25 @@ func stringSliceToJSON(v []string) string {
 }
 
 func consumerKeyFromModel(m *model.ConsumerKey) storage.ConsumerKey {
-	return storage.ConsumerKey{
-		ID:         m.ID,
-		ConsumerID: m.ConsumerID,
-		Name:       m.Name,
-		KeyPreview: m.KeyPreview,
-		KeyHash:    m.KeyHash,
-		Enabled:    m.Enabled,
-		ExpiresAt:  m.ExpiresAt,
-		LastUsedAt: m.LastUsedAt,
-		CreatedAt:  m.CreatedAt,
-		UpdatedAt:  m.UpdatedAt,
+	k := storage.ConsumerKey{
+		ID:           m.ID,
+		ConsumerID:   m.ConsumerID,
+		Name:         m.Name,
+		KeyPreview:   m.KeyPreview,
+		KeyHash:      m.KeyHash,
+		KeyPlaintext: m.KeyPlaintext,
+		Enabled:      m.Enabled,
+		ExpiresAt:    m.ExpiresAt,
+		LastUsedAt:   m.LastUsedAt,
+		CreatedAt:    m.CreatedAt,
+		UpdatedAt:    m.UpdatedAt,
 	}
+	// For plaintext-stored keys, expose the recoverable raw key on read paths
+	// via Token (create sets Token to the same value explicitly).
+	if k.KeyPlaintext != "" {
+		k.Token = k.KeyPlaintext
+	}
+	return k
 }
 
 func consumerQuotaFromModel(m *model.ConsumerQuota) storage.ConsumerQuota {

--- a/go/internal/storage/database/plaintext_test.go
+++ b/go/internal/storage/database/plaintext_test.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/nyroway/nyro/go/internal/storage"
+)
+
+// TestPlaintextKeysRoundTripSQL mirrors the memory-backend test on the SQL
+// backend: with SetPlaintextKeys(true), the raw key is stored (column
+// key_plaintext) and recovered on read paths via Token; the default leaves it
+// hash-only.
+func TestPlaintextKeysRoundTripSQL(t *testing.T) {
+	b := newTestBackend(t)
+	b.SetPlaintextKeys(true)
+	var st storage.Storage = b
+
+	created, err := st.Consumers().Create(storage.CreateConsumer{
+		Name: "acme",
+		Keys: []storage.CreateConsumerKey{{Name: "primary"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := created.Keys[0].Token
+	if raw == "" {
+		t.Fatal("create did not expose raw token")
+	}
+
+	got, err := st.Consumers().Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Keys[0].Token != raw {
+		t.Errorf("read Token = %q, want recovered raw %q", got.Keys[0].Token, raw)
+	}
+
+	// The recovered raw key still authenticates via the hash path.
+	rec, err := st.Auth().FindKey(raw)
+	if err != nil || rec == nil {
+		t.Fatalf("FindKey(raw) after plaintext round-trip: rec=%v err=%v", rec, err)
+	}
+}
+
+func TestHashOnlyKeysDefaultSQL(t *testing.T) {
+	b := newTestBackend(t) // no SetPlaintextKeys
+	var st storage.Storage = b
+
+	created, err := st.Consumers().Create(storage.CreateConsumer{
+		Name: "acme",
+		Keys: []storage.CreateConsumerKey{{Name: "primary"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := created.Keys[0].Token
+
+	got, err := st.Consumers().Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Keys[0].Token != "" {
+		t.Errorf("hash-only read must not expose a raw token, got %q", got.Keys[0].Token)
+	}
+	// Auth still works (hash path unaffected by storage mode).
+	if rec, err := st.Auth().FindKey(raw); err != nil || rec == nil {
+		t.Fatalf("FindKey(raw) hash-only: rec=%v err=%v", rec, err)
+	}
+}

--- a/go/internal/storage/key.go
+++ b/go/internal/storage/key.go
@@ -9,13 +9,17 @@ import (
 
 // keyPreviewLeadLen and keyPreviewTrailLen are the number of raw-key
 // characters persisted as KeyPreview (leading+trailing, concatenated). The
-// leading slice alone is also what KeyAuthStore.FindKey uses to narrow
+// whole concatenated preview is also what KeyAuthStore.FindKey uses to narrow
 // candidates before a hash compare — auth time always has the full raw key,
 // so it derives the identical leading+trailing slice and does an exact-match
 // lookup against the stored value, preserving the same indexed-equality
-// lookup behavior as before this field also carried a trailing slice.
+// lookup behavior.
+//
+// The lead length is 9 so the preview keeps the "sk-" prefix plus the first 6
+// key characters; the UI renders it as "sk-xxxxxx******xxxxxx" (a fixed run of
+// mask characters added at display time, never persisted).
 const (
-	keyPreviewLeadLen  = 12
+	keyPreviewLeadLen  = 9
 	keyPreviewTrailLen = 6
 )
 

--- a/go/internal/storage/key_test.go
+++ b/go/internal/storage/key_test.go
@@ -1,0 +1,46 @@
+package storage
+
+import "testing"
+
+// TestPreviewOfFormat locks the persisted preview shape: the "sk-" prefix plus
+// the first 6 key characters, concatenated with the trailing 6 characters
+// (15 chars total, no mask characters — the UI adds those at display time).
+func TestPreviewOfFormat(t *testing.T) {
+	raw := "sk-0123456789abcdef0123456789abcdef" // len 35 > lead+trail
+	got := PreviewOf(raw)
+	want := raw[:9] + raw[len(raw)-6:]
+	if got != want {
+		t.Fatalf("PreviewOf(%q) = %q, want %q", raw, got, want)
+	}
+	if len(got) != keyPreviewLeadLen+keyPreviewTrailLen {
+		t.Fatalf("preview len = %d, want %d", len(got), keyPreviewLeadLen+keyPreviewTrailLen)
+	}
+	if got[:3] != "sk-" {
+		t.Fatalf("preview should keep the sk- prefix, got %q", got)
+	}
+}
+
+// TestPreviewOfShortKey returns the whole string when it is no longer than the
+// combined lead+trail length (nothing to mask).
+func TestPreviewOfShortKey(t *testing.T) {
+	raw := "sk-123456" // len 9 <= 15
+	if got := PreviewOf(raw); got != raw {
+		t.Fatalf("PreviewOf(%q) = %q, want the whole key", raw, got)
+	}
+}
+
+// TestGenerateKeyPreviewMatchesHashLookup proves the preview a freshly
+// generated key persists is exactly the preview recomputed from its raw value
+// — the invariant KeyAuthStore.FindKey relies on to narrow candidates.
+func TestGenerateKeyPreviewMatchesHashLookup(t *testing.T) {
+	raw, preview, hash, err := GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview != PreviewOf(raw) {
+		t.Errorf("stored preview %q != PreviewOf(raw) %q", preview, PreviewOf(raw))
+	}
+	if hash != HashKey(raw) {
+		t.Errorf("stored hash != HashKey(raw)")
+	}
+}

--- a/go/internal/storage/memory/consumers.go
+++ b/go/internal/storage/memory/consumers.go
@@ -18,6 +18,11 @@ func (b *Backend) consumerWithDetails(c storage.Consumer) storage.Consumer {
 	var keys []storage.ConsumerKey
 	for _, k := range b.consumerKeys {
 		if k.ConsumerID == c.ID {
+			// For plaintext-stored keys, expose the recoverable raw key on read
+			// paths via Token (matches the database backend's convert path).
+			if k.KeyPlaintext != "" {
+				k.Token = k.KeyPlaintext
+			}
 			keys = append(keys, k)
 		}
 	}
@@ -63,6 +68,9 @@ func (b *Backend) createConsumerKey(consumerID string, in storage.CreateConsumer
 	k := storage.ConsumerKey{
 		ID: newID(), ConsumerID: consumerID, Name: in.Name, KeyPreview: preview, KeyHash: hash,
 		Enabled: enabled, ExpiresAt: in.ExpiresAt, CreatedAt: now, UpdatedAt: now,
+	}
+	if b.plaintextKeys {
+		k.KeyPlaintext = raw
 	}
 	b.consumerKeys[k.ID] = k
 	k.Token = raw
@@ -333,8 +341,11 @@ func (s consumerStore) UpdateKey(keyID string, in storage.UpdateConsumerKey) (st
 		k.ExpiresAt = *in.ExpiresAt
 	}
 	k.UpdatedAt = nowISO()
-	k.Token = ""
 	s.b.consumerKeys[keyID] = k
+	// Return Token only for plaintext-stored keys (recoverable); hash-only keys
+	// never expose a raw token on read/update paths. The stored map entry keeps
+	// Token empty — it is a transient response field.
+	k.Token = k.KeyPlaintext
 	return k, nil
 }
 

--- a/go/internal/storage/memory/memory.go
+++ b/go/internal/storage/memory/memory.go
@@ -30,7 +30,17 @@ type Backend struct {
 	consumerRoutes map[string]consumerRouteGrant // synthetic id -> grant
 	consumerQuotas map[string]storage.ConsumerQuota
 	settings       map[string]string
+
+	// plaintextKeys mirrors the database backend: store the recoverable raw
+	// key on creation so it can be retrieved later. Set once at startup via
+	// SetPlaintextKeys; default false (hash-only). Standalone mode leaves this
+	// off — the raw keys already live in the operator's YAML.
+	plaintextKeys bool
 }
+
+// SetPlaintextKeys toggles recoverable plaintext key storage. It is set once
+// at startup before the backend serves any request.
+func (b *Backend) SetPlaintextKeys(v bool) { b.plaintextKeys = v }
 
 // consumerRouteGrant is one consumer_routes row (consumer_id, route_id), kept
 // under a synthetic map key since the pair itself has no natural single key

--- a/go/internal/storage/memory/plaintext_test.go
+++ b/go/internal/storage/memory/plaintext_test.go
@@ -1,0 +1,76 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/nyroway/nyro/go/internal/storage"
+)
+
+// TestPlaintextKeysRoundTrip proves that with SetPlaintextKeys(true), a created
+// key's raw value is recoverable on read paths (List/Get) via Token, while the
+// hash/preview are still persisted for auth.
+func TestPlaintextKeysRoundTrip(t *testing.T) {
+	b := New()
+	b.SetPlaintextKeys(true)
+	st := b.Storage()
+
+	created, err := st.Consumers().Create(storage.CreateConsumer{
+		Name: "acme",
+		Keys: []storage.CreateConsumerKey{{Name: "primary"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(created.Keys) != 1 || created.Keys[0].Token == "" {
+		t.Fatalf("create did not expose raw token: %+v", created.Keys)
+	}
+	raw := created.Keys[0].Token
+
+	// Read back — plaintext mode re-exposes the same raw key via Token.
+	got, err := st.Consumers().Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(got.Keys))
+	}
+	if got.Keys[0].Token != raw {
+		t.Errorf("read Token = %q, want recovered raw %q", got.Keys[0].Token, raw)
+	}
+	// Auth still works off the hash, and the preview follows the sk-+6 / +6 rule.
+	if got.Keys[0].KeyHash != storage.HashKey(raw) {
+		t.Errorf("persisted hash must match HashKey(raw)")
+	}
+	if got.Keys[0].KeyPreview != storage.PreviewOf(raw) {
+		t.Errorf("persisted preview must match PreviewOf(raw)")
+	}
+}
+
+// TestHashOnlyKeysDefault proves the default (no SetPlaintextKeys) never
+// re-exposes the raw key on read paths — Token is empty after creation.
+func TestHashOnlyKeysDefault(t *testing.T) {
+	b := New()
+	st := b.Storage()
+
+	created, err := st.Consumers().Create(storage.CreateConsumer{
+		Name: "acme",
+		Keys: []storage.CreateConsumerKey{{Name: "primary"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Keys[0].Token == "" {
+		t.Fatal("create should still expose the one-time raw token")
+	}
+
+	got, err := st.Consumers().Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Keys[0].Token != "" {
+		t.Errorf("hash-only read must not expose a raw token, got %q", got.Keys[0].Token)
+	}
+	if got.Keys[0].KeyPlaintext != "" {
+		t.Errorf("hash-only key must not persist plaintext")
+	}
+}

--- a/go/internal/storage/model/models.go
+++ b/go/internal/storage/model/models.go
@@ -73,11 +73,15 @@ type ConsumerKey struct {
 	Name       string `gorm:"column:name;not null;uniqueIndex:idx_consumer_key_name;size:255"`
 	KeyPreview string `gorm:"column:key_preview;not null;index;size:191"`
 	KeyHash    string `gorm:"column:key_hash;not null"`
-	Enabled    bool   `gorm:"column:enabled;not null;default:true"`
-	ExpiresAt  string `gorm:"column:expires_at"`
-	LastUsedAt string `gorm:"column:last_used_at"`
-	CreatedAt  string `gorm:"column:created_at;not null"`
-	UpdatedAt  string `gorm:"column:updated_at;not null"`
+	// KeyPlaintext stores the recoverable raw key when the admin runs with
+	// --plaintext-keys; empty (hash-only) by default. Never sent to gateways
+	// over config-sync.
+	KeyPlaintext string `gorm:"column:key_plaintext"`
+	Enabled      bool   `gorm:"column:enabled;not null;default:true"`
+	ExpiresAt    string `gorm:"column:expires_at"`
+	LastUsedAt   string `gorm:"column:last_used_at"`
+	CreatedAt    string `gorm:"column:created_at;not null"`
+	UpdatedAt    string `gorm:"column:updated_at;not null"`
 }
 
 func (ConsumerKey) TableName() string { return "consumer_keys" }

--- a/go/webui/src/components/layout/sidebar.tsx
+++ b/go/webui/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ScrollText,
   BarChart3,
   KeyRound,
+  Plug,
   ChevronLeft,
   Settings,
   MessageSquarePlus,
@@ -22,6 +23,7 @@ const NAV_ITEMS = [
   { label: "Providers", path: "/providers", icon: Server },
   { label: "Models", path: "/models", icon: Route },
   { label: "API Keys", path: "/api-keys", icon: KeyRound },
+  { label: "Connect", path: "/connect", icon: Plug },
   { label: "Nodes", path: "/nodes", icon: Network },
   { type: "divider" as const },
   { label: "Logs", path: "/logs", icon: ScrollText },
@@ -128,13 +130,15 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                           ? "模型"
                           : label === "API Keys"
                             ? "秘钥"
-                            : label === "Nodes"
-                              ? "节点"
-                              : label === "Logs"
-                                ? "日志"
-                                : label === "Stats"
-                                  ? "统计"
-                                  : "系统设置"
+                            : label === "Connect"
+                              ? "接入"
+                              : label === "Nodes"
+                                ? "节点"
+                                : label === "Logs"
+                                  ? "日志"
+                                  : label === "Stats"
+                                    ? "统计"
+                                    : "系统设置"
                     : label}
                 </span>
               )}

--- a/go/webui/src/lib/format.ts
+++ b/go/webui/src/lib/format.ts
@@ -118,17 +118,23 @@ export function tryPrettyJson(raw: string | null | undefined): string {
 /** Backend only ever returns a masked key_preview (leading 12 + trailing 6
  *  characters of the raw key, concatenated — never the full plaintext, except
  *  the one-time reveal right after create/add/regenerate). This renders it as
- *  "sk-abc123************************abc123": a fixed-length mask so the
- *  asterisk run never hints at the real key's length. Shared by the API-keys
- *  page and the request-log table so a preview looks the same everywhere. */
+ *  "sk-abc123******abc123": the backend persists the preview as lead(9)+trail(6)
+ *  with no middle, and this inserts a fixed-length mask between them so it reads
+ *  as a masked key without hinting at the real key's length. Shared by the
+ *  API-keys page, Connect page, and request-log table so a preview looks the
+ *  same everywhere. */
 const KEY_PREVIEW_LEAD_VISIBLE = 9;
 const KEY_PREVIEW_TRAIL_VISIBLE = 6;
-const KEY_PREVIEW_MASK_LEN = 28;
+const KEY_PREVIEW_MASK_LEN = 6;
 
 export function formatKeyPreview(preview: string | undefined | null): string {
   const trimmed = (preview ?? "").trim();
   if (!trimmed) return "sk-";
-  if (trimmed.length <= KEY_PREVIEW_LEAD_VISIBLE + KEY_PREVIEW_TRAIL_VISIBLE) return trimmed;
+  // Strictly-less-than: the canonical preview is exactly lead+trail (15 chars)
+  // with no overlap, so it should be masked; only shorter strings (where the
+  // lead and trail slices would overlap and duplicate characters) render
+  // verbatim.
+  if (trimmed.length < KEY_PREVIEW_LEAD_VISIBLE + KEY_PREVIEW_TRAIL_VISIBLE) return trimmed;
   const lead = trimmed.slice(0, KEY_PREVIEW_LEAD_VISIBLE);
   const trail = trimmed.slice(-KEY_PREVIEW_TRAIL_VISIBLE);
   return `${lead}${"*".repeat(KEY_PREVIEW_MASK_LEN)}${trail}`;

--- a/go/webui/src/lib/service-address.ts
+++ b/go/webui/src/lib/service-address.ts
@@ -1,0 +1,33 @@
+// Helpers for rendering a connected gateway's real service address, shared by
+// the Nodes page (a table column) and the Connect page (base_url fallback when
+// gateway.public_url is unset). The two inputs come from independent sources:
+// remote_addr is the gRPC peer address admin observed (host + ephemeral source
+// port), and service_port is the port the gateway self-reports from its own
+// --listen. The source port in remote_addr has no relation to the service
+// port, so it is stripped.
+
+// formatAddressHost strips the ephemeral source port from a config-sync gRPC
+// peer address, leaving just the host (handles bracketed IPv6).
+export function formatAddressHost(addr: string): string {
+  if (!addr) return "";
+  if (addr.startsWith("[")) {
+    // Bracketed IPv6, e.g. "[::1]:54321" -> "[::1]".
+    const bracketEnd = addr.indexOf("]");
+    return bracketEnd >= 0 ? addr.slice(0, bracketEnd + 1) : addr;
+  }
+  const lastColon = addr.lastIndexOf(":");
+  if (lastColon <= 0) return addr;
+  return addr.slice(0, lastColon);
+}
+
+// formatServiceAddress combines the host from remote_addr with the
+// self-reported service_port into "host:port". Either side can be missing (an
+// older gateway build, or a connection still mid-handshake), so each falls
+// back independently rather than collapsing to "-" when only one is present.
+export function formatServiceAddress(remoteAddr: string, servicePort: string): string {
+  const host = formatAddressHost(remoteAddr);
+  if (!host && !servicePort) return "-";
+  if (!host) return `:${servicePort}`;
+  if (!servicePort) return host;
+  return `${host}:${servicePort}`;
+}

--- a/go/webui/src/main.tsx
+++ b/go/webui/src/main.tsx
@@ -14,6 +14,7 @@ const DashboardPage = lazy(() => import("@/pages/dashboard"));
 const ProvidersPage = lazy(() => import("@/pages/providers"));
 const ModelsPage = lazy(() => import("@/pages/models"));
 const ApiKeysPage = lazy(() => import("@/pages/api-keys"));
+const ConnectPage = lazy(() => import("@/pages/connect"));
 const NodesPage = lazy(() => import("@/pages/nodes"));
 const LogsPage = lazy(() => import("@/pages/logs"));
 const StatsPage = lazy(() => import("@/pages/stats"));
@@ -46,6 +47,7 @@ createRoot(document.getElementById("root")!).render(
                   <Route path="providers" element={<ProvidersPage />} />
                   <Route path="models" element={<ModelsPage />} />
                   <Route path="api-keys" element={<ApiKeysPage />} />
+                  <Route path="connect" element={<ConnectPage />} />
                   <Route path="nodes" element={<NodesPage />} />
                   <Route path="logs" element={<LogsPage />} />
                   <Route path="stats" element={<StatsPage />} />

--- a/go/webui/src/pages/api-keys.tsx
+++ b/go/webui/src/pages/api-keys.tsx
@@ -4,8 +4,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatKeyPreview } from "@/lib/format";
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
+  Copy,
   Info,
   KeyRound,
   Pencil,
@@ -57,6 +59,33 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const PAGE_SIZE = 7;
+
+// CopyFullKeyButton copies a recoverable raw key (present only when the admin
+// runs with --plaintext-keys) to the clipboard, briefly swapping its icon to a
+// check as feedback. Module-scope so it can own per-row state without breaking
+// the rules-of-hooks in the renderKeyRow map callback.
+function CopyFullKeyButton({ token, isZh }: { token: string; isZh: boolean }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      title={copied ? (isZh ? "已复制" : "Copied") : isZh ? "复制完整 Key" : "Copy full key"}
+      aria-label={isZh ? "复制完整 Key" : "Copy full key"}
+      className="inline-flex text-slate-400 transition-colors hover:text-slate-600"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(token);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          // Clipboard may be unavailable (insecure context); ignore silently.
+        }
+      }}
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
 
 type ExpirePreset = "never" | "1d" | "7d" | "30d" | "90d" | "180d" | "1y";
 
@@ -869,20 +898,26 @@ export default function ApiKeysPage() {
   // per-key add/delete.
   function renderKeyRow(consumer: Consumer, key: ConsumerKey) {
     const keyExpired = isApiKeyExpired(key.expires_at);
+    // key.token is only present on read when admin runs with --plaintext-keys
+    // (recoverable storage); otherwise the full key is shown once at creation.
+    const recoverableToken = key.token;
     return (
       <div key={key.id} className="flex items-center justify-between rounded-xl bg-slate-50/60 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="inline-flex h-5 items-center text-xs text-slate-800">{key.name}</span>
           <code
             title={
-              isZh
-                ? "完整 Key 仅在创建/新增/重新生成时展示一次，此处仅展示部分字符，无法复制完整 Key"
-                : "Full key is shown once on create/add/regenerate; this is a partial preview and cannot be copied here"
+              recoverableToken
+                ? (isZh ? "明文存储已开启，可复制完整 Key" : "Plaintext storage is on; the full key can be copied")
+                : isZh
+                  ? "完整 Key 仅在创建/新增/重新生成时展示一次，此处仅展示部分字符，无法复制完整 Key"
+                  : "Full key is shown once on create/add/regenerate; this is a partial preview and cannot be copied here"
             }
             className="inline-flex h-5 items-center rounded bg-slate-100 px-2 py-0.5 text-[10px] leading-none font-medium text-slate-600"
           >
             {formatKeyPreview(key.key_preview)}
           </code>
+          {recoverableToken && <CopyFullKeyButton token={recoverableToken} isZh={isZh} />}
           {!key.enabled && (
             <Badge variant="danger" className="connect-label-badge">
               {isZh ? "已禁用" : "Disabled"}

--- a/go/webui/src/pages/connect.tsx
+++ b/go/webui/src/pages/connect.tsx
@@ -1,0 +1,699 @@
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Code2, Copy } from "lucide-react";
+
+import { backend } from "@/lib/backend";
+import type { Consumer, Route } from "@/lib/types";
+import { useLocale } from "@/lib/i18n";
+import { formatKeyPreview } from "@/lib/format";
+import { Combobox } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { ProviderIcon } from "@/components/ui/provider-icon";
+
+const CodeHighlighter = lazy(() => import("@/components/ui/code-highlighter"));
+
+const PUBLIC_GATEWAY_URL_KEY = "gateway.public_url";
+const DEFAULT_MAX_TOKENS = "1024";
+// Fixed local base_url used in samples when gateway.public_url is not set.
+const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:19530";
+// Environment variable the samples read the key from when the full key is not
+// available to fill in (i.e. admin is not running with --plaintext-keys).
+const API_KEY_ENV = "NYRO_API_KEY";
+
+type CodeLanguage = "python" | "typescript" | "curl";
+type CodeProtocol = "openai-compatible" | "openai-responses" | "anthropic-messages" | "google-gemini";
+
+type CodeProtocolOption = {
+  id: CodeProtocol;
+  name: string;
+  iconKey: string;
+  apiPath: string;
+};
+
+const CODE_LANGS: CodeLanguage[] = ["python", "typescript", "curl"];
+const CODE_PROTOCOLS: CodeProtocolOption[] = [
+  { id: "openai-compatible", name: "OpenAI Compatible", iconKey: "openai", apiPath: "/v1/chat/completions" },
+  { id: "openai-responses", name: "OpenAI Responses", iconKey: "openai", apiPath: "/v1/responses" },
+  { id: "anthropic-messages", name: "Anthropic Messages", iconKey: "anthropic", apiPath: "/v1/messages" },
+  { id: "google-gemini", name: "Google Gemini", iconKey: "gemini", apiPath: "/v1beta/models/{model}:generateContent" },
+];
+
+// A consumer key flattened with its owning consumer's route grants, so the
+// Connect page can decide which keys apply to the selected model. token is set
+// only when the admin runs with --plaintext-keys (recoverable storage).
+type FlatKey = {
+  id: string;
+  name: string;
+  keyPreview: string;
+  token?: string;
+  grantsAll: boolean;
+  routes: string[];
+};
+
+function flattenKeys(consumers: Consumer[]): FlatKey[] {
+  const out: FlatKey[] = [];
+  for (const c of consumers) {
+    if (c.enabled === false) continue;
+    const routes = c.routes ?? [];
+    const grantsAll = routes.length === 0; // empty grant = access to all routes
+    for (const k of c.keys ?? []) {
+      if (k.enabled === false) continue;
+      out.push({ id: k.id, name: k.name, keyPreview: k.key_preview, token: k.token, grantsAll, routes });
+    }
+  }
+  return out;
+}
+
+function protocolLabel(protocol: CodeProtocol) {
+  if (protocol === "openai-compatible") return "OpenAI Compatible";
+  if (protocol === "openai-responses") return "OpenAI Responses";
+  if (protocol === "anthropic-messages") return "Anthropic Messages";
+  return "Google Gemini";
+}
+
+function jsonText(input: unknown) {
+  return JSON.stringify(input, null, 2);
+}
+
+function encodeGeminiModelForPath(model: string) {
+  // Keep ":" readable for model variants like gemma3:1b.
+  return encodeURIComponent(model).replace(/%3A/gi, ":");
+}
+
+function syntaxLanguage(language: CodeLanguage) {
+  if (language === "python") return "python";
+  if (language === "typescript") return "typescript";
+  return "bash";
+}
+
+function languageLabel(language: CodeLanguage) {
+  if (language === "python") return "Python";
+  if (language === "typescript") return "TypeScript";
+  return "cURL";
+}
+
+function codeTemplate(params: {
+  protocol: CodeProtocol;
+  model: string;
+  host: string;
+  language: CodeLanguage;
+  stream: boolean;
+  maxTokens?: number;
+  // apiKeyLiteral is the full recoverable key to inline as a string literal;
+  // when useEnvVar is true it is ignored and the sample reads the key from the
+  // API_KEY_ENV environment variable instead.
+  apiKeyLiteral: string;
+  useEnvVar: boolean;
+}) {
+  const { protocol, model, host, language, stream, maxTokens, apiKeyLiteral, useEnvVar } = params;
+
+  // Per-language rendering of the API key: an environment-variable reference
+  // (non-plaintext mode) or an inlined string literal (recoverable key).
+  const pyKey = useEnvVar ? `os.environ["${API_KEY_ENV}"]` : `"${apiKeyLiteral}"`;
+  const tsKey = useEnvVar ? `process.env.${API_KEY_ENV}` : `"${apiKeyLiteral}"`;
+  const shKey = useEnvVar ? `$${API_KEY_ENV}` : apiKeyLiteral;
+  const pyOsImport = useEnvVar ? "import os\n" : "";
+
+  // ── cURL ──────────────────────────────────────────────────────────────
+  if (language === "curl") {
+    const streamFlag = stream ? "-N \\\n  " : "";
+    if (protocol === "openai-compatible") {
+      const body: Record<string, unknown> = { model, messages: [{ role: "user", content: "Hello" }] };
+      if (maxTokens) body.max_tokens = maxTokens;
+      if (stream) body.stream = true;
+      return `curl ${host}/v1/chat/completions \\
+  ${streamFlag}-H "Authorization: Bearer ${shKey}" \\
+  -H "Content-Type: application/json" \\
+  -d '${jsonText(body)}'`;
+    }
+    if (protocol === "openai-responses") {
+      const body: Record<string, unknown> = { model, input: "Hello" };
+      if (maxTokens) body.max_output_tokens = maxTokens;
+      if (stream) body.stream = true;
+      return `curl ${host}/v1/responses \\
+  ${streamFlag}-H "Authorization: Bearer ${shKey}" \\
+  -H "Content-Type: application/json" \\
+  -d '${jsonText(body)}'`;
+    }
+    if (protocol === "anthropic-messages") {
+      const body: Record<string, unknown> = {
+        model,
+        max_tokens: maxTokens ?? 1024,
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      if (stream) body.stream = true;
+      return `curl ${host}/v1/messages \\
+  ${streamFlag}-H "x-api-key: ${shKey}" \\
+  -H "anthropic-version: 2023-06-01" \\
+  -H "Content-Type: application/json" \\
+  -d '${jsonText(body)}'`;
+    }
+    const geminiBody: Record<string, unknown> = { contents: [{ role: "user", parts: [{ text: "Hello" }] }] };
+    if (maxTokens) geminiBody.generationConfig = { maxOutputTokens: maxTokens };
+    const method = stream ? "streamGenerateContent" : "generateContent";
+    return `curl ${host}/v1beta/models/${encodeGeminiModelForPath(model)}:${method}${stream ? "?alt=sse" : ""} \\
+  ${streamFlag}-H "x-goog-api-key: ${shKey}" \\
+  -H "Content-Type: application/json" \\
+  -d '${jsonText(geminiBody)}'`;
+  }
+
+  // ── Python ────────────────────────────────────────────────────────────
+  if (language === "python") {
+    if (protocol === "openai-compatible") {
+      const kw = maxTokens ? `\n    max_tokens=${maxTokens},` : "";
+      const head = `# pip install openai
+${pyOsImport}from openai import OpenAI
+
+client = OpenAI(
+    api_key=${pyKey},
+    base_url="${host}/v1"
+)`;
+      if (stream) {
+        return `${head}
+
+stream = client.chat.completions.create(
+    model="${model}",
+    messages=[{"role": "user", "content": "Hello"}],${kw}
+    stream=True
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content or "", end="", flush=True)`;
+      }
+      return `${head}
+
+response = client.chat.completions.create(
+    model="${model}",
+    messages=[{"role": "user", "content": "Hello"}],${kw}
+)
+
+print(response.choices[0].message.content)`;
+    }
+    if (protocol === "openai-responses") {
+      const kw = maxTokens ? `\n    max_output_tokens=${maxTokens},` : "";
+      const head = `# pip install openai
+${pyOsImport}from openai import OpenAI
+
+client = OpenAI(
+    api_key=${pyKey},
+    base_url="${host}/v1"
+)`;
+      if (stream) {
+        return `${head}
+
+stream = client.responses.create(
+    model="${model}",
+    input="Hello",${kw}
+    stream=True
+)
+
+for event in stream:
+    if event.type == "response.output_text.delta":
+        print(event.delta, end="", flush=True)`;
+      }
+      return `${head}
+
+response = client.responses.create(
+    model="${model}",
+    input="Hello",${kw}
+)
+
+print(response.output_text)`;
+    }
+    if (protocol === "anthropic-messages") {
+      const mt = maxTokens ?? 1024;
+      const head = `# pip install anthropic
+${pyOsImport}from anthropic import Anthropic
+
+client = Anthropic(
+    api_key=${pyKey},
+    base_url="${host}"
+)`;
+      if (stream) {
+        return `${head}
+
+with client.messages.stream(
+    model="${model}",
+    max_tokens=${mt},
+    messages=[{"role": "user", "content": "Hello"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)`;
+      }
+      return `${head}
+
+response = client.messages.create(
+    model="${model}",
+    max_tokens=${mt},
+    messages=[{"role": "user", "content": "Hello"}]
+)
+
+print(response.content[0].text)`;
+    }
+    const cfg = maxTokens ? `\n    config={"max_output_tokens": ${maxTokens}},` : "";
+    const head = `# pip install google-genai
+${pyOsImport}from google import genai
+
+client = genai.Client(
+    api_key=${pyKey},
+    http_options={"base_url": "${host}"}
+)`;
+    if (stream) {
+      return `${head}
+
+for chunk in client.models.generate_content_stream(
+    model="${model}",
+    contents="Hello",${cfg}
+):
+    print(chunk.text, end="", flush=True)`;
+    }
+    return `${head}
+
+response = client.models.generate_content(
+    model="${model}",
+    contents="Hello",${cfg}
+)
+
+print(response.text)`;
+  }
+
+  // ── TypeScript ──────────────────────────────────────────────────────────
+  if (protocol === "openai-compatible") {
+    const mt = maxTokens ? `\n  max_tokens: ${maxTokens},` : "";
+    const head = `// npm install openai
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: ${tsKey},
+  baseURL: "${host}/v1",
+});`;
+    if (stream) {
+      return `${head}
+
+const stream = await client.chat.completions.create({
+  model: "${model}",
+  messages: [{ role: "user", content: "Hello" }],${mt}
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? "");
+}`;
+    }
+    return `${head}
+
+const response = await client.chat.completions.create({
+  model: "${model}",
+  messages: [{ role: "user", content: "Hello" }],${mt}
+});
+
+console.log(response.choices[0]?.message?.content);`;
+  }
+  if (protocol === "openai-responses") {
+    const mt = maxTokens ? `\n  max_output_tokens: ${maxTokens},` : "";
+    const head = `// npm install openai
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: ${tsKey},
+  baseURL: "${host}/v1",
+});`;
+    if (stream) {
+      return `${head}
+
+const stream = await client.responses.create({
+  model: "${model}",
+  input: "Hello",${mt}
+  stream: true,
+});
+
+for await (const event of stream) {
+  if (event.type === "response.output_text.delta") process.stdout.write(event.delta);
+}`;
+    }
+    return `${head}
+
+const response = await client.responses.create({
+  model: "${model}",
+  input: "Hello",${mt}
+});
+
+console.log(response.output_text);`;
+  }
+  if (protocol === "anthropic-messages") {
+    const mt = maxTokens ?? 1024;
+    const head = `// npm install @anthropic-ai/sdk
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  apiKey: ${tsKey},
+  baseURL: "${host}",
+});`;
+    if (stream) {
+      return `${head}
+
+const stream = client.messages.stream({
+  model: "${model}",
+  max_tokens: ${mt},
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+for await (const event of stream) {
+  if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+    process.stdout.write(event.delta.text);
+  }
+}`;
+    }
+    return `${head}
+
+const response = await client.messages.create({
+  model: "${model}",
+  max_tokens: ${mt},
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+console.log(response.content[0]);`;
+  }
+  const cfg = maxTokens ? `\n  config: { maxOutputTokens: ${maxTokens} },` : "";
+  const head = `// npm install @google/genai
+import { GoogleGenAI } from "@google/genai";
+
+const client = new GoogleGenAI({
+  apiKey: ${tsKey},
+  baseUrl: "${host}",
+});`;
+  if (stream) {
+    return `${head}
+
+const stream = await client.models.generateContentStream({
+  model: "${model}",
+  contents: "Hello",${cfg}
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.text ?? "");
+}`;
+  }
+  return `${head}
+
+const response = await client.models.generateContent({
+  model: "${model}",
+  contents: "Hello",${cfg}
+});
+
+console.log(response.text);`;
+}
+
+export default function ConnectPage() {
+  const { locale } = useLocale();
+  const isZh = locale === "zh-CN";
+
+  const [codeLang, setCodeLang] = useState<CodeLanguage>("python");
+  const [selectedProtocol, setSelectedProtocol] = useState<CodeProtocol>("openai-compatible");
+  const [selectedRouteId, setSelectedRouteId] = useState("");
+  const [selectedKeyId, setSelectedKeyId] = useState("");
+  const [stream, setStream] = useState(false);
+  const [maxTokensInput, setMaxTokensInput] = useState(DEFAULT_MAX_TOKENS);
+  const [copied, setCopied] = useState(false);
+  const [isDarkTheme, setIsDarkTheme] = useState(false);
+
+  const { data: routes = [] } = useQuery<Route[]>({
+    queryKey: ["routes"],
+    queryFn: () => backend("list_routes"),
+  });
+  const { data: consumers = [] } = useQuery<Consumer[]>({
+    queryKey: ["consumers"],
+    queryFn: () => backend("list_consumers"),
+  });
+  const { data: publicUrl } = useQuery<string | null>({
+    queryKey: ["setting", PUBLIC_GATEWAY_URL_KEY],
+    queryFn: () => backend("get_setting", { key: PUBLIC_GATEWAY_URL_KEY }),
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const syncTheme = () => setIsDarkTheme(root.getAttribute("data-theme") === "dark");
+    syncTheme();
+    const observer = new MutationObserver(syncTheme);
+    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (selectedRouteId && !routes.some((r) => r.id === selectedRouteId)) {
+      setSelectedRouteId("");
+    }
+  }, [routes, selectedRouteId]);
+
+  const selectedRoute = useMemo(
+    () => routes.find((r) => r.id === selectedRouteId) ?? null,
+    [routes, selectedRouteId],
+  );
+
+  const flatKeys = useMemo(() => flattenKeys(consumers), [consumers]);
+  // Plaintext mode is inferred from the presence of a recoverable token on any
+  // key (only admin --plaintext-keys populates it). It gates both the key
+  // dropdown and whether the sample can inline a real key.
+  const plaintextMode = useMemo(() => flatKeys.some((k) => !!k.token), [flatKeys]);
+  const availableKeys = useMemo(() => {
+    if (!selectedRoute) return [];
+    return flatKeys.filter((k) => k.grantsAll || k.routes.includes(selectedRoute.model));
+  }, [flatKeys, selectedRoute]);
+
+  const showKeyPicker = Boolean(selectedRoute?.enable_auth) && plaintextMode;
+
+  useEffect(() => {
+    if (!showKeyPicker) {
+      setSelectedKeyId("");
+      return;
+    }
+    if (selectedKeyId && !availableKeys.some((k) => k.id === selectedKeyId)) {
+      setSelectedKeyId("");
+    }
+  }, [availableKeys, selectedKeyId, showKeyPicker]);
+
+  const selectedKey = useMemo(
+    () => availableKeys.find((k) => k.id === selectedKeyId) ?? null,
+    [availableKeys, selectedKeyId],
+  );
+
+  // base_url: a configured public URL wins; otherwise a fixed local address.
+  const trimmedPublicUrl = (publicUrl ?? "").trim().replace(/\/+$/, "");
+  const host = trimmedPublicUrl || DEFAULT_LOCAL_BASE_URL;
+
+  // Inline a real key only when plaintext storage exposed one for the selected
+  // key; otherwise the sample reads it from an environment variable.
+  const realKey = showKeyPicker ? selectedKey?.token ?? "" : "";
+  const useEnvVar = realKey === "";
+
+  const parsedMaxTokens = (() => {
+    const n = Number.parseInt(maxTokensInput, 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  })();
+
+  const generatedCode = codeTemplate({
+    protocol: selectedProtocol,
+    model: selectedRoute?.model ?? "gpt-4o",
+    host,
+    language: codeLang,
+    stream,
+    maxTokens: parsedMaxTokens,
+    apiKeyLiteral: realKey,
+    useEnvVar,
+  });
+
+  async function copyCode() {
+    try {
+      await navigator.clipboard.writeText(generatedCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard may be unavailable (insecure context); ignore silently.
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">{isZh ? "接入" : "Connect"}</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          {isZh
+            ? "通过代码将应用连接到 Nyro Gateway（支持流式与非流式）"
+            : "Connect your app to Nyro Gateway via code (streaming and non-streaming)"}
+        </p>
+      </div>
+
+      <div className="connect-panel glass rounded-2xl p-5 space-y-4">
+        <div className="space-y-2">
+          <p className="ml-1 text-xs leading-none font-normal text-slate-900">
+            {isZh ? "选择接入协议" : "Select Ingress Protocol"}
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {CODE_PROTOCOLS.map((protocol) => {
+              const active = protocol.id === selectedProtocol;
+              return (
+                <button
+                  key={protocol.id}
+                  type="button"
+                  onClick={() => setSelectedProtocol(protocol.id)}
+                  data-state={active ? "on" : "off"}
+                  className="provider-preset-card h-auto rounded-xl px-3 py-2.5 text-left"
+                >
+                  <div className="flex items-start gap-2.5">
+                    <div className="inline-flex h-9 w-9 items-center justify-center">
+                      <ProviderIcon
+                        iconKey={protocol.iconKey}
+                        name={protocol.name}
+                        protocol={protocol.id}
+                        size={30}
+                        className="provider-preset-icon provider-preset-icon-colored rounded-none border-0 bg-transparent"
+                      />
+                      <ProviderIcon
+                        iconKey={protocol.iconKey}
+                        name={protocol.name}
+                        protocol={protocol.id}
+                        size={30}
+                        monochrome
+                        className="provider-preset-icon provider-preset-icon-mono rounded-none border-0 bg-transparent"
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm leading-tight font-semibold text-slate-900">{protocol.name}</p>
+                      <p className="mt-1 text-xs text-slate-500 break-all">{protocol.apiPath}</p>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="connect-cli-shell rounded-xl border p-4 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Code2 className="h-4 w-4 text-slate-600" />
+            <p className="text-sm font-semibold text-slate-900">{protocolLabel(selectedProtocol)}</p>
+            <Badge variant="outline" className="connect-label-badge">
+              {CODE_PROTOCOLS.find((p) => p.id === selectedProtocol)?.apiPath}
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 items-start">
+            <div className="space-y-2">
+              <p className="ml-1 text-xs leading-none font-normal text-slate-900">
+                {isZh ? "选择模型" : "Select Model"}
+              </p>
+              <Combobox
+                className="bg-white"
+                value={selectedRouteId}
+                onValueChange={setSelectedRouteId}
+                options={routes.map((r) => ({ value: r.id, label: r.model }))}
+                placeholder={
+                  routes.length > 0
+                    ? isZh ? "选择模型" : "Select model"
+                    : isZh ? "请先创建模型" : "Create a model first"
+                }
+                searchPlaceholder={isZh ? "搜索模型..." : "Search models..."}
+                emptyText={isZh ? "暂无可选模型" : "No models available"}
+              />
+            </div>
+
+            {showKeyPicker && (
+              <div className="space-y-2">
+                <p className="ml-1 text-xs leading-none font-normal text-slate-900">
+                  {isZh ? "选择 API Key" : "Select API Key"}
+                </p>
+                <Combobox
+                  className="bg-white"
+                  value={selectedKeyId}
+                  onValueChange={setSelectedKeyId}
+                  options={availableKeys.map((k) => ({
+                    value: k.id,
+                    label: `${k.name} · ${formatKeyPreview(k.keyPreview)}`,
+                  }))}
+                  placeholder={isZh ? "选择 API Key" : "Select API key"}
+                  searchPlaceholder={isZh ? "搜索 API Key..." : "Search API keys..."}
+                  emptyText={isZh ? "暂无可选 API Key" : "No API keys available"}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 items-start">
+            <div className="space-y-2">
+              <p className="ml-1 text-xs leading-none font-normal text-slate-900">
+                {isZh ? "最大 Token 数" : "Max tokens (max_tokens)"}
+              </p>
+              <Input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                className="bg-white"
+                value={maxTokensInput}
+                onChange={(e) => setMaxTokensInput(e.target.value)}
+                placeholder={isZh ? "默认 1024" : "Default 1024"}
+              />
+            </div>
+            <div className="space-y-2">
+              <p className="ml-1 text-xs leading-none font-normal text-slate-900">
+                {isZh ? "输出方式" : "Output Mode"}
+              </p>
+              <label className="flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                <span className="text-xs text-slate-600">
+                  {stream
+                    ? isZh ? "流式：逐块返回" : "Streaming: incremental chunks (stream)"
+                    : isZh ? "非流式：一次性返回" : "Non-streaming: single response"}
+                </span>
+                <Switch checked={stream} onCheckedChange={setStream} />
+              </label>
+            </div>
+          </div>
+
+          {selectedRoute ? (
+            <div className="space-y-2">
+              <div className="connect-code-tabs flex gap-1">
+                {CODE_LANGS.map((lang) => (
+                  <button
+                    key={lang}
+                    onClick={() => setCodeLang(lang)}
+                    className={`connect-code-tab-btn px-3 py-2 text-xs font-medium transition-colors cursor-pointer ${
+                      codeLang === lang ? "is-active" : ""
+                    }`}
+                  >
+                    {languageLabel(lang)}
+                  </button>
+                ))}
+              </div>
+
+              <div className="connect-code-example-box relative rounded-xl p-4">
+                <button
+                  onClick={copyCode}
+                  className="connect-code-copy-btn absolute top-3 right-3 rounded-xl p-3 cursor-pointer transition-colors"
+                  title={isZh ? "复制代码" : "Copy code"}
+                >
+                  {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
+                </button>
+                <Suspense fallback={<pre className="overflow-x-auto text-xs text-slate-500">{generatedCode}</pre>}>
+                  <CodeHighlighter code={generatedCode} language={syntaxLanguage(codeLang)} dark={isDarkTheme} padding={0} />
+                </Suspense>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-amber-600">
+              {isZh ? "请先选择模型以生成代码示例。" : "Select a model first to generate code samples."}
+            </p>
+          )}
+
+          {selectedRoute && useEnvVar && (
+            <p className="text-xs text-slate-500">
+              {isZh
+                ? `示例从环境变量 ${API_KEY_ENV} 读取密钥；如需回填完整 Key，请以 --plaintext-keys 启动 admin。`
+                : `The sample reads the key from the ${API_KEY_ENV} environment variable; start admin with --plaintext-keys to inline the full key.`}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/go/webui/src/pages/nodes.tsx
+++ b/go/webui/src/pages/nodes.tsx
@@ -5,6 +5,7 @@ import { backend } from "@/lib/backend";
 import type { GatewayNode } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
 import { formatUptime } from "@/lib/format";
+import { formatServiceAddress } from "@/lib/service-address";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 // The absolute connect timestamp is only shown on hover (the cell itself shows
@@ -29,36 +30,6 @@ function connModeBadge(mode: string | undefined, isZh: boolean) {
     default:
       return { Icon: LockOpen, label: isZh ? "明文" : "Plaintext", className: "text-slate-400" };
   }
-}
-
-// remote_addr is the config-sync gRPC connection's peer address (host +
-// ephemeral source port) — the port has no relation to the gateway's own
-// service port, so it's stripped here to avoid misleading readers.
-function formatAddressHost(addr: string) {
-  if (!addr) return "";
-  if (addr.startsWith("[")) {
-    // Bracketed IPv6, e.g. "[::1]:54321" -> "[::1]".
-    const bracketEnd = addr.indexOf("]");
-    return bracketEnd >= 0 ? addr.slice(0, bracketEnd + 1) : addr;
-  }
-  const lastColon = addr.lastIndexOf(":");
-  if (lastColon <= 0) return addr;
-  return addr.slice(0, lastColon);
-}
-
-// formatServiceAddress combines the two independently-sourced pieces that
-// together make up "where this gateway actually serves traffic": the host
-// from remote_addr (the real gRPC peer IP, observed by admin) and the port
-// from service_port (self-reported by the gateway from its own --listen).
-// Either can be missing on its own (an older gateway build, or a connection
-// still mid-handshake), so each falls back independently rather than the
-// whole cell collapsing to "-" when only one side is present.
-function formatServiceAddress(remoteAddr: string, servicePort: string) {
-  const host = formatAddressHost(remoteAddr);
-  if (!host && !servicePort) return "-";
-  if (!host) return `:${servicePort}`;
-  if (!servicePort) return host;
-  return `${host}:${servicePort}`;
 }
 
 // CopyButton copies `value` to the clipboard and briefly swaps its icon to a


### PR DESCRIPTION
## 概述
将主项目的「接入」页迁移到 Go 控制面 webui（仅代码接入），并为其补齐两项能力：`gateway.public_url` 的消费、以及可选的「可取回明文 API Key」存储。

## Part A — 接入页（`go/webui`）
- 新增 `/connect` 页：OpenAI Compatible / **OpenAI Responses** / Anthropic Messages / Google Gemini × Python / TypeScript / cURL，含**流式/非流式开关**与 模型 / API Key / max_tokens(默认 1024) 设置。
- 接入协议快速选择两行两列；`base_url` 取自 `gateway.public_url`，未配置时回退固定本地地址 `http://127.0.0.1:19530`。
- API Key：`--plaintext-keys` 模式下显示下拉并内联完整 key；非该模式隐藏下拉、示例统一从 `NYRO_API_KEY` 环境变量读取。
- 注册路由/侧边栏「接入」；抽出 `lib/service-address`；api-keys 页新增「复制完整 Key」按钮，掩码统一为 `sk-<6>******<6>`。

## Part B — 可取回明文 Key（`go/internal/storage`）
- `ConsumerKey` 新增 `key_plaintext` 列，**仅当 admin 以 `--plaintext-keys` 启动时写入**（默认关 = hash-only，行为不变）；读路径经 `Token` 暴露以便事后取回。
- **鉴权路径完全未改**：`FindKey` 仍走哈希比对，config-sync 永不下发明文。
- preview 规则改为 `sk-` + 前 6 + 尾 6（lead 9 / trail 6），星号由前端渲染。
- admin 新增 `--plaintext-keys`，经 `OpenStorageFromDSN` 线程化注入 database/memory 后端。

## 测试
- 新增单测：preview 格式、明文/hash round-trip（memory + SQL），鉴权回归。
- 真实 HTTP：`--plaintext-keys` 时 `/consumers` 返回 token、默认不返回；Playwright 驱动 `/connect` 覆盖协议/语言/流式/max_tokens/base_url/env-var 各路径。
- `go test ./...` 全绿；`go/webui` `npm run build` 通过；`nyro migrate dump` 确认新列 DDL。

## 设计说明
- 「明文 vs 加密」实为「能否事后取回」：hash 取不回、plain 可取回。本 PR 只做 hash+plain，encrypted 未实现（可后续加列扩展）。默认保持 hash-only，不削弱现有安全。