### PR TITLE
refactor(go): rename serve command and PKI roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ go-webui-embed-build: go-webui-embed-assets
 # schema; it's off by default regardless of backend (see
 # go/docs/schema/database.md).
 go-webui-embed-run: go-webui-embed-build
-	cd go && ./bin/nyro server --auto-migrate
+	cd go && ./bin/nyro serve --auto-migrate
 
 # Run a standalone Go proxy (data plane) locally against a running server
 go-run:

--- a/go/README.md
+++ b/go/README.md
@@ -29,7 +29,7 @@ until parity is reached (P0–P6 migration plan).
 | `internal/auth/` | `auth/` + `admin/oauth.rs` | inbound API key + quotas; outbound OAuth drivers (Claude/Codex/Vertex) |
 | `internal/storage/` | `db/` + `storage/` | `Storage` interface, idempotent migrations, sqlite/pg/memory |
 | `internal/logging/` | `logging/` | async request-log collector + retention |
-| `nyro.go` | `src-server/` + `crates/nyro-tools/` | unified CLI: `nyro proxy` (data plane) / `nyro server` (control plane) / `nyro tool` (utilities) |
+| `nyro.go` | `src-server/` + `crates/nyro-tools/` | unified CLI: `nyro proxy` (data plane) / `nyro serve` (control plane) |
 
 ## Library mapping (Rust → Go)
 
@@ -52,12 +52,12 @@ by `modernc.org/sqlite`. Added with the storage layer in P3.
 
 ```bash
 go build ./...
-go run . server --auto-migrate      # everything: control plane + embedded data plane
+go run . serve --auto-migrate       # everything: control plane + embedded data plane
 go test ./...
 go vet ./...
 ```
 
-`nyro server` alone is a complete, usable nyro: the management API and WebUI on
+`nyro serve` alone is a complete, usable nyro: the management API and WebUI on
 `127.0.0.1:19531`, plus an embedded data plane on `127.0.0.1:19530`. The
 embedded data plane subscribes to config over an in-process pipe — the same
 config-sync client, cache and router a remote node uses, so there is no second
@@ -67,7 +67,7 @@ The two roles can also be split, for horizontal scaling or to keep the node
 holding credentials out of the traffic path:
 
 ```bash
-go run . server --proxy-listen= --sync-listen 127.0.0.1:19532   # control plane only
+go run . serve --proxy-listen= --sync-listen 127.0.0.1:19532    # control plane only
 go run . proxy --server 127.0.0.1:19532                         # extra data plane node
 go run . proxy --config ./nyro.yaml                             # standalone: no server, no DB
 ```
@@ -92,7 +92,7 @@ npm install
 npm run lint
 npm run build
 cd ..
