### PR TITLE
refactor(go): centralize database connections

### DIFF
--- a/.github/workflows/storage-backends.yml
+++ b/.github/workflows/storage-backends.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -77,6 +83,12 @@ jobs:
         run: python3 -m pytest tests/e2e/storage/test_storage.py -vv -s -rA -m storage -k postgres
         env:
           DB_URL: postgresql://nyro:nyro@localhost:5432/nyro_test
+
+      - name: Run Go PostgreSQL integration test
+        working-directory: go
+        run: go test ./internal/storage/database -run TestPostgresIntegration -count=1
+        env:
+          NYRO_TEST_POSTGRES_DSN: postgres://nyro:nyro@localhost:5432/nyro_test?sslmode=disable
 
       - name: Run storage E2E tests (mysql)
         run: python3 -m pytest tests/e2e/storage/test_storage.py -vv -s -rA -m storage -k mysql

--- a/go/cmd/migrate/migrate.go
+++ b/go/cmd/migrate/migrate.go
@@ -12,17 +12,32 @@
 package migrate
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
 
-	"github.com/nyroway/nyro/go/internal/bootstrap"
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
+	dbsqlite "github.com/nyroway/nyro/go/infra/database/sqlite"
 	"github.com/nyroway/nyro/go/internal/schemadump"
 	"github.com/nyroway/nyro/go/internal/storage/database"
 )