-go run . server --webui-dir ./webui/dist
+go run . serve --webui-dir ./webui/dist
 ```
 
 **Release-embedding workflow** — bake the built assets into the `nyro`

--- a/go/cmd/ca/ca.go
+++ b/go/cmd/ca/ca.go
@@ -1,9 +1,9 @@
 // Package ca implements the `nyro ca` subcommand group: an offline
-// certificate authority for the config-sync mTLS channel between admin
-// (control plane) and gateway (data plane). It never runs online — it's a
+// certificate authority for the config-sync mTLS channel between the server
+// (control plane) and proxy (data plane). It never runs online — it's a
 // one-shot CLI for generating a CA and signing leaf certificates that get
-// distributed to admin/gateway hosts and loaded via their
-// --config-tls-ca/-cert/-key flags.
+// distributed to server/proxy hosts and loaded via their
+// --sync-tls-ca/-cert/-key flags.
 package ca
 
 import (
@@ -19,8 +19,8 @@ import (
 	"github.com/nyroway/nyro/go/internal/configsync/pki"
 )
 
-// defaultDir is ~/.nyro/pki, matching the admin control plane's ~/.nyro home
-// convention (see cmd/admin's nyroHomeDir). Falls back to ./.nyro/pki if the
+// defaultDir is ~/.nyro/pki, matching the server control plane's ~/.nyro home
+// convention (see cmd/server's nyroHomeDir). Falls back to ./.nyro/pki if the
 // OS user home directory can't be resolved.
 func defaultDir() string {
 	home, err := os.UserHomeDir()
@@ -80,11 +80,8 @@ func newInitCmd() *cobra.Command {
 
 // newSignServerCmd issues the control plane's config-sync server certificate.
 //
-// The subcommand is named after the `nyro server` deployment role, but the
-// certificate it writes keeps the historical "admin" identity: the SPIFFE SAN
-// (spiffe://nyro/admin, see pki.AdminSPIFFEID) and the default --out basename
-// are a wire/on-disk compatibility surface, so renaming them would invalidate
-// every already-issued certificate. See the CLI rename plan for the rationale.
+// The certificate carries the fixed spiffe://nyro/server workload identity;
+// --out controls only the output file basename.
 func newSignServerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sign-server",
@@ -92,7 +89,7 @@ func newSignServerCmd() *cobra.Command {
 	}
 	dir := cmd.Flags().String("dir", defaultDir(), "directory containing ca.pem/ca-key.pem (from `nyro ca init`)")
 	valid := cmd.Flags().Duration("valid", defaultLeafValid, "leaf certificate validity period")
-	out := cmd.Flags().String("out", "admin", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
+	out := cmd.Flags().String("out", "server", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		certPath, keyPath, err := signWithCA(*dir, func(c *pki.CA) (string, string, error) {
 			return c.SignServer(*dir, *out, *valid)
@@ -100,25 +97,24 @@ func newSignServerCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (identity: spiffe://nyro/%s)\n", certPath, keyPath, pki.AdminSPIFFEID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s and %s (identity: spiffe://nyro/%s)\n", certPath, keyPath, pki.ServerSPIFFEID)
 		return nil
 	}
 	return cmd
 }
 
 // newSignProxyCmd issues a data-plane node's config-sync client certificate.
-// Like sign-server, the certificate keeps the historical "gateway" identity
-// (spiffe://nyro/gateway/<node-id>) and --out basename for compatibility with
-// already-issued certificates; only the subcommand name follows the new CLI.
+// The certificate carries a spiffe://nyro/proxy/<node-id> workload identity;
+// --out controls only the output file basename.
 func newSignProxyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sign-proxy",
 		Short: "Sign a proxy node's config-sync client certificate",
 	}
 	dir := cmd.Flags().String("dir", defaultDir(), "directory containing ca.pem/ca-key.pem (from `nyro ca init`)")
-	nodeID := cmd.Flags().String("node-id", "", "node identity for the SPIFFE SAN (spiffe://nyro/gateway/<node-id>); random if unset")
+	nodeID := cmd.Flags().String("node-id", "", "node identity for the SPIFFE SAN (spiffe://nyro/proxy/<node-id>); random if unset")
 	valid := cmd.Flags().Duration("valid", defaultLeafValid, "leaf certificate validity period")
-	out := cmd.Flags().String("out", "gateway", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
+	out := cmd.Flags().String("out", "proxy", "output file basename (writes <dir>/<out>.pem and <dir>/<out>-key.pem)")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		id := *nodeID
 		if id == "" {

--- a/go/cmd/ca/ca_test.go
+++ b/go/cmd/ca/ca_test.go
@@ -74,7 +74,7 @@ func TestInit_Force(t *testing.T) {
 	}
 }
 
-func TestSignServer_WritesCertWithAdminIdentity(t *testing.T) {
+func TestSignServer_WritesCertWithServerIdentity(t *testing.T) {
 	dir := t.TempDir()
 	if _, _, err := runCmd(t, "init", "--dir", dir); err != nil {
 		t.Fatal(err)
@@ -86,9 +86,9 @@ func TestSignServer_WritesCertWithAdminIdentity(t *testing.T) {
 	if stdout == "" {
 		t.Fatal("expected sign-server to report the identity it signed")
 	}
-	certPath := filepath.Join(dir, "admin.pem")
+	certPath := filepath.Join(dir, "server.pem")
 	if _, err := os.Stat(certPath); err != nil {
-		t.Fatalf("admin.pem not written: %v", err)
+		t.Fatalf("server.pem not written: %v", err)
 	}
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
@@ -99,8 +99,8 @@ func TestSignServer_WritesCertWithAdminIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pki.VerifyAdminIdentity(cert); err != nil {
-		t.Errorf("VerifyAdminIdentity: %v", err)
+	if err := pki.VerifyServerIdentity(cert); err != nil {
+		t.Errorf("VerifyServerIdentity: %v", err)
 	}
 }
 
@@ -123,9 +123,9 @@ func TestSignProxy_RandomNodeIDWhenUnset(t *testing.T) {
 	if stdout == "" {
 		t.Fatal("expected sign-proxy to report the generated node-id")
 	}
-	certPath := filepath.Join(dir, "gateway.pem")
+	certPath := filepath.Join(dir, "proxy.pem")
 	if _, err := os.Stat(certPath); err != nil {
-		t.Fatalf("gateway.pem not written: %v", err)
+		t.Fatalf("proxy.pem not written: %v", err)
 	}
 }
 

--- a/go/cmd/proxy/configtls_test.go
+++ b/go/cmd/proxy/configtls_test.go
@@ -37,7 +37,7 @@ func TestResolveConfigSyncClientTLS_AllThreeLoadsMTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPath, keyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	certPath, keyPath, err := ca.SignClient(dir, "proxy", "node-1", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmd/proxy/proxy.go
+++ b/go/cmd/proxy/proxy.go
@@ -121,8 +121,8 @@ func NewCmd() *cobra.Command {
 // it is acceptable based on whether --server leaves this host.
 //
 // There is deliberately no --server-name-style override here:
-// pki.LoadClientTLS verifies admin's server certificate by SPIFFE identity
-// (spiffe://nyro/admin), not by matching its SAN against the dial address,
+// pki.LoadClientTLS verifies the server certificate by SPIFFE identity
+// (spiffe://nyro/server), not by matching its SAN against the dial address,
 // so the address used in --server (direct, load balancer, k8s
 // Service name, IP) never affects verification.
 func resolveConfigSyncClientTLS(caPath, certPath, keyPath string) (*tls.Config, error) {

--- a/go/cmd/server/configtls_test.go
+++ b/go/cmd/server/configtls_test.go
@@ -40,7 +40,7 @@ func TestResolveConfigSyncServerTLS_AllThreeLoadsMTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPath, keyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	certPath, keyPath, err := ca.SignServer(dir, "server", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmd/server/server.go
+++ b/go/cmd/server/server.go
@@ -1,4 +1,4 @@
-// Package server implements the `nyro server` subcommand: the control plane
+// Package server implements the `nyro serve` subcommand: the control plane
 // (management API + WebUI + OAuth session lifecycle + config-sync push).
 package server
 
@@ -50,7 +50,7 @@ func defaultDSN() string {
 
 // NewCmd builds the server (control-plane) subcommand.
 //
-// `nyro server` is the single-command deployment: the REST API + WebUI on
+// `nyro serve` is the single-command deployment: the REST API + WebUI on
 // --listen, and — unless --proxy-listen is empty — an embedded data plane on
 // --proxy-listen, so one process is a complete, usable nyro. The embedded data
 // plane is assembled by internal/dataplane over an in-process config-sync
@@ -63,7 +63,7 @@ func defaultDSN() string {
 // embedded and remote alike.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "server",
+		Use:   "serve",
 		Short: "Run the control plane, with an embedded data plane by default",
 	}
 	cmd.Flags().String("listen", "127.0.0.1:19531", "listen address for the control plane")
@@ -82,7 +82,7 @@ func NewCmd() *cobra.Command {
 	// Repeatable so a token can be rotated without downtime: add the new one,
 	// roll the proxies onto it, then drop the old one. Prefer the env var —
 	// a token passed as a flag is visible in `ps`.
-	cmd.Flags().StringArray("sync-token", nil, "join token a remote `nyro proxy` must present to subscribe to config-sync; repeatable so tokens can be rotated without downtime. A join credential, NOT an identity: mTLS is what gives each node a verifiable identity. Prefer NYRO_SERVER_SYNC_TOKEN over the flag, which exposes the value in `ps`")
+	cmd.Flags().StringArray("sync-token", nil, "join token a remote `nyro proxy` must present to subscribe to config-sync; repeatable so tokens can be rotated without downtime. A join credential, NOT an identity: mTLS is what gives each node a verifiable identity. Prefer NYRO_SERVE_SYNC_TOKEN over the flag, which exposes the value in `ps`")
 	cmd.Flags().String("sync-tls-ca", "", "config-sync mTLS: path to the CA certificate that signs server/proxy leaf certs (see `nyro ca`); must be set together with --sync-tls-cert/-key")
 	cmd.Flags().String("sync-tls-cert", "", "config-sync mTLS: path to the server's config-sync server certificate")
 	cmd.Flags().String("sync-tls-key", "", "config-sync mTLS: path to the server's config-sync server private key")

--- a/go/cmd/server/server_test.go
+++ b/go/cmd/server/server_test.go
@@ -21,8 +21,8 @@ func TestNewCmdFlags(t *testing.T) {
 	if addr, _ := cmd.Flags().GetString("listen"); addr != "127.0.0.1:19531" {
 		t.Errorf("default listen = %q, want 127.0.0.1:19531", addr)
 	}
-	if cmd.Use != "server" {
-		t.Errorf("Use = %q, want server", cmd.Use)
+	if cmd.Use != "serve" {
+		t.Errorf("Use = %q, want serve", cmd.Use)
 	}
 	// Pre-rename flag names must be gone (no compatibility period).
 	for _, old := range []string{"config-listen", "config-tls-ca", "config-tls-cert", "config-tls-key", "plaintext-keys"} {

--- a/go/docs/cutover.md
+++ b/go/docs/cutover.md
@@ -30,9 +30,9 @@ go build -o /tmp/nyro .
 /tmp/nyro proxy --listen 127.0.0.1:19529 \
   --config ./config.yaml
 # control plane (management API + WebUI):
-/tmp/nyro server --listen 127.0.0.1:19531 \
+/tmp/nyro serve --listen 127.0.0.1:19531 \
   --sync-listen= --webui-dir ./webui/dist \
-  --token "$NYRO_SERVER_TOKEN" --auto-migrate
+  --token "$NYRO_SERVE_TOKEN" --auto-migrate
 ```
 
 `--auto-migrate` above lets this first-boot server create its own (default
@@ -58,8 +58,8 @@ fastest path — and the only one that needs no token:
 
 ```bash
 # control plane, with config-sync enabled (loopback plaintext, no token needed):
-/tmp/nyro server --listen 127.0.0.1:19531 \
-  --sync-listen 127.0.0.1:19532 --token "$NYRO_SERVER_TOKEN" --auto-migrate
+/tmp/nyro serve --listen 127.0.0.1:19531 \
+  --sync-listen 127.0.0.1:19532 --token "$NYRO_SERVE_TOKEN" --auto-migrate
 # data plane, subscribing to config-sync instead of --config:
 /tmp/nyro proxy --listen 127.0.0.1:19529 \
   --server 127.0.0.1:19532
@@ -75,12 +75,12 @@ certificates and configure a complete TLS path set on both processes:
 ```bash
 /tmp/nyro ca init
 /tmp/nyro ca sign-server
-/tmp/nyro ca sign-proxy --node-id gw-1
-# distribute ca.pem + admin.{pem,key.pem} / gateway.{pem,key.pem}, then:
-/tmp/nyro server --sync-listen 0.0.0.0:19532 --auto-migrate \
-  --sync-tls-ca ~/.nyro/pki/ca.pem --sync-tls-cert ~/.nyro/pki/admin.pem --sync-tls-key ~/.nyro/pki/admin-key.pem
+/tmp/nyro ca sign-proxy --node-id proxy-1
+# distribute ca.pem + server.{pem,key.pem} / proxy.{pem,key.pem}, then:
+/tmp/nyro serve --sync-listen 0.0.0.0:19532 --auto-migrate \
+  --sync-tls-ca ~/.nyro/pki/ca.pem --sync-tls-cert ~/.nyro/pki/server.pem --sync-tls-key ~/.nyro/pki/server-key.pem
 /tmp/nyro proxy --server server.internal:19532 \
-  --sync-tls-ca ~/.nyro/pki/ca.pem --sync-tls-cert ~/.nyro/pki/gateway.pem --sync-tls-key ~/.nyro/pki/gateway-key.pem
+  --sync-tls-ca ~/.nyro/pki/ca.pem --sync-tls-cert ~/.nyro/pki/proxy.pem --sync-tls-key ~/.nyro/pki/proxy-key.pem
 ```
 
 `--config` and `--server` are mutually exclusive — exactly one must
@@ -100,10 +100,10 @@ DDL a DBA reviews (print it with `nyro migrate dump`/`diff`; see
 
 ```bash
 # Run on each server host, with a distinct --listen/--sync-listen address.
-/tmp/nyro server --listen 10.0.0.11:19531 \
+/tmp/nyro serve --listen 10.0.0.11:19531 \
   --sync-listen 10.0.0.11:19532 \
   --dsn "$NYRO_SHARED_DSN" \
-  --token "$NYRO_SERVER_TOKEN"
+  --token "$NYRO_SERVE_TOKEN"
 ```
 
 The polling default is `0` (disabled); a single server still pushes its own

--- a/go/docs/schema/migrations.md
+++ b/go/docs/schema/migrations.md
@@ -10,7 +10,7 @@ covered too (it just uses AutoMigrate directly; see [database.md](database.md)).
 
 ### 1. Automatic — `--auto-migrate` (GORM AutoMigrate)
 
-`nyro server`/`nyro proxy --auto-migrate` runs `GORM AutoMigrate` at startup,
+`nyro serve`/`nyro proxy --auto-migrate` runs `GORM AutoMigrate` at startup,
 creating/altering tables to match the models. Requires the connecting account
 to have DDL rights. Off by default (whether the account has DDL rights is a
 deployment decision, not inferred from the engine). Good for local sqlite dev
@@ -100,7 +100,7 @@ in any schema-tool dependency.
 
 ## Runtime behavior
 
-`nyro server`/`nyro proxy`:
+`nyro serve`/`nyro proxy`:
 
 - `--auto-migrate`: run AutoMigrate at startup (see above).
 - unset (default): no DDL. A read-only `CheckSchema` confirms every canonical

--- a/go/docs/security/config-sync-mtls.md
+++ b/go/docs/security/config-sync-mtls.md
@@ -1,6 +1,6 @@
 # Config-sync transport and mTLS
 
-The config-sync gRPC channel is how `nyro server` (control plane) pushes the
+The config-sync gRPC channel is how `nyro serve` (control plane) pushes the
 live config snapshot — including every upstream's `credentials_json` — to every
 connected `nyro proxy` (data plane). Its transport mode is selected only from
 the three `--sync-tls-*` paths:
@@ -65,11 +65,11 @@ values, so a token can be rotated with no downtime: add the new one, roll the
 proxies onto it, then drop the old one.
 
 ```bash
-nyro server --sync-listen 0.0.0.0:19532 --sync-token "$OLD" --sync-token "$NEW"
+nyro serve --sync-listen 0.0.0.0:19532 --sync-token "$OLD" --sync-token "$NEW"
 nyro proxy --server server.internal:19532 --sync-token "$NEW"
 ```
 
-Prefer the environment (`NYRO_SERVER_SYNC_TOKEN`, `NYRO_PROXY_SYNC_TOKEN`) over
+Prefer the environment (`NYRO_SERVE_SYNC_TOKEN`, `NYRO_PROXY_SYNC_TOKEN`) over
 the flag, which exposes the value in `ps`. The same applies to the management
 API's `--token`.
 
@@ -79,17 +79,8 @@ client that can subscribe can claim any id. The WebUI's node list flags such
 ids as unverified for exactly this reason. Only mTLS yields a per-node identity,
 derived from the client certificate's SPIFFE SAN.
 
-The embedded data plane of `nyro server` needs no token: it subscribes over an
+The embedded data plane of `nyro serve` needs no token: it subscribes over an
 in-memory pipe with no socket, and is reported as `conn_mode: inprocess`.
-
-> **Naming note.** The subcommands are `server` / `proxy`, but the PKI layer
-> still uses the historical identifiers `admin` / `gateway`: the SPIFFE SANs
-> (`spiffe://nyro/admin`, `spiffe://nyro/gateway/<node-id>`) and the default
-> certificate basenames (`admin.pem`, `gateway.pem`). Those are a
-> compatibility surface — renaming them would invalidate every certificate
-> already issued — so they were deliberately left alone when the CLI was
-> renamed. Read `admin` as "the control plane's identity" and `gateway` as
-> "a data plane node's identity" throughout this document.
 
 ## The three commands
 
@@ -99,21 +90,21 @@ Ansible, a Secret, a Docker volume, whatever fits your deployment).
 
 ```bash
 nyro ca init [--dir ~/.nyro/pki] [--valid 87600h] [--force]
-nyro ca sign-server [--dir ~/.nyro/pki] [--valid 8760h] [--out admin]
-nyro ca sign-proxy [--dir ~/.nyro/pki] [--node-id <id>] [--valid 8760h] [--out gateway]
+nyro ca sign-server [--dir ~/.nyro/pki] [--valid 8760h] [--out server]
+nyro ca sign-proxy [--dir ~/.nyro/pki] [--node-id <id>] [--valid 8760h] [--out proxy]
 ```
 
 - `init` creates (or, without `--force`, reuses) the CA: `ca.pem` +
   `ca-key.pem` in `--dir`.
 - `sign-server` issues the server's config-sync certificate, with a **fixed
-  identity** encoded as a SPIFFE URI SAN (`spiffe://nyro/admin`) — not a DNS/IP
+  identity** encoded as a SPIFFE URI SAN (`spiffe://nyro/server`) — not a DNS/IP
   SAN list. There is no `--advertise`-style flag: the proxy verifies this
   certificate by identity, not by matching a hostname it dialed against a SAN
   list, so the same certificate is valid no matter what address a proxy uses
   to reach the server (direct, load balancer, Kubernetes Service name, IP —
   see "Why identity, not hostname" below).
 - `sign-proxy` issues one proxy node's client certificate, with its identity
-  encoded as a SPIFFE URI SAN (`spiffe://nyro/gateway/<node-id>`). Run once
+  encoded as a SPIFFE URI SAN (`spiffe://nyro/proxy/<node-id>`). Run once
   per proxy node (or once per shared cert if you're intentionally pooling
   identity across a fleet — see "elastic scaling" below). `--node-id`
   defaults to a random value if omitted.
@@ -128,14 +119,14 @@ proxy never read it directly (see below).
 They only ever load three explicit file paths:
 
 ```bash
-nyro server --sync-tls-ca ~/.nyro/pki/ca.pem \
-            --sync-tls-cert ~/.nyro/pki/admin.pem \
-            --sync-tls-key ~/.nyro/pki/admin-key.pem
+nyro serve --sync-tls-ca ~/.nyro/pki/ca.pem \
+            --sync-tls-cert ~/.nyro/pki/server.pem \
+            --sync-tls-key ~/.nyro/pki/server-key.pem
 
 nyro proxy --server 127.0.0.1:19532 \
            --sync-tls-ca ~/.nyro/pki/ca.pem \
-           --sync-tls-cert ~/.nyro/pki/gateway.pem \
-           --sync-tls-key ~/.nyro/pki/gateway-key.pem
+           --sync-tls-cert ~/.nyro/pki/proxy.pem \
+           --sync-tls-key ~/.nyro/pki/proxy-key.pem
 ```
 
 All three flags must be given together, or not at all — a partial set (e.g.
@@ -153,7 +144,7 @@ docker-compose, Helm values), not on every interactive invocation.
 ### Why identity, not hostname
 
 The proxy's config-sync client verifies the server's certificate by SPIFFE
-identity (`spiffe://nyro/admin`), not by matching a hostname/IP SAN against
+identity (`spiffe://nyro/server`), not by matching a hostname/IP SAN against
 the address in `--server` — the classic web-PKI model most CLI tools
 default to. That classic model needs a `--tls-server-name`-style escape
 hatch the moment the dial address and the cert's SAN diverge (a load
@@ -165,7 +156,7 @@ after a rename.
 Identity-based verification sidesteps the whole problem: `--server`
 can be a direct address, a load balancer, or a Kubernetes Service name — none
 of it matters, because the check is "does this certificate say
-`spiffe://nyro/admin`", not "does this certificate's SAN match the string I
+`spiffe://nyro/server`", not "does this certificate's SAN match the string I
 dialed". There is deliberately no override flag for this on the proxy side.
 
 ## BYO external PKI
@@ -183,7 +174,7 @@ One command is a complete, usable nyro — the control plane on
 `127.0.0.1:19531` and an embedded data plane on `127.0.0.1:19530`:
 
 ```bash
-nyro server --auto-migrate
+nyro serve --auto-migrate
 ```
 
 **No config-sync port is opened.** The embedded data plane subscribes over an