+
+type openedGorm struct {
+	DB         *gorm.DB
+	connection *infradatabase.Connection
+}
+
+func (o *openedGorm) Close() error {
+	if o == nil {
+		return nil
+	}
+	return o.connection.Close()
+}
 
 // NewCmd builds the `nyro tool migrate` command group.
 func NewCmd() *cobra.Command {
@@ -43,11 +58,12 @@ func newDumpCmd() *cobra.Command {
 	dsn := cmd.Flags().String("dsn", "", "Database DSN used to select SQL dialect")
 	output := cmd.Flags().String("output", "", "Write SQL to a file")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		db, err := openGorm(orSQLiteMem(*dsn))
+		opened, err := openGorm(cmd.Context(), orSQLiteMem(*dsn))
 		if err != nil {
 			return err
 		}
-		sql, err := schemadump.Dump(db)
+		defer func() { _ = opened.Close() }()
+		sql, err := schemadump.Dump(opened.DB)
 		if err != nil {
 			return err
 		}
@@ -72,15 +88,16 @@ func newDiffCmd() *cobra.Command {
 		if *targetDSN != "" && *targetDSN == *shadowDSN {
 			return fmt.Errorf("--shadow-dsn must differ from --target-dsn (the shadow is written to)")
 		}
-		shadow, err := openGorm(orSQLiteMem(*shadowDSN))
+		shadow, err := openGorm(cmd.Context(), orSQLiteMem(*shadowDSN))
 		if err != nil {
 			return fmt.Errorf("open shadow: %w", err)
 		}
-		current, err := currentSchema(*targetFile, *targetDSN)
+		defer func() { _ = shadow.Close() }()
+		current, err := currentSchema(cmd.Context(), *targetFile, *targetDSN)
 		if err != nil {
 			return err
 		}
-		sql, err := schemadump.Diff(shadow, current)
+		sql, err := schemadump.Diff(shadow.DB, current)
 		if err != nil {
 			return err
 		}
@@ -91,7 +108,7 @@ func newDiffCmd() *cobra.Command {
 
 // currentSchema resolves the diff's "current state" from exactly one of a
 // schema file or a live target DB (introspected).
-func currentSchema(targetFile, targetDSN string) (string, error) {
+func currentSchema(ctx context.Context, targetFile, targetDSN string) (string, error) {
 	if targetFile != "" {
 		b, err := os.ReadFile(targetFile)
 		if err != nil {
@@ -99,36 +116,37 @@ func currentSchema(targetFile, targetDSN string) (string, error) {
 		}
 		return string(b), nil
 	}
-	target, err := openGorm(targetDSN)
+	target, err := openGorm(ctx, targetDSN)
 	if err != nil {
 		return "", fmt.Errorf("open target: %w", err)
 	}
-	sql, err := schemadump.IntrospectSchema(target)
+	defer func() { _ = target.Close() }()
+	sql, err := schemadump.IntrospectSchema(target.DB)
 	if err != nil {
 		return "", fmt.Errorf("introspect --target-dsn: %w", err)
 	}
 	return sql, nil
 }
 
-// openGorm opens a gorm.DB for dsn, reusing the storage backend constructors.
-func openGorm(dsn string) (*gorm.DB, error) {
-	backend, driverDSN, err := bootstrap.ParseDSN(dsn)
+// openGorm opens a caller-owned SQL connection and wraps it with the Config
+// Engine's GORM backend.
+func openGorm(ctx context.Context, dsn string) (*openedGorm, error) {
+	connection, err := infradatabase.Open(ctx, dsn, infradatabase.Options{
+		SQLite: dbsqlite.Options{
+			BusyTimeout:  5 * time.Second,
+			MaxOpenConns: 5,
+			MaxIdleConns: 2,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-	var b *database.Backend
-	switch backend {
-	case "sqlite":
-		b, err = database.NewSQLite(driverDSN)
-	case "postgres":
-		b, err = database.NewPostgres(driverDSN)
-	default:
-		return nil, fmt.Errorf("unknown backend %q", backend)
-	}
+	b, err := database.New(connection.Kind, connection.DB)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", backend, err)
+		_ = connection.Close()
+		return nil, err
 	}
-	return b.DB(), nil
+	return &openedGorm{DB: b.DB(), connection: connection}, nil
 }
 
 func orSQLiteMem(dsn string) string {

--- a/go/cmd/migrate/migrate_test.go
+++ b/go/cmd/migrate/migrate_test.go
@@ -2,11 +2,31 @@ package migrate
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestOpenGormOwnsClosableConnection(t *testing.T) {
+	opened, err := openGorm(context.Background(), "sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("openGorm() error = %v", err)
+	}
+	if opened.DB == nil {
+		t.Fatal("openGorm() DB = nil")
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if err := opened.connection.DB.Ping(); err == nil {
+		t.Fatal("connection remains usable after Close()")
+	}
+}
 
 // run executes `nyro tool migrate <args...>` against an isolated command tree and
 // returns combined stdout and any error.

--- a/go/cmd/server/server.go
+++ b/go/cmd/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
 	dbsqlite "github.com/nyroway/nyro/go/infra/database/sqlite"
 	infraobserve "github.com/nyroway/nyro/go/infra/observe"
 	"github.com/nyroway/nyro/go/infra/observe/otlphttp"
@@ -189,11 +190,11 @@ func NewCmd() *cobra.Command {
 			dsn = defaultDSN()
 		}
 
-		backend, driverDSN, err := bootstrap.ParseDSN(dsn)
+		backend, driverDSN, err := infradatabase.ParseDSN(dsn)
 		if err != nil {
 			return err
 		}
-		if backend == "sqlite" {
+		if backend == infradatabase.KindSQLite {
 			// The sqlite driver opens/creates the DB file itself but never its
 			// parent directory. For the ~/.nyro default that's our own managed
 			// space, so auto-creating it (like ~/.aws, ~/.docker, ~/.kube) is
@@ -222,13 +223,15 @@ func NewCmd() *cobra.Command {
 			return err
 		}
 
-		st, err := bootstrap.OpenStorageFromDSN(dsn, autoMigrate, plaintextKeys)
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
+		openedStorage, err := bootstrap.OpenStorageFromDSN(ctx, dsn, autoMigrate, plaintextKeys)
 		if err != nil {
 			return err
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		defer func() { _ = openedStorage.Close() }()
+		st := openedStorage.Storage
 
 		if !disableOTLP {
 			seedDefaultObsEndpoint(st.Settings(), otlpAddr)
@@ -324,7 +327,7 @@ func NewCmd() *cobra.Command {
 			// Cross-replica epoch polling is only meaningful when another
 			// replica can write to the same database, which the DSN scheme
 			// already tells us — see epochPollInterval.
-			watcher, err := startEpochWatcher(ctx, epochPollInterval(backend), st.Settings(), srv)
+			watcher, err := startEpochWatcher(ctx, epochPollInterval(string(backend)), st.Settings(), srv)
 			if err != nil {
 				return err
 			}

--- a/go/docs/schema/database.md
+++ b/go/docs/schema/database.md
@@ -159,7 +159,10 @@ Single-node `nyro serve` keeps its three local databases under
 - `observe.db` stores lossless OTLP batches plus query indexes for the embedded
   Observe Engine.
 
-State and Observe use independent caller-owned `database/sql` pools. Their
+SQL connection ownership is centralized under `go/infra/database`: SQLite and
+Postgres pools are opened, verified, configured, and closed there. The Config
+Engine wraps its caller-owned pool with GORM for schema and query behavior;
+State and Observe use independent caller-owned SQLite pools directly. Their
 protocol boundaries are Redis and OTLP, so a clustered deployment can disable
 the embedded listeners and point clients at external components.
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.3.0
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/spf13/cobra v1.10.2
@@ -50,7 +51,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go/infra/database/database.go
+++ b/go/infra/database/database.go
@@ -1,0 +1,94 @@
+// Package database opens SQL connection pools shared by Nyro infrastructure.
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/nyroway/nyro/go/infra/database/postgres"
+	"github.com/nyroway/nyro/go/infra/database/sqlite"
+)
+
+// Kind identifies a supported SQL database engine.
+type Kind string
+
+const (
+	KindSQLite   Kind = "sqlite"
+	KindPostgres Kind = "postgres"
+)
+
+// Options contains driver-specific connection settings.
+type Options struct {
+	SQLite   sqlite.Options
+	Postgres postgres.Options
+}
+
+// Connection owns a verified SQL connection pool.
+type Connection struct {
+	Kind Kind
+	DB   *sql.DB
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Close closes the pool. It is safe to call more than once.
+func (c *Connection) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.closeOnce.Do(func() {
+		if c.DB != nil {
+			c.closeErr = c.DB.Close()
+		}
+	})
+	return c.closeErr
+}
+
+// ParseDSN identifies a supported DSN and returns its driver-native value.
+func ParseDSN(dsn string) (Kind, string, error) {
+	switch {
+	case strings.HasPrefix(dsn, "sqlite://"):
+		return KindSQLite, strings.TrimPrefix(dsn, "sqlite://"), nil
+	case strings.HasPrefix(dsn, "postgres://"):
+		return KindPostgres, dsn, nil
+	case dsn == "":
+		return "", "", errors.New("--dsn is empty (want sqlite:// or postgres://)")
+	default:
+		scheme, _, found := strings.Cut(dsn, "://")
+		if !found {
+			scheme = "<missing>"
+		}
+		return "", "", fmt.Errorf("unrecognized --dsn scheme %q (want sqlite:// or postgres://)", scheme)
+	}
+}
+
+// Open parses dsn, opens the selected driver, and returns an owned connection.
+func Open(ctx context.Context, dsn string, opts Options) (*Connection, error) {
+	kind, nativeDSN, err := ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	var db *sql.DB
+	switch kind {
+	case KindSQLite:
+		sqliteOptions := opts.SQLite
+		sqliteOptions.Path = nativeDSN
+		db, err = sqlite.Open(ctx, sqliteOptions)
+	case KindPostgres:
+		postgresOptions := opts.Postgres
+		postgresOptions.DSN = nativeDSN
+		db, err = postgres.Open(ctx, postgresOptions)
+	default:
+		return nil, fmt.Errorf("unsupported database kind %q", kind)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open %s database: %w", kind, err)
+	}
+	return &Connection{Kind: kind, DB: db}, nil
+}

--- a/go/infra/database/database_test.go
+++ b/go/infra/database/database_test.go
@@ -1,0 +1,95 @@
+package database
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nyroway/nyro/go/infra/database/sqlite"
+)
+
+func TestParseDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dsn        string
+		wantKind   Kind
+		wantNative string
+		wantErr    bool
+		secret     string
+	}{
+		{name: "sqlite absolute path", dsn: "sqlite:///abs/x.db", wantKind: KindSQLite, wantNative: "/abs/x.db"},
+		{name: "sqlite relative path", dsn: "sqlite://./x.db", wantKind: KindSQLite, wantNative: "./x.db"},
+		{name: "sqlite memory", dsn: "sqlite://:memory:", wantKind: KindSQLite, wantNative: ":memory:"},
+		{name: "postgres passthrough", dsn: "postgres://user:pass@host:5432/db?sslmode=disable", wantKind: KindPostgres, wantNative: "postgres://user:pass@host:5432/db?sslmode=disable"},
+		{name: "postgresql alias rejected", dsn: "postgresql://user:pass@host:5432/db", wantErr: true, secret: "pass"},
+		{name: "mysql rejected", dsn: "mysql://user:pass@host/db", wantErr: true, secret: "pass"},
+		{name: "keyword DSN rejected without leaking", dsn: "host=localhost user=nyro secret=top-secret", wantErr: true, secret: "top-secret"},
+		{name: "empty rejected", dsn: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind, native, err := ParseDSN(tt.dsn)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseDSN(%q) error = nil", tt.dsn)
+				}
+				if tt.secret != "" && strings.Contains(err.Error(), tt.secret) {
+					t.Fatalf("ParseDSN(%q) error leaks credentials: %v", tt.dsn, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDSN(%q) error = %v", tt.dsn, err)
+			}
+			if kind != tt.wantKind || native != tt.wantNative {
+				t.Fatalf("ParseDSN(%q) = (%q, %q), want (%q, %q)", tt.dsn, kind, native, tt.wantKind, tt.wantNative)
+			}
+		})
+	}
+}
+
+func TestOpenSQLiteAppliesDriverOptionsAndOwnsClose(t *testing.T) {
+	conn, err := Open(context.Background(), "sqlite://:memory:", Options{
+		SQLite: sqlite.Options{MaxOpenConns: 5, MaxIdleConns: 2},
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if conn.Kind != KindSQLite {
+		t.Fatalf("Kind = %q, want %q", conn.Kind, KindSQLite)
+	}
+	if got := conn.DB.Stats().MaxOpenConnections; got != 5 {
+		t.Fatalf("MaxOpenConnections = %d, want 5", got)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if err := conn.DB.Ping(); err == nil {
+		t.Fatal("Ping() after Close() error = nil")
+	}
+}
+
+func TestOpenPostgresParseErrorDoesNotLeakPassword(t *testing.T) {
+	const dsn = "postgres://user:top-secret@127.0.0.1:not-a-port/db"
+
+	conn, err := Open(context.Background(), dsn, Options{})
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil {
+		t.Fatal("Open() error = nil")
+	}
+	if strings.Contains(err.Error(), "top-secret") || strings.Contains(err.Error(), dsn) {
+		t.Fatalf("Open() error leaks credentials: %v", err)
+	}
+}

--- a/go/infra/database/postgres/postgres.go
+++ b/go/infra/database/postgres/postgres.go
@@ -1,0 +1,115 @@
+// Package postgres opens caller-owned PostgreSQL connection pools.
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+// Options configures a PostgreSQL connection pool.
+type Options struct {
+	DSN             string
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	ConnMaxIdleTime time.Duration
+}
+
+// Open opens and verifies a caller-owned PostgreSQL connection pool.
+func Open(ctx context.Context, opts Options) (*sql.DB, error) {
+	if opts.DSN == "" {
+		return nil, errors.New("postgres: DSN is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: open: %w", err)
+	}
+
+	config, location, err := connectionConfig(opts.DSN)
+	if err != nil {
+		return nil, err
+	}
+	var openOptions []stdlib.OptionOpenDB
+	if location != nil {
+		openOptions = append(openOptions, stdlib.OptionAfterConnect(func(_ context.Context, conn *pgx.Conn) error {
+			conn.TypeMap().RegisterType(&pgtype.Type{
+				Name:  "timestamp",
+				OID:   pgtype.TimestampOID,
+				Codec: &pgtype.TimestampCodec{ScanLocation: location},
+			})
+			return nil
+		}))
+	}
+
+	db := stdlib.OpenDB(*config, openOptions...)
+	if opts.MaxOpenConns > 0 {
+		db.SetMaxOpenConns(opts.MaxOpenConns)
+	}
+	if opts.MaxIdleConns > 0 {
+		db.SetMaxIdleConns(opts.MaxIdleConns)
+	}
+	if opts.ConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(opts.ConnMaxLifetime)
+	}
+	if opts.ConnMaxIdleTime > 0 {
+		db.SetConnMaxIdleTime(opts.ConnMaxIdleTime)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("postgres: ping: %w", safeError(err, opts.DSN))
+	}
+	return db, nil
+}
+
+// connectionConfig mirrors the timestamp handling used by GORM's PostgreSQL
+// dialector when it owns the connection. The infra layer owns the pool now, so
+// it must also install the location-aware timestamp codec.
+func connectionConfig(dsn string) (*pgx.ConnConfig, *time.Location, error) {
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("postgres: parse DSN: %w", safeError(err, dsn))
+	}
+
+	var zone string
+	for key, value := range config.RuntimeParams {
+		if strings.EqualFold(key, "timezone") || strings.EqualFold(key, "time_zone") {
+			zone = value
+			delete(config.RuntimeParams, key)
+		}
+	}
+	if zone == "" {
+		return config, nil, nil
+	}
+
+	location, err := time.LoadLocation(zone)
+	if err != nil {
+		return nil, nil, fmt.Errorf("postgres: load TimeZone %q: %w", zone, err)
+	}
+	config.RuntimeParams["timezone"] = zone
+	return config, location, nil
+}
+
+func safeError(err error, dsn string) error {
+	message := err.Error()
+	u, parseErr := url.Parse(dsn)
+	if parseErr != nil || u.User == nil {
+		return errors.New(strings.ReplaceAll(message, dsn, "<redacted DSN>"))
+	}
+	password, ok := u.User.Password()
+	if !ok {
+		return errors.New(strings.ReplaceAll(message, dsn, u.String()))
+	}
+	message = strings.ReplaceAll(message, password, "xxxxx")
+	message = strings.ReplaceAll(message, url.QueryEscape(password), "xxxxx")
+	u.User = url.UserPassword(u.User.Username(), "xxxxx")
+	message = strings.ReplaceAll(message, dsn, u.String())
+	return errors.New(message)
+}

--- a/go/infra/database/postgres/postgres_test.go
+++ b/go/infra/database/postgres/postgres_test.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConnectionConfigNormalizesTimeZone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dsn      string
+		wantZone string
+	}{
+		{name: "URL TimeZone", dsn: "postgres://user:pass@localhost/db?TimeZone=Asia%2FShanghai", wantZone: "Asia/Shanghai"},
+		{name: "keyword time_zone", dsn: "host=localhost user=user password=pass dbname=db time_zone=Europe/London", wantZone: "Europe/London"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config, location, err := connectionConfig(tt.dsn)
+			if err != nil {
+				t.Fatalf("connectionConfig() error = %v", err)
+			}
+			if got := config.RuntimeParams["timezone"]; got != tt.wantZone {
+				t.Fatalf("runtime timezone = %q, want %q", got, tt.wantZone)
+			}
+			if got := location.String(); got != tt.wantZone {
+				t.Fatalf("scan location = %q, want %q", got, tt.wantZone)
+			}
+			if _, ok := config.RuntimeParams["TimeZone"]; ok {
+				t.Fatal("mixed-case TimeZone runtime parameter was not normalized")
+			}
+			if _, ok := config.RuntimeParams["time_zone"]; ok {
+				t.Fatal("time_zone runtime parameter was not normalized")
+			}
+		})
+	}
+}
+
+func TestConnectionConfigWithoutTimeZoneUsesDefaultTimestampCodec(t *testing.T) {
+	t.Parallel()
+
+	_, location, err := connectionConfig("postgres://user:pass@localhost/db")
+	if err != nil {
+		t.Fatalf("connectionConfig() error = %v", err)
+	}
+	if location != nil {
+		t.Fatalf("scan location = %v, want nil", location)
+	}
+}
+
+func TestOpenHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	db, err := Open(ctx, Options{DSN: "postgres://user:pass@localhost/db"})
+	if db != nil {
+		_ = db.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("Open() error = %v, want context cancellation", err)
+	}
+}
+
+func TestConnectionConfigErrorDoesNotLeakPassword(t *testing.T) {
+	t.Parallel()
+
+	const dsn = "postgres://user:top-secret@localhost:not-a-port/db"
+	_, _, err := connectionConfig(dsn)
+	if err == nil {
+		t.Fatal("connectionConfig() error = nil")
+	}
+	if strings.Contains(err.Error(), "top-secret") || strings.Contains(err.Error(), dsn) {
+		t.Fatalf("connectionConfig() error leaks credentials: %v", err)
+	}
+}

--- a/go/internal/bootstrap/bootstrap.go
+++ b/go/internal/bootstrap/bootstrap.go
@@ -16,40 +16,32 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
+	dbsqlite "github.com/nyroway/nyro/go/infra/database/sqlite"
 	"github.com/nyroway/nyro/go/internal/storage"
 	"github.com/nyroway/nyro/go/internal/storage/database"
 )
 
-// ParseDSN parses a --dsn value into a storage backend name and the
-// driver-native DSN that backend's constructor (NewSQLite/NewPostgres)
-// expects. Recognized schemes:
-//   - "sqlite://<path>": path is everything after "sqlite://" verbatim, so
-//     an absolute path is "sqlite:///abs/x.db", a relative path is
-//     "sqlite://./x.db", and an in-memory DB is "sqlite://:memory:".
-//   - "postgres://...": returned unchanged (with scheme) — gorm's postgres
-//     driver (pgx) accepts the URL form natively. "postgresql://" (the other
-//     libpq-recognized alias) is deliberately not accepted, to keep exactly
-//     one spelling per backend.
-//
-// Any other scheme (including "mysql://", "memory://" and "postgresql://") is
-// a hard error — there is no ephemeral backend reachable through --dsn.
-func ParseDSN(dsn string) (string, string, error) {
-	switch {
-	case strings.HasPrefix(dsn, "sqlite://"):
-		return "sqlite", strings.TrimPrefix(dsn, "sqlite://"), nil
-	case strings.HasPrefix(dsn, "postgres://"):
-		return "postgres", dsn, nil
-	default:
-		return "", "", fmt.Errorf("unrecognized --dsn scheme %q (want sqlite:// or postgres://)", dsn)
-	}
+// OpenedStorage owns a Config Engine storage backend and its SQL connection.
+type OpenedStorage struct {
+	storage.Storage
+	connection *infradatabase.Connection
 }
 
-// OpenStorageFromDSN parses dsn via ParseDSN and opens the resulting
-// backend.
+// Close releases the Config Engine connection pool.
+func (s *OpenedStorage) Close() error {
+	if s == nil {
+		return nil
+	}
+	return s.connection.Close()
+}
+
+type databaseOpener func(context.Context, string, infradatabase.Options) (*infradatabase.Connection, error)
+
+// OpenStorageFromDSN opens the Config Engine backend and owns its connection.
 //
 // autoMigrate controls whether the config-schema tables are created/altered
 // via GORM AutoMigrate (DDL). Its default is false regardless of backend —
@@ -63,29 +55,33 @@ func ParseDSN(dsn string) (string, string, error) {
 // key alongside its hash on creation, so keys can be retrieved after creation
 // (e.g. to display/copy a full key in the UI). Default false (hash-only); it
 // never affects the inbound auth path, which always compares hashes.
-func OpenStorageFromDSN(dsn string, autoMigrate, plaintextKeys bool) (storage.Storage, error) {
-	backend, driverDSN, err := ParseDSN(dsn)
+func OpenStorageFromDSN(ctx context.Context, dsn string, autoMigrate, plaintextKeys bool) (*OpenedStorage, error) {
+	return openStorageFromDSN(ctx, dsn, autoMigrate, plaintextKeys, infradatabase.Open)
+}
+
+func openStorageFromDSN(ctx context.Context, dsn string, autoMigrate, plaintextKeys bool, open databaseOpener) (*OpenedStorage, error) {
+	connection, err := open(ctx, dsn, infradatabase.Options{
+		SQLite: dbsqlite.Options{
+			BusyTimeout:  5 * time.Second,
+			MaxOpenConns: 5,
+			MaxIdleConns: 2,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-	switch backend {
-	case "sqlite":
-		b, err := database.NewSQLite(driverDSN)
-		if err != nil {
-			return nil, fmt.Errorf("open sqlite: %w", err)
-		}
-		b.SetPlaintextKeys(plaintextKeys)
-		return bootstrapSQL(b, autoMigrate)
-	case "postgres":
-		b, err := database.NewPostgres(driverDSN)
-		if err != nil {
-			return nil, fmt.Errorf("open postgres: %w", err)
-		}
-		b.SetPlaintextKeys(plaintextKeys)
-		return bootstrapSQL(b, autoMigrate)
-	default:
-		return nil, fmt.Errorf("unknown storage backend %q", backend)
+	b, err := database.New(connection.Kind, connection.DB)
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
 	}
+	b.SetPlaintextKeys(plaintextKeys)
+	st, err := bootstrapSQL(b, autoMigrate)
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	return &OpenedStorage{Storage: st, connection: connection}, nil
 }
 
 func bootstrapSQL(st storage.Storage, autoMigrate bool) (storage.Storage, error) {

--- a/go/internal/bootstrap/bootstrap_test.go
+++ b/go/internal/bootstrap/bootstrap_test.go
@@ -6,53 +6,20 @@ import (
 	"reflect"
 	"sync"
 	"testing"
-)
 
-func TestParseDSN(t *testing.T) {
-	tests := []struct {
-		name        string
-		dsn         string
-		wantBackend string
-		wantDriver  string
-		wantErr     bool
-	}{
-		{"sqlite absolute path", "sqlite:///abs/x.db", "sqlite", "/abs/x.db", false},
-		{"sqlite relative path", "sqlite://./x.db", "sqlite", "./x.db", false},
-		{"sqlite memory", "sqlite://:memory:", "sqlite", ":memory:", false},
-		{"postgres passthrough", "postgres://user:pass@host:5432/db?sslmode=disable", "postgres", "postgres://user:pass@host:5432/db?sslmode=disable", false},
-		{"postgresql alias rejected", "postgresql://user:pass@host:5432/db", "", "", true},
-		{"mysql scheme rejected", "mysql://user:pass@host/db", "", "", true},
-		{"memory scheme rejected", "memory://", "", "", true},
-		{"bad scheme", "redis://host:6379", "", "", true},
-		{"empty dsn rejected", "", "", "", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			backend, driver, err := ParseDSN(tt.dsn)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("ParseDSN(%q): expected error, got backend=%q driver=%q", tt.dsn, backend, driver)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("ParseDSN(%q): unexpected error: %v", tt.dsn, err)
-			}
-			if backend != tt.wantBackend {
-				t.Errorf("ParseDSN(%q) backend = %q, want %q", tt.dsn, backend, tt.wantBackend)
-			}
-			if driver != tt.wantDriver {
-				t.Errorf("ParseDSN(%q) driver = %q, want %q", tt.dsn, driver, tt.wantDriver)
-			}
-		})
-	}
-}
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
+	dbsqlite "github.com/nyroway/nyro/go/infra/database/sqlite"
+)
 
 func TestOpenStorageFromDSN(t *testing.T) {
 	t.Run("sqlite in-memory with auto-migrate migrates and serves", func(t *testing.T) {
-		st, err := OpenStorageFromDSN("sqlite://:memory:", true, false)
+		st, err := OpenStorageFromDSN(context.Background(), "sqlite://:memory:", true, false)
 		if err != nil {
 			t.Fatalf("sqlite: %v", err)
+		}
+		t.Cleanup(func() { _ = st.Close() })
+		if got := st.connection.DB.Stats().MaxOpenConnections; got != 5 {
+			t.Fatalf("config SQLite MaxOpenConnections = %d, want 5", got)
 		}
 		h, _ := st.Migrator().Health()
 		if h.Backend != "sqlite" {
@@ -63,15 +30,32 @@ func TestOpenStorageFromDSN(t *testing.T) {
 		}
 	})
 	t.Run("sqlite in-memory without auto-migrate fails schema check", func(t *testing.T) {
-		if _, err := OpenStorageFromDSN("sqlite://:memory:", false, false); err == nil {
+		if _, err := OpenStorageFromDSN(context.Background(), "sqlite://:memory:", false, false); err == nil {
 			t.Error("expected schema-check error on an unmigrated in-memory db")
 		}
 	})
 	t.Run("bad scheme errors", func(t *testing.T) {
-		if _, err := OpenStorageFromDSN("bogus://x", false, false); err == nil {
+		if _, err := OpenStorageFromDSN(context.Background(), "bogus://x", false, false); err == nil {
 			t.Error("expected error for bogus scheme")
 		}
 	})
+}
+
+func TestOpenStorageFromDSNClosesConnectionWhenBootstrapFails(t *testing.T) {
+	pool, err := dbsqlite.Open(context.Background(), dbsqlite.Options{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open SQLite pool: %v", err)
+	}
+	opener := func(context.Context, string, infradatabase.Options) (*infradatabase.Connection, error) {
+		return &infradatabase.Connection{Kind: infradatabase.KindSQLite, DB: pool}, nil
+	}
+
+	if _, err := openStorageFromDSN(context.Background(), "sqlite://:memory:", false, false, opener); err == nil {
+		t.Fatal("openStorageFromDSN() error = nil")
+	}
+	if err := pool.Ping(); err == nil {
+		t.Fatal("connection remains open after schema bootstrap failure")
+	}
 }
 
 func TestRunManagedServersShutsDownInReverseDependencyOrder(t *testing.T) {

--- a/go/internal/storage/database/backend.go
+++ b/go/internal/storage/database/backend.go
@@ -3,6 +3,7 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 
@@ -10,6 +11,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
 	"github.com/nyroway/nyro/go/internal/storage"
 	"github.com/nyroway/nyro/go/internal/storage/model"
 	"github.com/nyroway/nyro/go/internal/storage/query"
@@ -26,35 +28,33 @@ type Backend struct {
 	plaintextKeys bool
 }
 
+// New creates a shared SQL backend over a caller-owned connection pool.
+func New(kind infradatabase.Kind, pool *sql.DB) (*Backend, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("%s database connection is nil", kind)
+	}
+
+	var dialector gorm.Dialector
+	switch kind {
+	case infradatabase.KindSQLite:
+		dialector = sqlite.Dialector{Conn: pool}
+	case infradatabase.KindPostgres:
+		dialector = postgres.New(postgres.Config{Conn: pool})
+	default:
+		return nil, fmt.Errorf("unsupported database kind %q", kind)
+	}
+
+	db, err := gorm.Open(dialector, &gorm.Config{Logger: newGormLogger(os.Stderr)})
+	if err != nil {
+		return nil, fmt.Errorf("initialize %s GORM backend: %w", kind, err)
+	}
+	return &Backend{backend: string(kind), db: db, q: query.Use(db)}, nil
+}
+
 // SetPlaintextKeys toggles recoverable plaintext key storage. It is set once
 // at startup (from the admin's --raw-api-keys flag) before the backend
 // serves any request.
 func (b *Backend) SetPlaintextKeys(v bool) { b.plaintextKeys = v }
-
-// NewSQLite opens a SQLite database and returns a shared SQL backend.
-func NewSQLite(path string) (*Backend, error) {
-	if path == "" {
-		path = ":memory:"
-	}
-	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{Logger: newGormLogger(os.Stderr)})
-	if err != nil {
-		return nil, err
-	}
-	sqlDB, _ := db.DB()
-	sqlDB.SetMaxOpenConns(5)
-	db.Exec("PRAGMA journal_mode=WAL")
-	db.Exec("PRAGMA busy_timeout=5000")
-	return &Backend{backend: "sqlite", db: db, q: query.Use(db)}, nil
-}
-
-// NewPostgres opens a Postgres database and returns a shared SQL backend.
-func NewPostgres(dsn string) (*Backend, error) {
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: newGormLogger(os.Stderr)})
-	if err != nil {
-		return nil, err
-	}
-	return &Backend{backend: "postgres", db: db, q: query.Use(db)}, nil
-}
 
 // DB exposes the underlying GORM database for tests and advanced callers.
 func (b *Backend) DB() *gorm.DB { return b.db }

--- a/go/internal/storage/database/backend_test.go
+++ b/go/internal/storage/database/backend_test.go
@@ -1,12 +1,60 @@
 package database
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
+	dbsqlite "github.com/nyroway/nyro/go/infra/database/sqlite"
+)
+
+func TestNewUsesCallerOwnedConnection(t *testing.T) {
+	pool, err := dbsqlite.Open(context.Background(), dbsqlite.Options{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite pool: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	b, err := New(infradatabase.KindSQLite, pool)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	gotPool, err := b.DB().DB()
+	if err != nil {
+		t.Fatalf("GORM DB(): %v", err)
+	}
+	if gotPool != pool {
+		t.Fatal("Backend does not use the caller-owned connection pool")
+	}
+}
+
+func TestNewRejectsInvalidConnection(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New(infradatabase.KindSQLite, nil); err == nil {
+		t.Fatal("New(sqlite, nil) error = nil")
+	}
+	if _, err := New(infradatabase.Kind("unknown"), nil); err == nil {
+		t.Fatal("New(unknown, nil) error = nil")
+	}
+}
+
+func newSQLiteBackend(t *testing.T) *Backend {
+	t.Helper()
+	pool, err := dbsqlite.Open(context.Background(), dbsqlite.Options{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open SQLite pool: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+	b, err := New(infradatabase.KindSQLite, pool)
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	return b
+}
 
 func TestSQLiteBackendMigratesNewConfigSchema(t *testing.T) {
-	b, err := NewSQLite(":memory:")
-	if err != nil {
-		t.Fatalf("new sqlite: %v", err)
-	}
+	b := newSQLiteBackend(t)
 	if err := b.Migrate(); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -27,10 +75,7 @@ func TestSQLiteBackendMigratesNewConfigSchema(t *testing.T) {
 }
 
 func TestCheckSchema(t *testing.T) {
-	b, err := NewSQLite(":memory:")
-	if err != nil {
-		t.Fatalf("new sqlite: %v", err)
-	}
+	b := newSQLiteBackend(t)
 
 	// Fresh database: canonical tables missing → CheckSchema fails.
 	if err := b.CheckSchema(); err == nil {

--- a/go/internal/storage/database/core_test.go
+++ b/go/internal/storage/database/core_test.go
@@ -9,10 +9,7 @@ import (
 
 func newTestBackend(t *testing.T) *Backend {
 	t.Helper()
-	b, err := NewSQLite(":memory:")
-	if err != nil {
-		t.Fatalf("NewSQLite: %v", err)
-	}
+	b := newSQLiteBackend(t)
 	if err := b.Migrate(); err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}

--- a/go/internal/storage/database/postgres_integration_test.go
+++ b/go/internal/storage/database/postgres_integration_test.go
@@ -1,0 +1,97 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	infradatabase "github.com/nyroway/nyro/go/infra/database"
+	dbpostgres "github.com/nyroway/nyro/go/infra/database/postgres"
+	"github.com/nyroway/nyro/go/internal/storage"
+)
+
+func TestPostgresIntegration(t *testing.T) {
+	dsn := os.Getenv("NYRO_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("NYRO_TEST_POSTGRES_DSN is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	adminConnection, err := infradatabase.Open(ctx, dsn, infradatabase.Options{})
+	if err != nil {
+		t.Fatalf("open PostgreSQL admin connection: %v", err)
+	}
+	t.Cleanup(func() { _ = adminConnection.Close() })
+
+	schema := fmt.Sprintf("nyro_go_test_%d", time.Now().UnixNano())
+	quotedSchema := `"` + strings.ReplaceAll(schema, `"`, `""`) + `"`
+	if _, err := adminConnection.DB.ExecContext(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
+		t.Fatalf("create temporary schema: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if _, err := adminConnection.DB.ExecContext(cleanupCtx, "DROP SCHEMA "+quotedSchema+" CASCADE"); err != nil {
+			t.Errorf("drop temporary schema: %v", err)
+		}
+	})
+
+	schemaDSN := postgresDSNWithSearchPath(t, dsn, schema)
+	connection, err := infradatabase.Open(ctx, schemaDSN, infradatabase.Options{
+		Postgres: dbpostgres.Options{MaxOpenConns: 7, MaxIdleConns: 3},
+	})
+	if err != nil {
+		t.Fatalf("open schema-scoped PostgreSQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	if got := connection.DB.Stats().MaxOpenConnections; got != 7 {
+		t.Fatalf("MaxOpenConnections = %d, want 7", got)
+	}
+
+	b, err := New(connection.Kind, connection.DB)
+	if err != nil {
+		t.Fatalf("create PostgreSQL backend: %v", err)
+	}
+	if err := b.Migrate(); err != nil {
+		t.Fatalf("migrate PostgreSQL backend: %v", err)
+	}
+	created, err := b.Upstreams().Create(storage.CreateUpstream{
+		Name:     "postgres-integration",
+		Protocol: "openai-chatcompletions",
+		BaseURL:  "https://api.example.com/v1",
+	})
+	if err != nil {
+		t.Fatalf("create upstream: %v", err)
+	}
+	got, err := b.Upstreams().Get(created.ID)
+	if err != nil {
+		t.Fatalf("get upstream: %v", err)
+	}
+	if got == nil || got.Name != "postgres-integration" {
+		t.Fatalf("upstream = %+v", got)
+	}
+	health, err := b.Health()
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	if health.Backend != "postgres" || !health.CanConnect || !health.SchemaCompatible || !health.Writable {
+		t.Fatalf("health = %+v", health)
+	}
+}
+
+func postgresDSNWithSearchPath(t *testing.T, dsn, schema string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse NYRO_TEST_POSTGRES_DSN: %v", err)
+	}
+	query := u.Query()
+	query.Set("search_path", schema)
+	u.RawQuery = query.Encode()
+	return u.String()
+}


### PR DESCRIPTION
## Summary

- centralize SQLite and PostgreSQL DSN parsing, connection setup, pooling, health checks, and ownership under go/infra/database
- inject caller-owned SQL pools into the Config Engine and close them explicitly from serve and migrate
- add PostgreSQL TimeZone handling, credential-safe errors, integration coverage, and scheduled storage workflow validation

## Validation

- make go-check
- go mod tidy -diff
- git diff --check
- storage-backends workflow YAML parse