@@ -203,7 +194,7 @@ To attach data planes running elsewhere, open the config-sync listener
 (`--sync-listen`, off by default) and point each proxy at it:
 
 ```bash
-nyro server --sync-listen 127.0.0.1:19532 --auto-migrate
+nyro serve --sync-listen 127.0.0.1:19532 --auto-migrate
 nyro proxy --listen 127.0.0.1:19530 --server 127.0.0.1:19532
 ```
 
@@ -238,11 +229,11 @@ by anyone who observes it. Use this only on a tightly controlled network, and
 prefer mTLS below.
 
 ```bash
-export NYRO_SERVER_SYNC_TOKEN=... NYRO_PROXY_SYNC_TOKEN=...   # same value
+export NYRO_SERVE_SYNC_TOKEN=... NYRO_PROXY_SYNC_TOKEN=...   # same value
 
-nyro server --listen 10.0.0.10:19531 \
+nyro serve --listen 10.0.0.10:19531 \
   --sync-listen 10.0.0.10:19532 \
-  --token "$NYRO_SERVER_TOKEN" --auto-migrate
+  --token "$NYRO_SERVE_TOKEN" --auto-migrate
 nyro proxy --server 10.0.0.10:19532
 ```
 
@@ -257,16 +248,16 @@ start both processes with complete TLS path sets:
 ```bash
 nyro ca init
 nyro ca sign-server
-nyro ca sign-proxy --node-id gw-1
+nyro ca sign-proxy --node-id proxy-1
 
-nyro server --sync-listen 0.0.0.0:19532 --auto-migrate \
+nyro serve --sync-listen 0.0.0.0:19532 --auto-migrate \
   --sync-tls-ca ~/.nyro/pki/ca.pem \
-  --sync-tls-cert ~/.nyro/pki/admin.pem \
-  --sync-tls-key ~/.nyro/pki/admin-key.pem
+  --sync-tls-cert ~/.nyro/pki/server.pem \
+  --sync-tls-key ~/.nyro/pki/server-key.pem
 nyro proxy --server server.internal:19532 \
   --sync-tls-ca ~/.nyro/pki/ca.pem \
-  --sync-tls-cert ~/.nyro/pki/gateway.pem \
-  --sync-tls-key ~/.nyro/pki/gateway-key.pem
+  --sync-tls-cert ~/.nyro/pki/proxy.pem \
+  --sync-tls-key ~/.nyro/pki/proxy-key.pem
 ```
 
 ### Multiple server replicas
@@ -285,16 +276,16 @@ case that workflow is for:
 
 ```bash
 # server-1
-nyro server --listen 10.0.0.11:19531 \
+nyro serve --listen 10.0.0.11:19531 \
   --sync-listen 10.0.0.11:19532 \
   --dsn "$NYRO_SHARED_DSN" \
-  --token "$NYRO_SERVER_TOKEN"
+  --token "$NYRO_SERVE_TOKEN"
 
 # server-2
-nyro server --listen 10.0.0.12:19531 \
+nyro serve --listen 10.0.0.12:19531 \
   --sync-listen 10.0.0.12:19532 \
   --dsn "$NYRO_SHARED_DSN" \
-  --token "$NYRO_SERVER_TOKEN"
+  --token "$NYRO_SERVE_TOKEN"
 ```
 
 Use the same shared PostgreSQL DSN on every replica and add complete
@@ -309,7 +300,7 @@ standalone proxy driven by a YAML file is therefore fully independent of the
 control plane:
 
 ```bash
-nyro server --auto-migrate
+nyro serve --auto-migrate
 nyro proxy --config ./config.yaml
 ```
 
@@ -323,7 +314,7 @@ The server's REST/WebUI `--listen` endpoint and the proxy's client API
 HTTPS on either endpoint. Terminate public or cross-host HTTPS in a reverse
 proxy, ingress, load balancer, or service mesh.
 
-`nyro server --token <value>` optionally adds Bearer authentication to
+`nyro serve --token <value>` optionally adds Bearer authentication to
 `/api/v1` routes; it does not authenticate config-sync. Omitting it is allowed,
 but a non-loopback server `--listen` address emits a warning that control-plane
 routes are unauthenticated. Use a token for exposed management APIs, and carry it
@@ -332,7 +323,7 @@ over deployment-layer HTTPS so the token itself is not sent in cleartext.
 ## Elastic scaling
 
 **Elastic scaling (containers/k8s):** `ca.pem` is safe to bake into the image
-(it's a public certificate, not a secret). `gateway.pem`/`gateway-key.pem`
+(it's a public certificate, not a secret). `proxy.pem`/`proxy-key.pem`
 should **not** — mount them via a Kubernetes Secret (`items`/`subPath` to
 rename into whatever path your command line expects), or use cert-manager to
 issue a fresh per-pod certificate on scheduling. Either way, the private key
@@ -341,7 +332,7 @@ never lands in the image layer.
 ## Certificate lifetime and rotation
 
 - CA: 10 years by default (`nyro ca init --valid`).
-- Leaf certificates (`admin`/`gateway` identities): 1 year by default (`--valid` on
+- Leaf certificates (`server`/`proxy` identities): 1 year by default (`--valid` on
   `sign-server`/`sign-proxy`).
 - Rotation is manual and offline: re-run the relevant `sign-*` command,
   redistribute the new cert/key, restart the process. There is no online

--- a/go/internal/bootstrap/bootstrap.go
+++ b/go/internal/bootstrap/bootstrap.go
@@ -130,19 +130,19 @@ type HTTPServer struct {
 
 // RunServers starts every server and blocks until SIGINT/SIGTERM or the first
 // listen error, then gracefully shuts all of them down. It exists because
-// `nyro server` listens twice — the control plane on --listen and, unless
+// `nyro serve` listens twice — the control plane on --listen and, unless
 // disabled, an embedded data plane on --proxy-listen — and both must share one
 // signal handler so a single Ctrl-C drains both rather than leaving one
 // serving.
 //
 // Shutdown runs in REVERSE registration order, each server's AfterShutdown
 // firing before the next one is stopped. Register dependencies first: in `nyro
-// server` the control plane is also the embedded data plane's OTLP sink, so
+// serve` the control plane is also the embedded data plane's OTLP sink, so
 // stopping it first would make the data plane's final telemetry flush fail with
 // connection-refused on every clean exit.
 //
 // A listen error on ANY server aborts the whole process: a half-up `nyro
-// server` (management API reachable, data plane port already taken) is a
+// serve` (management API reachable, data plane port already taken) is a
 // confusing state to debug, and failing fast surfaces the port conflict
 // immediately.
 func RunServers(servers ...HTTPServer) error {

--- a/go/internal/configsync/inprocess.go
+++ b/go/internal/configsync/inprocess.go
@@ -38,7 +38,7 @@ const ConnModeInProcess = "inprocess"
 // ServeInProcess serves srv over an in-memory pipe instead of a network
 // listener, and returns the dial options a ConfigClient needs to reach it.
 //
-// This is what lets `nyro server` run an embedded data plane over the SAME
+// This is what lets `nyro serve` run an embedded data plane over the SAME
 // config-sync code path as a standalone `nyro proxy`: the embedded proxy builds
 // a real ConfigClient, receives real ConfigSnapshot messages, and fills a real
 // ConfigCache. Only the dial target differs. The alternative — having the

--- a/go/internal/configsync/pki/ca.go
+++ b/go/internal/configsync/pki/ca.go
@@ -26,7 +26,7 @@ const (
 // CA is a loaded (or freshly generated) certificate authority: its
 // certificate (used to build trust chains / ClientCAs / RootCAs pools) and
 // private key (used to sign leaf certificates). The private key is only ever
-// needed by the offline `nyro ca sign-*` commands, never by admin/gateway at
+// needed by the offline `nyro ca sign-*` commands, never by server/proxy at
 // runtime.
 type CA struct {
 	Cert *x509.Certificate

--- a/go/internal/configsync/pki/doc.go
+++ b/go/internal/configsync/pki/doc.go
@@ -1,12 +1,12 @@
 // Package pki provides the offline certificate authority and TLS config
-// construction used to secure the config-sync gRPC channel between admin
-// (control plane) and gateway (data plane) nodes.
+// construction used to secure the config-sync gRPC channel between the server
+// (control plane) and proxy (data plane) nodes.
 //
 // The trust model is a single self-signed CA per deployment (or an external
 // BYO PKI producing files in the same shape): the CA signs a server leaf
-// certificate for admin (DNS/IP SANs from --advertise) and a client leaf
-// certificate per gateway (a SPIFFE URI SAN carrying the node identity,
-// spiffe://nyro/gateway/<node-id>). admin/gateway load these at runtime via
+// certificate for the server (a fixed SPIFFE URI SAN) and a client leaf
+// certificate per proxy (a SPIFFE URI SAN carrying the node identity,
+// spiffe://nyro/proxy/<node-id>). Server and proxy load these at runtime via
 // LoadServerTLS/LoadClientTLS from three explicit file paths — there is no
 // directory-scanning or auto-discovery at runtime; only the offline `nyro ca`
 // commands write to a conventional directory.

--- a/go/internal/configsync/pki/expiry.go
+++ b/go/internal/configsync/pki/expiry.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ExpiryWarningWindow is how far ahead of a leaf certificate's expiry
-// admin/gateway should start logging a renewal warning. Certificates here
+// server/proxy should start logging a renewal warning. Certificates here
 // are offline-signed and manually rotated (see nyro ca sign-*); nothing
 // renews them automatically, so operators need advance notice before the
 // config-sync channel silently stops working.

--- a/go/internal/configsync/pki/identity.go
+++ b/go/internal/configsync/pki/identity.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 )
 
-// AdminSPIFFEID is the fixed identity every admin server certificate carries
-// (spiffe://nyro/admin) and the identity gateway's config-sync client
-// verifies admin's server certificate against — see VerifyAdminIdentity.
-// Unlike gateway identities, it does not vary per instance: config-sync has
-// exactly one logical admin peer, and pinning it to a constant means
+// ServerSPIFFEID is the fixed identity every config-sync server certificate
+// carries (spiffe://nyro/server) and the identity each proxy's config-sync
+// client verifies — see VerifyServerIdentity. Unlike proxy identities, it does
+// not vary per instance: config-sync has exactly one logical server peer, and
+// pinning it to a constant means
 // verification is fully decoupled from network topology (LB, k8s Service
 // name, IP, hostname — none of it matters, only the identity in the cert
-// does), so there is no --config-server-name-style override to maintain.
-const AdminSPIFFEID = "admin"
+// does), so there is no TLS server-name override to maintain.
+const ServerSPIFFEID = "server"
 
 // identityFromCert extracts the raw path (minus leading slash) from cert's
-// spiffe://<trust-domain>/... URI SAN, e.g. "admin" or "gateway/<node-id>".
+// spiffe://<trust-domain>/... URI SAN, e.g. "server" or "proxy/<node-id>".
 // Returns an error if cert carries no such SAN.
 func identityFromCert(cert *x509.Certificate) (string, error) {
 	for _, u := range cert.URIs {
@@ -33,33 +33,33 @@ func identityFromCert(cert *x509.Certificate) (string, error) {
 	return "", fmt.Errorf("pki: certificate %q has no spiffe://%s/... URI SAN", cert.Subject.CommonName, spiffeTrustDomain)
 }
 
-// GatewayNodeIDFromCert extracts the node identity from a gateway's client
-// certificate's SPIFFE URI SAN (spiffe://nyro/gateway/<node-id>), returning
-// just the <node-id> segment — the same shape as the gateway's
+// ProxyNodeIDFromCert extracts the node identity from a proxy's client
+// certificate's SPIFFE URI SAN (spiffe://nyro/proxy/<node-id>), returning
+// just the <node-id> segment — the same shape as the proxy's
 // self-reported node_id, so callers can substitute one for the other
 // transparently. Returns an error if cert carries no spiffe:// URI SAN under
-// the expected gateway path shape.
-func GatewayNodeIDFromCert(cert *x509.Certificate) (string, error) {
+// the expected proxy path shape.
+func ProxyNodeIDFromCert(cert *x509.Certificate) (string, error) {
 	id, err := identityFromCert(cert)
 	if err != nil {
 		return "", err
 	}
-	nodeID, ok := strings.CutPrefix(id, "gateway/")
+	nodeID, ok := strings.CutPrefix(id, "proxy/")
 	if !ok || nodeID == "" {
-		return "", fmt.Errorf("pki: certificate %q identity %q is not a spiffe://%s/gateway/<node-id> SAN", cert.Subject.CommonName, id, spiffeTrustDomain)
+		return "", fmt.Errorf("pki: certificate %q identity %q is not a spiffe://%s/proxy/<node-id> SAN", cert.Subject.CommonName, id, spiffeTrustDomain)
 	}
 	return nodeID, nil
 }
 
-// VerifyAdminIdentity reports whether cert's SPIFFE URI SAN identifies it as
-// admin (spiffe://nyro/admin) — see AdminSPIFFEID.
-func VerifyAdminIdentity(cert *x509.Certificate) error {
+// VerifyServerIdentity reports whether cert's SPIFFE URI SAN identifies it as
+// the config-sync server (spiffe://nyro/server) — see ServerSPIFFEID.
+func VerifyServerIdentity(cert *x509.Certificate) error {
 	id, err := identityFromCert(cert)
 	if err != nil {
 		return err
 	}
-	if id != AdminSPIFFEID {
-		return fmt.Errorf("pki: certificate %q identity is %q, want %q", cert.Subject.CommonName, id, AdminSPIFFEID)
+	if id != ServerSPIFFEID {
+		return fmt.Errorf("pki: certificate %q identity is %q, want %q", cert.Subject.CommonName, id, ServerSPIFFEID)
 	}
 	return nil
 }

--- a/go/internal/configsync/pki/pki_test.go
+++ b/go/internal/configsync/pki/pki_test.go
@@ -50,14 +50,14 @@ func TestEnsureCA_IncompletePairErrors(t *testing.T) {
 	}
 }
 
-func TestSignServer_AdminIdentity(t *testing.T) {
+func TestSignServer_ServerIdentity(t *testing.T) {
 	dir := t.TempDir()
 	ca, err := EnsureCA(dir, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	certPath, keyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	certPath, keyPath, err := ca.SignServer(dir, "server", time.Hour)
 	if err != nil {
 		t.Fatalf("SignServer: %v", err)
 	}
@@ -66,8 +66,11 @@ func TestSignServer_AdminIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := VerifyAdminIdentity(cert); err != nil {
-		t.Errorf("VerifyAdminIdentity: %v", err)
+	if err := VerifyServerIdentity(cert); err != nil {
+		t.Errorf("VerifyServerIdentity: %v", err)
+	}
+	if len(cert.URIs) != 1 || cert.URIs[0].String() != "spiffe://nyro/server" {
+		t.Errorf("URI SANs = %v, want [spiffe://nyro/server]", cert.URIs)
 	}
 	if got := cert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageServerAuth {
 		t.Errorf("ExtKeyUsage = %v, want [ServerAuth]", got)
@@ -78,14 +81,14 @@ func TestSignServer_AdminIdentity(t *testing.T) {
 	}
 }
 
-func TestSignClient_SPIFFESAN(t *testing.T) {
+func TestSignClient_ProxySPIFFESAN(t *testing.T) {
 	dir := t.TempDir()
 	ca, err := EnsureCA(dir, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	certPath, _, err := ca.SignClient(dir, "gateway", "node-abcd", time.Hour)
+	certPath, _, err := ca.SignClient(dir, "proxy", "node-abcd", time.Hour)
 	if err != nil {
 		t.Fatalf("SignClient: %v", err)
 	}
@@ -94,28 +97,31 @@ func TestSignClient_SPIFFESAN(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id, err := GatewayNodeIDFromCert(cert)
+	id, err := ProxyNodeIDFromCert(cert)
 	if err != nil {
-		t.Fatalf("GatewayNodeIDFromCert: %v", err)
+		t.Fatalf("ProxyNodeIDFromCert: %v", err)
 	}
 	if id != "node-abcd" {
 		t.Errorf("identity = %q, want %q", id, "node-abcd")
 	}
+	if len(cert.URIs) != 1 || cert.URIs[0].String() != "spiffe://nyro/proxy/node-abcd" {
+		t.Errorf("URI SANs = %v, want [spiffe://nyro/proxy/node-abcd]", cert.URIs)
+	}
 	if got := cert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageClientAuth {
 		t.Errorf("ExtKeyUsage = %v, want [ClientAuth]", got)
 	}
-	if err := VerifyAdminIdentity(cert); err == nil {
-		t.Fatal("expected a gateway client cert to fail VerifyAdminIdentity")
+	if err := VerifyServerIdentity(cert); err == nil {
+		t.Fatal("expected a proxy client cert to fail VerifyServerIdentity")
 	}
 }
 
-func TestGatewayNodeIDFromCert_RejectsAdminCert(t *testing.T) {
+func TestProxyNodeIDFromCert_RejectsServerCert(t *testing.T) {
 	dir := t.TempDir()
 	ca, err := EnsureCA(dir, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPath, _, err := ca.SignServer(dir, "admin", time.Hour)
+	certPath, _, err := ca.SignServer(dir, "server", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,13 +129,13 @@ func TestGatewayNodeIDFromCert_RejectsAdminCert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := GatewayNodeIDFromCert(cert); err == nil {
-		t.Fatal("expected error extracting a gateway node-id from admin's own certificate")
+	if _, err := ProxyNodeIDFromCert(cert); err == nil {
+		t.Fatal("expected error extracting a proxy node-id from the server certificate")
 	}
 }
 
 // TestMTLSRoundTrip exercises LoadServerTLS/LoadClientTLS end-to-end over a
-// real TCP loopback listener: a server presenting an admin cert requiring
+// real TCP loopback listener: a server presenting a server cert requiring
 // client certs, and three client dial attempts (matching CA + cert, wrong
 // CA, no cert) to confirm accept/reject behavior.
 func TestMTLSRoundTrip(t *testing.T) {
@@ -138,11 +144,11 @@ func TestMTLSRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverCertPath, serverKeyPath, err := ca.SignServer(dir, "admin", time.Hour)
+	serverCertPath, serverKeyPath, err := ca.SignServer(dir, "server", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "proxy", "node-1", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +206,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "gateway", "node-1", time.Hour)
+		otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "proxy", "node-1", time.Hour)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -226,7 +232,7 @@ func TestMTLSRoundTrip(t *testing.T) {
 		// handshake actually reaches the point where the server enforces
 		// RequireAndVerifyClientCert — this subtest is specifically about
 		// the server rejecting a missing client cert, not about client-side
-		// verification of admin's identity.
+		// verification of the server's identity.
 		conn, dialErr := tls.Dial("tcp", lis.Addr().String(), &tls.Config{InsecureSkipVerify: true})
 		if dialErr == nil {
 			_ = conn.Close()
@@ -238,25 +244,25 @@ func TestMTLSRoundTrip(t *testing.T) {
 	})
 }
 
-// TestLoadClientTLS_RejectsNonAdminServerIdentity proves LoadClientTLS's
+// TestLoadClientTLS_RejectsNonServerIdentity proves LoadClientTLS's
 // VerifyConnection checks identity, not just chain validity: a certificate
-// signed by the trusted CA but not carrying the AdminSPIFFEID identity (here,
-// a gateway's own client cert, reused as a server cert) must be rejected
+// signed by the trusted CA but not carrying the ServerSPIFFEID identity (here,
+// a proxy's own client cert, reused as a server cert) must be rejected
 // even though the chain itself verifies fine.
-func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
+func TestLoadClientTLS_RejectsNonServerIdentity(t *testing.T) {
 	dir := t.TempDir()
 	ca, err := EnsureCA(dir, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// SignClient's cert has no ServerAuth EKU and identifies as
-	// "gateway/impersonator", not "admin" — either alone is grounds for
+	// "proxy/impersonator", not "server" — either alone is grounds for
 	// LoadClientTLS to reject it.
-	notAdminCertPath, notAdminKeyPath, err := ca.SignClient(dir, "not-admin", "impersonator", time.Hour)
+	notServerCertPath, notServerKeyPath, err := ca.SignClient(dir, "not-server", "impersonator", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "gateway", "node-1", time.Hour)
+	clientCertPath, clientKeyPath, err := ca.SignClient(dir, "proxy", "node-1", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,9 +270,9 @@ func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
 
 	// tls.Listen doesn't itself enforce the serving cert's EKU, so this is a
 	// faithful stand-in for "some entity presents a CA-signed cert that
-	// isn't admin's" regardless of which specific property makes it invalid.
+	// isn't the server's" regardless of which specific property makes it invalid.
 	rawServerTLS := &tls.Config{MinVersion: tls.VersionTLS12}
-	tlsCert, err := tls.LoadX509KeyPair(notAdminCertPath, notAdminKeyPath)
+	tlsCert, err := tls.LoadX509KeyPair(notServerCertPath, notServerKeyPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +297,7 @@ func TestLoadClientTLS_RejectsNonAdminServerIdentity(t *testing.T) {
 	conn, dialErr := tls.Dial("tcp", lis.Addr().String(), clientTLS)
 	if dialErr == nil {
 		_ = conn.Close()
-		t.Fatal("expected the client to reject a server certificate that isn't identified as admin")
+		t.Fatal("expected the client to reject a server certificate that isn't identified as server")
 	}
 }
 
@@ -321,7 +327,7 @@ func TestLeafNotAfter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPath, keyPath, err := ca.SignServer(dir, "admin", 2*time.Hour)
+	certPath, keyPath, err := ca.SignServer(dir, "server", 2*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +352,7 @@ func TestWatchExpiry_WarnsImmediatelyForSoonExpiringCert(t *testing.T) {
 	}
 	// Valid for less than the warning window: should trigger a warning on
 	// the very first (synchronous, pre-ticker) check.
-	certPath, keyPath, err := ca.SignServer(dir, "admin", 24*time.Hour)
+	certPath, keyPath, err := ca.SignServer(dir, "server", 24*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +378,7 @@ func TestWatchExpiry_NoWarningForFreshCert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPath, keyPath, err := ca.SignServer(dir, "admin", 8760*time.Hour)
+	certPath, keyPath, err := ca.SignServer(dir, "server", 8760*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/configsync/pki/sign.go
+++ b/go/internal/configsync/pki/sign.go
@@ -19,20 +19,20 @@ import (
 // identities within it; it does not need to vary per deployment.
 const spiffeTrustDomain = "nyro"
 
-// SignServer issues admin's server leaf certificate (ExtKeyUsage:
-// ServerAuth), carrying the fixed identity AdminSPIFFEID as a SPIFFE URI SAN
-// (spiffe://nyro/admin) — the same identity-based verification model as
-// SignClient, so gateway's config-sync client checks "is this cert admin?"
+// SignServer issues the config-sync server leaf certificate (ExtKeyUsage:
+// ServerAuth), carrying the fixed identity ServerSPIFFEID as a SPIFFE URI SAN
+// (spiffe://nyro/server) — the same identity-based verification model as
+// SignClient, so each proxy's config-sync client checks "is this cert server?"
 // rather than "does this cert's SAN match the hostname I dialed?". That
-// means admin's certificate stays valid no matter what address/hostname a
-// gateway uses to reach it (direct, load balancer, k8s Service name, IP —
+// means the server certificate stays valid no matter what address/hostname a
+// proxy uses to reach it (direct, load balancer, k8s Service name, IP —
 // all of it), with no per-deployment DNS/IP SAN list to maintain and no
-// --config-server-name-style override needed on the client side.
+// TLS server-name override needed on the client side.
 //
 // The resulting cert/key are written to <dir>/<name>.pem and
 // <dir>/<name>-key.pem (0600) and their paths are returned. name is only the
 // output file basename (see --out) — it does not affect the identity baked
-// into the certificate, which is always AdminSPIFFEID.
+// into the certificate, which is always ServerSPIFFEID.
 func (ca *CA) SignServer(dir, name string, ttl time.Duration) (certPath, keyPath string, err error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -43,12 +43,12 @@ func (ca *CA) SignServer(dir, name string, ttl time.Duration) (certPath, keyPath
 		return "", "", err
 	}
 
-	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/" + AdminSPIFFEID}
+	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/" + ServerSPIFFEID}
 
 	now := time.Now()
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: AdminSPIFFEID},
+		Subject:      pkix.Name{CommonName: ServerSPIFFEID},
 		NotBefore:    now.Add(-5 * time.Minute),
 		NotAfter:     now.Add(ttl),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
@@ -60,8 +60,8 @@ func (ca *CA) SignServer(dir, name string, ttl time.Duration) (certPath, keyPath
 }
 
 // SignClient issues a client leaf certificate (ExtKeyUsage: ClientAuth) for
-// a gateway node, carrying its identity as a SPIFFE URI SAN
-// (spiffe://nyro/gateway/<nodeID>). The resulting cert/key are written to
+// a proxy node, carrying its identity as a SPIFFE URI SAN
+// (spiffe://nyro/proxy/<nodeID>). The resulting cert/key are written to
 // <dir>/<name>.pem and <dir>/<name>-key.pem (0600) and their paths are
 // returned.
 func (ca *CA) SignClient(dir, name, nodeID string, ttl time.Duration) (certPath, keyPath string, err error) {
@@ -78,7 +78,7 @@ func (ca *CA) SignClient(dir, name, nodeID string, ttl time.Duration) (certPath,
 		return "", "", err
 	}
 
-	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/gateway/" + nodeID}
+	spiffeURI := &url.URL{Scheme: "spiffe", Host: spiffeTrustDomain, Path: "/proxy/" + nodeID}
 
 	now := time.Now()
 	tmpl := &x509.Certificate{

--- a/go/internal/configsync/pki/tls.go
+++ b/go/internal/configsync/pki/tls.go
@@ -7,11 +7,11 @@ import (
 	"os"
 )
 
-// LoadServerTLS builds the *tls.Config for admin's config-sync gRPC listener:
+// LoadServerTLS builds the *tls.Config for the config-sync gRPC listener:
 // it presents (certPath, keyPath) as its server certificate and requires +
 // verifies every client certificate against caPath. All three paths are
-// mandatory — callers (the admin CLI) are responsible for enforcing that
-// --config-tls-ca/-cert/-key are given all together or not at all; this
+// mandatory — callers (the serve CLI) are responsible for enforcing that
+// --sync-tls-ca/-cert/-key are given all together or not at all; this
 // function has no directory-scanning fallback.
 func LoadServerTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
 	pool, err := loadCertPool(caPath)
@@ -30,18 +30,18 @@ func LoadServerTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
 	}, nil
 }
 
-// LoadClientTLS builds the *tls.Config for a gateway's config-sync client: it
-// trusts caPath as the root for verifying admin's server certificate and
+// LoadClientTLS builds the *tls.Config for a proxy's config-sync client: it
+// trusts caPath as the root for verifying the server certificate and
 // presents (certPath, keyPath) as its own client certificate.
 //
 // Verification is identity-based, not hostname-based: the default Go TLS
 // client behavior (matching the server cert's DNS/IP SANs against the dial
 // address) is replaced with VerifyConnection checking that the presented
 // server certificate is signed by caPath, carries the ServerAuth extended
-// key usage, and identifies as AdminSPIFFEID (see VerifyAdminIdentity) — the
+// key usage, and identifies as ServerSPIFFEID (see VerifyServerIdentity) — the
 // same check regardless of what address/hostname was dialed (direct, load
 // balancer, k8s Service name, IP). This is why there is no
-// --config-server-name-style override flag: identity verification is fully
+// TLS server-name override flag: identity verification is fully
 // decoupled from network topology by design.
 func LoadClientTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
 	pool, err := loadCertPool(caPath)
@@ -77,7 +77,7 @@ func LoadClientTLS(caPath, certPath, keyPath string) (*tls.Config, error) {
 			if _, err := leaf.Verify(opts); err != nil {
 				return fmt.Errorf("pki: verify server certificate chain: %w", err)
 			}
-			return VerifyAdminIdentity(leaf)
+			return VerifyServerIdentity(leaf)
 		},
 	}, nil
 }

--- a/go/internal/configsync/plaintext_guard.go
+++ b/go/internal/configsync/plaintext_guard.go
@@ -41,7 +41,7 @@ encryption nor authentication. The stream carries upstream API credentials in
 the clear to any client that connects.
 
 Fix by either:
-  - set --sync-token (or NYRO_SERVER_SYNC_TOKEN) to require a join credential, or
+  - set --sync-token (or NYRO_SERVE_SYNC_TOKEN) to require a join credential, or
   - configure mTLS with --sync-tls-ca/-cert/-key (see `+"`nyro ca`"+`)
 Or bind --sync-listen to a loopback address`, addr)
 }

--- a/go/internal/configsync/plaintext_guard_test.go
+++ b/go/internal/configsync/plaintext_guard_test.go
@@ -54,7 +54,7 @@ func TestGuardPlaintextListen_ErrorNamesEveryWayOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	for _, want := range []string{"--sync-token", "NYRO_SERVER_SYNC_TOKEN", "--sync-tls-ca", "nyro ca", "loopback", "0.0.0.0:19532"} {
+	for _, want := range []string{"--sync-token", "NYRO_SERVE_SYNC_TOKEN", "--sync-tls-ca", "nyro ca", "loopback", "0.0.0.0:19532"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error message is missing %q:\n%s", want, err)
 		}

--- a/go/internal/configsync/server.go
+++ b/go/internal/configsync/server.go
@@ -129,7 +129,7 @@ func (s *ConfigServer) StreamConfig(req *pb.Subscribe, stream grpc.ServerStreami
 			if len(tlsInfo.State.VerifiedChains) > 0 && len(tlsInfo.State.VerifiedChains[0]) > 0 {
 				connMode = "mtls"
 				leaf := tlsInfo.State.VerifiedChains[0][0]
-				if id, err := pki.GatewayNodeIDFromCert(leaf); err == nil {
+				if id, err := pki.ProxyNodeIDFromCert(leaf); err == nil {
 					nodeID = id
 				} else {
 					log.Printf("configsync: client cert has no usable identity, keeping self-reported node_id: %v", err)

--- a/go/internal/configsync/server_mtls_test.go
+++ b/go/internal/configsync/server_mtls_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/nyroway/nyro/go/internal/configsync/pki"
 )
 
-// mtlsFixture is a self-signed CA plus an admin server leaf cert and a
-// gateway client leaf cert (identity "cert-node"), all issued for these
+// mtlsFixture is a self-signed CA plus a server leaf cert and a proxy client
+// leaf cert (identity "cert-node"), all issued for these
 // mTLS-focused tests.
 type mtlsFixture struct {
 	caPath                        string
@@ -32,11 +32,11 @@ func newMTLSFixture(t *testing.T) mtlsFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverCert, serverKey, err := ca.SignServer(dir, "admin", time.Hour)
+	serverCert, serverKey, err := ca.SignServer(dir, "server", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientCert, clientKey, err := ca.SignClient(dir, "gateway", "cert-node", time.Hour)
+	clientCert, clientKey, err := ca.SignClient(dir, "proxy", "cert-node", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestStreamConfig_MTLS_RejectsWrongCACert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "gateway", "cert-node", time.Hour)
+	otherCertPath, otherKeyPath, err := otherCA.SignClient(otherDir, "proxy", "cert-node", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/dataplane/dataplane.go
+++ b/go/internal/dataplane/dataplane.go
@@ -1,7 +1,7 @@
 // Package dataplane assembles a ready-to-serve proxy.Gateway from one of the
 // two config sources, together with its observability pipeline.
 //
-// It exists so that `nyro proxy` (standalone data plane) and `nyro server`
+// It exists so that `nyro proxy` (standalone data plane) and `nyro serve`
 // (control plane with an embedded data plane) share ONE assembly path. The
 // embedded case differs only in how its config-sync client dials — over an
 // in-process pipe (configsync.ServeInProcess) instead of TCP — so an embedded
@@ -11,7 +11,7 @@
 // from the distributed one.
 //
 // Layer: 3 (serve) — assembles the data plane for both `nyro proxy` and the
-// embedded plane inside `nyro server`; may import any lower layer. Nothing
+// embedded plane inside `nyro serve`; may import any lower layer. Nothing
 // below layer 3 may import it.
 package dataplane
 

--- a/go/internal/envflag/envflag.go
+++ b/go/internal/envflag/envflag.go
@@ -11,7 +11,7 @@
 //
 // The env var name for a flag is derived from the command path and flag name:
 //
-//	nyro server      --listen               -> NYRO_SERVER_LISTEN
+//	nyro serve       --listen               -> NYRO_SERVE_LISTEN
 //	nyro proxy       --config               -> NYRO_PROXY_CONFIG
 //	nyro ca init     --dir                  -> NYRO_CA_INIT_DIR
 //	nyro ca sign-server --out               -> NYRO_CA_SIGN_SERVER_OUT
@@ -35,8 +35,8 @@ import (
 const envPrefix = "NYRO"
 
 // EnvKey builds the environment variable name for a flag under the given
-// per-command prefix (e.g. prefix "SERVER", flag "obs-data-dir" ->
-// "NYRO_SERVER_OBS_DATA_DIR"). The flag name's dashes become
+// per-command prefix (e.g. prefix "SERVE", flag "obs-data-dir" ->
+// "NYRO_SERVE_OBS_DATA_DIR"). The flag name's dashes become
 // underscores and everything is upper-cased.
 func EnvKey(prefix, flagName string) string {
 	return envPrefix + "_" + prefix + "_" + normalize(flagName)

--- a/go/internal/envflag/envflag_test.go
+++ b/go/internal/envflag/envflag_test.go
@@ -8,22 +8,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newTestCmd builds a leaf command "nyro server" carrying string/bool/duration
-// flags, so Bind sees a realistic CommandPath ("nyro server") and prefix
-// ("SERVER"). The returned command is not executed; tests call Bind directly.
+// newTestCmd builds a leaf command "nyro serve" carrying string/bool/duration
+// flags, so Bind sees a realistic CommandPath ("nyro serve") and prefix
+// ("SERVE"). The returned command is not executed; tests call Bind directly.
 func newTestCmd() *cobra.Command {
 	root := &cobra.Command{Use: "nyro"}
-	server := &cobra.Command{Use: "server", RunE: func(*cobra.Command, []string) error { return nil }}
-	server.Flags().String("listen", "127.0.0.1:19531", "listen addr")
-	server.Flags().Bool("auto-migrate", false, "auto migrate")
-	server.Flags().Duration("config-poll-interval", 0, "poll interval")
-	root.AddCommand(server)
-	return server
+	serve := &cobra.Command{Use: "serve", RunE: func(*cobra.Command, []string) error { return nil }}
+	serve.Flags().String("listen", "127.0.0.1:19531", "listen addr")
+	serve.Flags().Bool("auto-migrate", false, "auto migrate")
+	serve.Flags().Duration("config-poll-interval", 0, "poll interval")
+	root.AddCommand(serve)
+	return serve
 }
 
 func TestBindAppliesEnvWhenFlagUnset(t *testing.T) {
 	cmd := newTestCmd()
-	t.Setenv("NYRO_SERVER_LISTEN", "0.0.0.0:29530")
+	t.Setenv("NYRO_SERVE_LISTEN", "0.0.0.0:29530")
 
 	if err := Bind(cmd, nil); err != nil {
 		t.Fatalf("Bind: %v", err)
@@ -43,7 +43,7 @@ func TestExplicitFlagBeatsEnv(t *testing.T) {
 	if err := cmd.Flags().Set("listen", "1.2.3.4:1111"); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("NYRO_SERVER_LISTEN", "0.0.0.0:29530")
+	t.Setenv("NYRO_SERVE_LISTEN", "0.0.0.0:29530")
 
 	if err := Bind(cmd, nil); err != nil {
 		t.Fatalf("Bind: %v", err)
@@ -70,8 +70,8 @@ func TestDefaultWhenNoEnvNoFlag(t *testing.T) {
 
 func TestBindTypedFlagsFromEnv(t *testing.T) {
 	cmd := newTestCmd()
-	t.Setenv("NYRO_SERVER_AUTO_MIGRATE", "true")
-	t.Setenv("NYRO_SERVER_CONFIG_POLL_INTERVAL", "5s")
+	t.Setenv("NYRO_SERVE_AUTO_MIGRATE", "true")
+	t.Setenv("NYRO_SERVE_CONFIG_POLL_INTERVAL", "5s")
 
 	if err := Bind(cmd, nil); err != nil {
 		t.Fatalf("Bind: %v", err)
@@ -86,7 +86,7 @@ func TestBindTypedFlagsFromEnv(t *testing.T) {
 
 func TestBindInvalidEnvValueErrors(t *testing.T) {
 	cmd := newTestCmd()
-	t.Setenv("NYRO_SERVER_CONFIG_POLL_INTERVAL", "not-a-duration")
+	t.Setenv("NYRO_SERVE_CONFIG_POLL_INTERVAL", "not-a-duration")
 
 	err := Bind(cmd, nil)
 	if err == nil {
@@ -96,8 +96,8 @@ func TestBindInvalidEnvValueErrors(t *testing.T) {
 
 func TestEnvKey(t *testing.T) {
 	cases := []struct{ prefix, flag, want string }{
-		{"SERVER", "listen", "NYRO_SERVER_LISTEN"},
-		{"SERVER", "obs-data-dir", "NYRO_SERVER_OBS_DATA_DIR"},
+		{"SERVE", "listen", "NYRO_SERVE_LISTEN"},
+		{"SERVE", "obs-data-dir", "NYRO_SERVE_OBS_DATA_DIR"},
 		{"PROXY", "sync-tls-ca", "NYRO_PROXY_SYNC_TLS_CA"},
 	}
 	for _, c := range cases {
@@ -128,7 +128,7 @@ func TestDecorateAppendsEnvHint(t *testing.T) {
 	Decorate(root)
 
 	usage := cmd.Flags().Lookup("listen").Usage
-	if want := "(env NYRO_SERVER_LISTEN)"; !strings.Contains(usage, want) {
+	if want := "(env NYRO_SERVE_LISTEN)"; !strings.Contains(usage, want) {
 		t.Errorf("listen usage = %q, want it to contain %q", usage, want)
 	}
 }

--- a/go/internal/observability/stage.go
+++ b/go/internal/observability/stage.go
@@ -216,7 +216,7 @@ var stageTarget atomic.Pointer[SwappableProvider]
 //
 // Calling it more than once per process is safe and idempotent: it simply
 // re-points the target. This matters because a single process can assemble more
-// than one data plane over its lifetime — `nyro server` embeds one alongside
+// than one data plane over its lifetime — `nyro serve` embeds one alongside
 // the control plane, and tests build many.
 //
 // This is distinct from hot-reload: an obs config change swaps the pipeline

--- a/go/internal/observability/stage_test.go
+++ b/go/internal/observability/stage_test.go
@@ -417,7 +417,7 @@ var _ attribute.KeyValue = attribute.KeyValue{}
 
 // TestRegisterObservabilityIsIdempotentAndRepoints pins the contract that
 // makes an embedded data plane safe: a process may register more than once
-// (`nyro server` assembles a data plane alongside the control plane, tests
+// (`nyro serve` assembles a data plane alongside the control plane, tests
 // assemble many), and doing so must neither double-emit nor keep an old
 // provider alive.
 //

--- a/go/nyro.go
+++ b/go/nyro.go
@@ -1,5 +1,5 @@
 // Command nyro is the unified gateway CLI: `nyro proxy` (data plane),
-// `nyro server` (control plane).
+// `nyro serve` (control plane).
 package main
 
 import (

--- a/go/nyro_test.go
+++ b/go/nyro_test.go
@@ -5,8 +5,12 @@ import "testing"
 func TestRootCmdSubcommands(t *testing.T) {
 	root := newRootCmd()
 	names := map[string]bool{}
+	aliases := map[string]bool{}
 	for _, c := range root.Commands() {
 		names[c.Name()] = true
+		for _, alias := range c.Aliases {
+			aliases[alias] = true
+		}
 	}
 	if names["completion"] {
 		t.Error("completion subcommand should be disabled")
@@ -17,8 +21,11 @@ func TestRootCmdSubcommands(t *testing.T) {
 	if !names["proxy"] {
 		t.Error("proxy subcommand missing")
 	}
-	if !names["server"] {
-		t.Error("server subcommand missing")
+	if !names["serve"] {
+		t.Error("serve subcommand missing")
+	}
+	if names["server"] || aliases["server"] {
+		t.Error("server subcommand should have been renamed to serve without an alias")
 	}
 	// The pre-rename names must be fully gone: the rename ships without a
 	// compatibility period, so a lingering alias would be a bug, not a courtesy.
@@ -26,7 +33,7 @@ func TestRootCmdSubcommands(t *testing.T) {
 		t.Error("gateway subcommand should have been renamed to proxy")
 	}
 	if names["admin"] {
-		t.Error("admin subcommand should have been renamed to server")
+		t.Error("admin subcommand should have been renamed to serve")
 	}
 }
 


### PR DESCRIPTION
## Summary

- rename the unreleased Go control-plane command from `nyro server` to `nyro serve` and move generated flag environment variables to `NYRO_SERVE_*`
- align config-sync PKI workload identities and default certificate names with the server/proxy terminology
- update tests, security guidance, cutover instructions, and Makefile examples without legacy aliases

## Testing

- `GOCACHE=/private/tmp/nyro-go-build-cache go test ./...`
- `GOCACHE=/private/tmp/nyro-go-vet-cache go vet ./...`
- `git diff --check`